### PR TITLE
v0.0.1: skeleton — quality pipeline + agent-affordance verbs

### DIFF
--- a/.claude/skills.local.yaml.example
+++ b/.claude/skills.local.yaml.example
@@ -1,0 +1,16 @@
+# Per-machine config for agentpypi's skills.
+# Copy this to skills.local.yaml (git-ignored) and adjust for your environment.
+# Skills read skills.local.yaml first, falling back to this example.
+
+# Path to the Culture server's agent manifest (suffix → directory mapping).
+# Used by: agent-config (if vendored later) and any skill that resolves
+# a registered agent suffix to its repo dir.
+culture_server_yaml: ~/.culture/server.yaml
+
+# Sibling project paths checked during the pr-review alignment-delta step.
+# Workspace-relative paths (../foo) are preferred. Skills skip entries
+# that don't exist on disk, so commenting out missing ones isn't required.
+sibling_projects:
+  - ../afi-cli
+  - ../ghafi
+  - ../steward

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: pr-review
+description: >
+  agentpypi PR workflow: branch, commit, push, PR, wait for Qodo/Copilot,
+  triage, fix, reply, resolve. Adds a portability lint (no absolute /home paths,
+  no per-user dotfile refs in committed docs), an alignment-delta check when
+  CLAUDE.md or culture.yaml change, and greenfield-aware test/version-bump
+  steps. Use when: creating PRs in agentpypi, handling review feedback, or the
+  user says "create PR", "review comments", "address feedback", "resolve threads".
+---
+
+# PR Review — agentpypi edition
+
+agentpypi's PRs touch CLI verb surfaces, `culture.yaml` (when it lands),
+quality-pipeline configs, and vendored skills. Path leaks and per-user
+config dependencies are the recurring bug class across every AgentCulture
+sibling — this skill catches both up front, plus an alignment-delta check
+when CLAUDE.md or culture.yaml change. The workflow is encapsulated in
+`scripts/workflow.sh` — follow that, not a manual checklist.
+
+Vendored from `../steward/.claude/skills/pr-review/` per
+`docs/skills-setup.md`. Re-sync when steward bumps the script. Adapted
+identifiers only — the workflow shape is identical.
+
+## Prerequisites
+
+Hard requirements: `gh` (GitHub CLI), `jq`, `bash`, `python3` (stdlib only),
+`curl` (used by `pr-status.sh`).
+
+Soft requirement: `PyYAML` is needed only for parsing Culture's server
+manifest if a sibling skill needs it. The vendored `pr-review` scripts
+work without it.
+
+Per-machine paths (sibling-project layout) live in
+`.claude/skills.local.yaml`; see the committed `.example` for the schema.
+
+## How to run
+
+`scripts/workflow.sh` is the entry point. Subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `workflow.sh lint` | Portability lint on the current diff (staged + unstaged). |
+| `workflow.sh poll <PR>` | Fetch and display all review comments. |
+| `workflow.sh delta` | Dump each sibling project's `CLAUDE.md` head + `culture.yaml`. |
+| `workflow.sh reply <PR>` | Batch reply (JSONL on stdin) and resolve threads. |
+| `workflow.sh help` | Print this list. |
+
+The vendored single-comment helpers — `pr-reply.sh`, `pr-status.sh` — live
+next to `workflow.sh` and are usable directly when batching isn't appropriate.
+
+## End-to-end flow
+
+```text
+git checkout -b <type>/<desc>
+# ... edit ...
+.claude/skills/pr-review/scripts/workflow.sh lint
+git commit -am "..." && git push -u origin <branch>
+gh pr create --title "..." --body "..."   # title <70 chars, body signed "- Claude"
+sleep 300                                  # wait for Qodo + Copilot
+.claude/skills/pr-review/scripts/workflow.sh poll <PR>
+# triage; if CLAUDE.md/culture.yaml/.claude/skills changed:
+.claude/skills/pr-review/scripts/workflow.sh delta
+# fix, re-lint, push
+.claude/skills/pr-review/scripts/workflow.sh reply <PR> < replies.jsonl
+gh pr checks <PR>
+# Wait for human merge — never merge yourself.
+```
+
+Branch naming: `fix/<desc>`, `feat/<desc>`, `docs/<desc>`, `skill/<name>`.
+Commit/PR signature: `- Claude` (workspace convention). The reply script
+auto-appends `- Claude` only if the body isn't already signed, so JSONL
+entries can include or omit it.
+
+## Triage rules
+
+For every comment, decide **FIX** or **PUSHBACK** with reasoning.
+
+Default to **FIX** for: portability complaints (always valid — recurring
+AgentCulture bug class), test or doc requests, style nits aligned with
+workspace conventions.
+
+Default to **PUSHBACK** for: architecture opinions that conflict with
+workspace `CLAUDE.md` or workspace conventions; greenfield false-positives
+(e.g. "add tests" before there's any source — defer to a later PR, don't
+refuse).
+
+### Alignment-delta rule
+
+If the PR touches `CLAUDE.md`, `culture.yaml`, or anything under
+`.claude/skills/`, run `workflow.sh delta` **before** declaring FIX or
+PUSHBACK on each comment. The script dumps the head of every sibling
+project's `CLAUDE.md` plus the full `culture.yaml`, using `sibling_projects`
+from `skills.local.yaml`. Note any sibling that needs a follow-up PR and
+mention it in your reply.
+
+## Greenfield-aware steps
+
+The lint and the workflow script are always-on. Stack-specific steps are
+conditional and currently active for agentpypi as the v0.0.1 quality
+pipeline lands:
+
+```bash
+[ -d tests ] && [ -f pyproject.toml ] && uv run pytest tests/ -x -q
+[ -f pyproject.toml ] && python3 .claude/skills/version-bump/scripts/bump.py patch
+[ -f .markdownlint-cli2.yaml ] && markdownlint-cli2 "$(git diff --name-only --cached '*.md')"
+```
+
+Re-evaluate as later milestones (`online`, `local` nouns) bring new
+review surfaces.
+
+## Reply etiquette
+
+Every comment must get a reply — no silent fixes. Always pass `--resolve`
+when batch-replying so threads close automatically. Reference the
+review-comment IDs in the fix-up commit message. agentpypi has no
+SonarCloud integration at v0.0.1 and isn't a registered mesh agent yet
+(culture.yaml lands but no daemon runs), so skip the sonarclaude check
+and the post-merge IRC ping that Culture's full `pr-review` includes —
+those will return when the corresponding systems wire up.

--- a/.claude/skills/pr-review/scripts/portability-lint.sh
+++ b/.claude/skills/pr-review/scripts/portability-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Portability lint: catch path leaks and per-user config dependencies in
+# committed docs/configs before they ship in a PR. AgentCulture's recurring
+# bug class (every sibling has shipped at least one).
+#
+# Usage: portability-lint.sh [--all]
+#   default: lint files modified vs HEAD (staged + unstaged)
+#   --all:   lint all tracked files
+#
+# Exits 0 if clean, 1 if any leak is found.
+
+set -euo pipefail
+
+mode="${1:-diff}"
+case "$mode" in
+    --all) files=$(git ls-files -- ':(exclude)*.lock') ;;
+    diff|--diff) files=$(git diff --diff-filter=AMR --name-only HEAD -- ':(exclude)*.lock') ;;
+    *) echo "Usage: $(basename "$0") [--all]" >&2; exit 2 ;;
+esac
+
+[ -z "$files" ] && { echo "(no files to check)"; exit 0; }
+
+# ----- Check 1: hard-coded /home/<user>/... paths -----
+hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+
+# ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
+# Carve-outs (allowed, NOT flagged):
+#   - ~/.claude/skills/<x>/scripts/   vendored tool calls
+#   - ~/.culture/                     Culture mesh data this skill is supposed to read
+md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
+if [ -n "$md_yaml" ]; then
+    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+        | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
+        | grep -vE '~/\.culture/' \
+        || true)
+else
+    hits2=""
+fi
+
+fail=0
+if [ -n "$hits1" ]; then
+    echo "❌ Hard-coded /home/<user>/ paths:"
+    echo "$hits1" | sed 's/^/    /'
+    echo "   Fix: use ../sibling, repo URL, or \$WORKSPACE/sibling instead."
+    fail=1
+fi
+if [ -n "$hits2" ]; then
+    [ "$fail" -eq 1 ] && echo
+    echo "❌ Per-user ~/.<dotfile> config refs in committed doc/config:"
+    echo "$hits2" | sed 's/^/    /'
+    echo "   Allowed carve-outs: ~/.claude/skills/.../scripts/ (tool calls), ~/.culture/ (mesh data)."
+    echo "   Otherwise: commit a repo-local config or document a portable lookup."
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "✓ portability lint clean ($(echo "$files" | wc -l | tr -d ' ') files checked)"
+exit $fail

--- a/.claude/skills/pr-review/scripts/pr-batch.sh
+++ b/.claude/skills/pr-review/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all PR feedback in one pass:
+#   1. Inline review comments (with thread resolve status)
+#   2. Issue comments (qodo summaries, sonarcloud, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# ── Section 1: inline review comments ─────────────────────────────────────
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Build a map from every comment ID in every thread → its thread metadata,
+# so replies in a thread also show resolved status (not just the first comment).
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] as $t | $t.comments.nodes[] | {
+    comment_id: .databaseId,
+    thread_id: $t.id,
+    resolved: $t.isResolved
+  }]
+')
+
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+INLINE_COUNT=$(echo "$INLINE" | jq 'length')
+
+echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
+echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "Author: \($c.user.login)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 2: issue comments (general PR comments) ───────────────────────
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
+
+echo ""
+echo "════════════════ ISSUE COMMENTS ($ISSUE_COUNT) ════════════════"
+echo "$ISSUE" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "ID: \(.id)  |  Author: \(.user.login)  |  Created: \(.created_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 3: top-level reviews with a body ──────────────────────────────
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
+REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
+
+echo ""
+echo "════════════════ TOP-LEVEL REVIEWS ($REVIEW_COUNT) ════════════════"
+echo "$REVIEWS_WITH_BODY" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "Review ID: \(.id)  |  Author: \(.user.login)  |  State: \(.state)  |  Submitted: \(.submitted_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'

--- a/.claude/skills/pr-review/scripts/pr-reply.sh
+++ b/.claude/skills/pr-review/scripts/pr-reply.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Append signature only if the body isn't already signed.
+if ! printf '%s' "$BODY" | grep -qE '(^|\n)[[:space:]]*-[[:space:]]+Claude[[:space:]]*$'; then
+    BODY="${BODY}
+
+- Claude"
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/pr-review/scripts/pr-status.sh
+++ b/.claude/skills/pr-review/scripts/pr-status.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# pr-status.sh — one-shot status overview for an agentpypi PR.
+#
+# Combines five things review feedback usually scatters across:
+#   1. PR state (open / merged / closed) + branch + author
+#   2. CI checks (build / lint / unit / sonarcloud / cf-pages / etc.)
+#   3. Review-bot pipeline status (Copilot, qodo, SonarCloud, Cloudflare)
+#   4. SonarCloud quality gate + open-issue count
+#   5. Inline-thread resolved-vs-unresolved tally
+#
+# Usage: scripts/pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo           auto-detected via `gh repo view`
+#   --sonar-key      derived from repo as `<owner>_<name>` (SonarCloud convention)
+#
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${REPO%%/*}_${REPO##*/}"
+fi
+
+# ── 1. PR header ──────────────────────────────────────────────────────────
+PR_JSON=$(gh pr view "$PR_NUMBER" --json \
+    number,title,state,isDraft,mergedAt,mergedBy,baseRefName,headRefName,author,url)
+
+echo "════════════════════════════════════════════════════════════════════"
+echo "$PR_JSON" | jq -r '
+    "PR #\(.number) — \(.title)",
+    "  \(.url)",
+    "  Author:  \(.author.login)",
+    "  Branch:  \(.headRefName)  →  \(.baseRefName)",
+    "  State:   \(if .state == "MERGED" then "MERGED at \(.mergedAt) by \(.mergedBy.login)" elif .state == "OPEN" and .isDraft then "OPEN (draft)" else .state end)"
+'
+echo "════════════════════════════════════════════════════════════════════"
+
+# ── 2. CI checks ──────────────────────────────────────────────────────────
+echo
+echo "── CI checks ─────────────────────────────────────────────────────────"
+# `gh pr checks` exits non-zero when checks are still pending/failing.
+# We don't care about its exit code here; capture and pretty-print.
+CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null || true)
+if [[ -z "$CHECKS" ]]; then
+    echo "  (no checks reported)"
+else
+    echo "$CHECKS" | awk -F'\t' '
+        {
+            name  = $1
+            state = $2
+            dur   = $3
+            sym   = "?"
+            if (state == "pass")            sym = "✅"
+            else if (state == "fail")       sym = "❌"
+            else if (state == "skipping")   sym = "⏭"
+            else if (state == "pending"  || state == "queued"   || state == "in_progress") sym = "…"
+            printf "  %s %-22s %-10s %s\n", sym, name, state, dur
+        }
+    '
+fi
+
+# ── 3. Review bots & comment pipeline ────────────────────────────────────
+echo
+echo "── Review pipeline ───────────────────────────────────────────────────"
+
+# Inline-thread tally via GraphQL (resolved vs unresolved).
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+INLINE_TOTAL=$(echo "$THREADS_JSON" | jq 'length')
+INLINE_RESOLVED=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved)] | length')
+INLINE_PENDING=$((INLINE_TOTAL - INLINE_RESOLVED))
+
+# Per-bot inline counts.
+COPILOT_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("Copilot"))] | length')
+QODO_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("qodo"))] | length')
+
+# Issue-level comments (qodo summary, sonarcloud quality-gate body, cf-pages preview, etc.).
+# Skip --paginate to avoid array concatenation; per_page=100 covers typical PRs.
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100")
+QODO_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("qodo"))] | length')
+SONARQUBE_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("sonarqubecloud"))] | length')
+CFPAGES_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | test("cloudflare"))] | length')
+COPILOT_TOPLEVEL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+    | jq '[.[] | select((.user.login // "") | startswith("copilot")) | select((.body // "") != "")] | length')
+
+# Cloudflare deploy URL hidden in issue-comment bodies (look for pages.dev).
+CF_URL=$(echo "$ISSUE" | jq -r '[.[].body // "" | scan("https?://[a-z0-9.-]+\\.pages\\.dev[^\\s)\"<]*")] | first // ""')
+
+printf "  %-12s %s\n"  "Copilot"     "$([[ "$COPILOT_TOPLEVEL" -gt 0 || "$COPILOT_INLINE" -gt 0 ]] && echo "✅ overview×$COPILOT_TOPLEVEL, inline×$COPILOT_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE" -gt 0 ]] && echo "✅ summary×$QODO_ISSUE, inline×$QODO_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
+
+# ── 4. SonarCloud quality gate + open issues ─────────────────────────────
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+    | jq -r '.total // 0')
+SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+    | jq -r '.paging.total // 0')
+
+case "$SONAR_QG_STATUS" in
+    OK)    SONAR_SYM="✅" ;;
+    ERROR) SONAR_SYM="❌" ;;
+    WARN)  SONAR_SYM="⚠ " ;;
+    *)     SONAR_SYM="?" ;;
+esac
+printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
+    "SonarCloud" "$SONAR_SYM" "$SONAR_QG_STATUS" "$SONAR_OPEN" "$SONAR_HOTSPOTS"
+
+# When SonarCloud has OPEN issues, list them — saves a follow-up curl.
+if [[ "$SONAR_OPEN" != "0" ]]; then
+    echo
+    echo "  SonarCloud OPEN issues:"
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+        | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
+fi
+
+# ── 5. Tally + summary ────────────────────────────────────────────────────
+echo
+echo "── Inline threads ────────────────────────────────────────────────────"
+printf "  Total: %d   Resolved: %d   Unresolved: %d\n" \
+    "$INLINE_TOTAL" "$INLINE_RESOLVED" "$INLINE_PENDING"
+
+if [[ "$INLINE_PENDING" -gt 0 ]]; then
+    echo
+    echo "  Unresolved threads:"
+    echo "$THREADS_JSON" | jq -r '
+        .[] | select(.isResolved == false) |
+        "    • \(.comments.nodes[0].author.login): thread \(.id)"
+    '
+fi
+
+echo
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "(For full comment bodies: bash \"$SCRIPT_DIR/pr-comments.sh\" $PR_NUMBER)"

--- a/.claude/skills/pr-review/scripts/workflow.sh
+++ b/.claude/skills/pr-review/scripts/workflow.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# agentpypi pr-review workflow entry point.
+#
+# Subcommands:
+#   lint              run the portability lint on the current diff (staged + unstaged)
+#   poll <PR>         fetch and display review comments
+#   reply <PR>        batch reply to review comments (JSONL on stdin), --resolve
+#   delta             dump CLAUDE.md head + culture.yaml for each sibling project
+#                     listed in skills.local.yaml (alignment-delta check)
+#   help              print this message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML list from CFG. Schema is intentionally tiny:
+#   <key>:
+#     - item
+#     - item
+# Stops at the next top-level key. No PyYAML dependency.
+read_list() {
+    awk -v key="$1" '
+        function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+        {
+            line = $0
+            sub(/[[:space:]]+#.*$/, "", line)
+        }
+        in_list && line ~ /^[[:space:]]*-[[:space:]]*/ {
+            item = line
+            sub(/^[[:space:]]*-[[:space:]]*/, "", item)
+            item = trim(item)
+            sub(/^["\047]/, "", item); sub(/["\047]$/, "", item)
+            if (item != "") print item
+            next
+        }
+        in_list && line ~ /^[^[:space:]#]/ { exit }
+        line ~ ("^" key ":[[:space:]]*($|#)") { in_list = 1 }
+    ' "$CFG"
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+    lint)
+        bash "$SCRIPT_DIR/portability-lint.sh"
+        ;;
+    poll)
+        PR="${1:?Usage: workflow.sh poll <PR>}"
+        bash "$SCRIPT_DIR/pr-comments.sh" "$PR"
+        ;;
+    reply)
+        PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"
+        bash "$SCRIPT_DIR/pr-batch.sh" --resolve "$PR"
+        ;;
+    delta)
+        any=0
+        while IFS= read -r sibling; do
+            [ -z "$sibling" ] && continue
+            any=1
+            sibling_abs="$REPO_ROOT/$sibling"
+            if [ ! -d "$sibling_abs" ] && [ ! -d "$sibling" ]; then
+                echo "=== $sibling ==="
+                echo "(not present on disk — skipped)"
+                continue
+            fi
+            target="$sibling_abs"
+            [ -d "$target" ] || target="$sibling"
+            echo "=== $target ==="
+            if [ -f "$target/CLAUDE.md" ]; then
+                head -40 "$target/CLAUDE.md"
+                echo "..."
+            else
+                echo "(no CLAUDE.md)"
+            fi
+            echo "--- culture.yaml ---"
+            if [ -f "$target/culture.yaml" ]; then
+                cat "$target/culture.yaml"
+            else
+                echo "(no culture.yaml)"
+            fi
+            echo
+        done < <(read_list sibling_projects)
+        [ "$any" -eq 0 ] && echo "(no sibling_projects configured in $CFG)"
+        ;;
+    help|--help|-h)
+        sed -n '2,11p' "${BASH_SOURCE[0]}" | sed 's/^# *//'
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        echo "run '$(basename "$0") help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: version-bump
+description: >
+  Bump the semver version in pyproject.toml (major, minor, or patch) and
+  prepend a Keep-a-Changelog entry to CHANGELOG.md. Use when preparing a
+  release, before creating a PR (the version-check CI job blocks merge if
+  you don't), or when the user says "bump version", "release", or
+  "increment version".
+---
+
+# Version Bump
+
+Bump the semver version in `pyproject.toml` and prepend a new entry to
+`CHANGELOG.md`. Mirrors the AgentCulture workflow used by `culture`,
+`afi-cli`, `cfafi`, and other org repos; vendored here so the repo is
+self-contained.
+
+## Usage
+
+Run from the repo root.
+
+```bash
+# With changelog content (pipe JSON via stdin):
+echo '{"added":["New X"],"changed":["Refactored Y"],"fixed":["Bug in Z"]}' \
+  | python3 .claude/skills/version-bump/scripts/bump.py minor
+
+# Without changelog content (inserts empty ### Added/Changed/Fixed stubs):
+python3 .claude/skills/version-bump/scripts/bump.py patch
+
+# Check current version without bumping:
+python3 .claude/skills/version-bump/scripts/bump.py show
+```
+
+## Bump Types
+
+| Type    | Example        | When to use                                                       |
+|---------|----------------|-------------------------------------------------------------------|
+| `major` | 0.1.0 → 1.0.0  | Breaking changes, namespace restructures, CLI surface breaks      |
+| `minor` | 0.1.0 → 0.2.0  | New features, new commands, new modules                           |
+| `patch` | 0.1.0 → 0.1.1  | Bug fixes, doc updates, dependency bumps, CI-only changes         |
+| `show`  | prints `0.1.0` | Read-only — no files changed                                      |
+
+## Changelog JSON Format
+
+Pass via stdin. All fields are optional — only non-empty sections are rendered.
+
+```json
+{
+  "added":   ["List of new features"],
+  "changed": ["List of changes to existing functionality"],
+  "fixed":   ["List of bug fixes"]
+}
+```
+
+## What it touches
+
+- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
+  `agentpypi/__init__.py` reads it via `importlib.metadata`, so there's no
+  separate `__version__` literal to keep in sync).
+- `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
+
+The script does the rest. Pick a bump type from the diff (patch for fixes,
+minor for new features, major for breaking changes), summarize the diff into
+`added` / `changed` / `fixed` lists, pipe as JSON, and commit the resulting
+`pyproject.toml` + `CHANGELOG.md` alongside the code change so the
+`version-check` CI job sees a consistent bump.

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -89,7 +89,9 @@ def read_changelog_entries() -> dict:
             return {}
         return json.loads(raw)
     except (json.JSONDecodeError, ValueError):
-        print("WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr)
+        print(
+            "WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr
+        )
         return {}
 
 
@@ -163,10 +165,12 @@ def main():
         if init.exists():
             init_text = init.read_text()
             if f'__version__ = "{current}"' in init_text:
-                init.write_text(init_text.replace(
-                    f'__version__ = "{current}"',
-                    f'__version__ = "{new}"',
-                ))
+                init.write_text(
+                    init_text.replace(
+                        f'__version__ = "{current}"',
+                        f'__version__ = "{new}"',
+                    )
+                )
                 print(f"Updated {init.relative_to(path.parent)}")
 
     # Update changelog

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Bump the version in pyproject.toml and CHANGELOG.md.
+
+If the package's ``__init__.py`` contains a literal ``__version__ = "..."``
+assignment, the script also rewrites that value. In repos that read
+``__version__`` from package metadata (the AgentCulture sibling convention
+used by agentpypi, steward, afi-cli, etc.), the ``__init__.py`` step is a
+no-op.
+
+Usage:
+    bump.py major    # 0.1.0 -> 1.0.0
+    bump.py minor    # 0.1.0 -> 0.2.0
+    bump.py patch    # 0.1.0 -> 0.1.1
+    bump.py show     # print current version
+
+Changelog entries are passed via stdin as a JSON object:
+    {
+      "added": ["New CLI command", "Observer module"],
+      "changed": ["Restructured namespace"],
+      "fixed": ["WHO reply index bug"]
+    }
+
+If no stdin is provided, an empty stub is inserted.
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def find_pyproject() -> Path:
+    """Walk up from cwd to find pyproject.toml."""
+    current = Path.cwd()
+    while current != current.parent:
+        candidate = current / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+    print("ERROR: pyproject.toml not found", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_version(path: Path) -> str:
+    """Extract version string from pyproject.toml."""
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: version field not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """Bump the specified part of a semver version."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"ERROR: version '{version}' is not semver (x.y.z)", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        print(f"ERROR: unknown bump type '{part}' (use major, minor, or patch)", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_version(path: Path, old: str, new: str) -> None:
+    """Replace old version with new in pyproject.toml."""
+    text = path.read_text()
+    updated = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    path.write_text(updated)
+
+
+def read_changelog_entries() -> dict:
+    """Read changelog entries from stdin as JSON."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print("WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr)
+        return {}
+
+
+def format_changelog_section(new: str, entries: dict) -> str:
+    """Format a changelog section from entries dict.
+
+    Output uses single blank lines between elements (markdownlint MD012
+    compliant). Trailing blank line before the next existing entry is
+    included.
+    """
+    today = date.today().isoformat()
+    chunks = [f"## [{new}] - {today}\n"]
+
+    for section in ("added", "changed", "fixed"):
+        items = entries.get(section, [])
+        if items:
+            chunks.append(f"\n### {section.capitalize()}\n\n")
+            chunks.extend(f"- {item}\n" for item in items)
+
+    # If no entries at all, emit empty section stubs.
+    if not any(entries.get(s) for s in ("added", "changed", "fixed")):
+        chunks.append("\n### Added\n\n### Changed\n\n### Fixed\n")
+
+    chunks.append("\n")  # blank line before the next existing entry
+    return "".join(chunks)
+
+
+def update_changelog(project_root: Path, new: str, entries: dict) -> None:
+    """Insert a new changelog entry into CHANGELOG.md."""
+    changelog = project_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print("No CHANGELOG.md found — skipping")
+        return
+
+    text = changelog.read_text()
+    new_entry = format_changelog_section(new, entries)
+
+    marker = "## ["
+    idx = text.find(marker)
+    if idx > 0:
+        changelog.write_text(text[:idx] + new_entry + text[idx:])
+        print(f"Updated CHANGELOG.md with [{new}]")
+    else:
+        print("WARNING: could not find insertion point in CHANGELOG.md", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    part = sys.argv[1].lower()
+    path = find_pyproject()
+    current = read_version(path)
+
+    if part == "show":
+        print(current)
+        sys.exit(0)
+
+    # Read changelog entries before bumping
+    entries = read_changelog_entries()
+
+    new = bump(current, part)
+    write_version(path, current, new)
+
+    # Also update __init__.py if it has __version__
+    init_candidates = [
+        path.parent / path.parent.name / "__init__.py",
+    ]
+    for init in init_candidates:
+        if init.exists():
+            init_text = init.read_text()
+            if f'__version__ = "{current}"' in init_text:
+                init.write_text(init_text.replace(
+                    f'__version__ = "{current}"',
+                    f'__version__ = "{new}"',
+                ))
+                print(f"Updated {init.relative_to(path.parent)}")
+
+    # Update changelog
+    update_changelog(path.parent, new, entries)
+
+    print(f"{current} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Match black's line length so flake8 and black agree.
+max-line-length = 100
+
+# E203: whitespace before ':' — conflicts with black's slice formatting.
+# W503: line break before binary operator — black does the opposite (W504-style).
+extend-ignore = E203, W503

--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,11 @@ max-line-length = 100
 # E203: whitespace before ':' — conflicts with black's slice formatting.
 # W503: line break before binary operator — black does the opposite (W504-style).
 extend-ignore = E203, W503
+
+# Per-file ignores. Keep narrow; do not broaden to silence real findings.
+# tests/*:
+#   S101 — pytest tests are asserts by convention; flake8-bandit warns on assert.
+#   S404 — `import subprocess` is a tool of the trade for invoking the CLI under test.
+#   S603 — `subprocess.run([sys.executable, "-m", ...])` is fully trusted input.
+per-file-ignores =
+    tests/*:S101,S404,S603

--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,10 @@ max-line-length = 100
 
 # E203: whitespace before ':' — conflicts with black's slice formatting.
 # W503: line break before binary operator — black does the opposite (W504-style).
-extend-ignore = E203, W503
+# S404, S603: subprocess use is intentional (doctor verb starts PyPI servers
+#   when --fix is set). Mirrored by `[tool.bandit] skips = ["B404", "B603"]`
+#   in pyproject.toml — keep both lists in sync.
+extend-ignore = E203, W503, S404, S603
 
 # Per-file ignores. Keep narrow; do not broaden to silence real findings.
 # tests/*:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "agentpypi/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "agentpypi/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - run: uv run pytest -n auto -v
+
+  test-publish:
+    # Skip on fork PRs — no OIDC context, the publish step would fail.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: test
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - name: Set dev version
+        run: |
+          BASE=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Publishing ${DEV_VERSION} to TestPyPI"
+      - name: Build and publish to TestPyPI
+        run: |
+          uv build
+          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
+      - name: Print install commands
+        if: always()
+        run: |
+          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match agentpypi==${DEV_VERSION}"
+
+  publish:
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - name: Build and publish to PyPI
+        run: |
+          uv build
+          uv publish --trusted-publishing always --check-url https://pypi.org/simple/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,95 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - run: uv run pytest -n auto --cov=agentpypi --cov-report=xml:coverage.xml --cov-report=term -v
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - name: black --check
+        run: uv run black --check agentpypi tests
+      - name: isort --check
+        run: uv run isort --check-only agentpypi tests
+      - name: flake8
+        run: uv run flake8 agentpypi tests
+      - name: pylint --errors-only
+        run: uv run pylint --errors-only agentpypi
+      - name: bandit
+        run: uv run bandit -c pyproject.toml -r agentpypi
+      - name: markdownlint-cli2
+        run: |
+          npm install -g markdownlint-cli2@0.21.0
+          markdownlint-cli2 "**/*.md" "#node_modules" "#.local" "#.afi"
+      - name: portability-lint
+        run: bash .claude/skills/pr-review/scripts/portability-lint.sh
+
+  version-check:
+    # Only run on PR events. On push to main after merge, HEAD == origin/main
+    # and the comparison would always fail.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - run: git fetch origin main
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Check version bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # AgentCulture rule: every PR bumps the version — even docs/config/CI.
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAIN_VERSION=$(git show origin/main:pyproject.toml 2>/dev/null | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])" 2>/dev/null || echo "")
+
+          if [ -z "$MAIN_VERSION" ]; then
+            echo "No pyproject.toml on main yet — skipping version check (initial scaffold)."
+            exit 0
+          fi
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            MARKER="<!-- version-check -->"
+            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Bump before merging to avoid a failed PyPI publish.
+
+          $MARKER"
+            EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --jq '.[] | select(.body | contains("<!-- version-check -->")) | .id' | head -1)
+            if [ -n "$EXISTING" ]; then
+              gh api repos/${{ github.repository }}/issues/comments/$EXISTING -X PATCH -f body="$BODY" > /dev/null
+            else
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" || true
+            fi
+            echo "::error::Version $PR_VERSION matches main. Bump before merging."
+            exit 1
+          else
+            echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -195,9 +195,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 # Temporary file for partial code execution

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,10 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# AgentCulture sibling — per-machine skill config (committed example only)
+.claude/skills.local.yaml
+.claude/settings.local.json
+
+# AFI scaffold — written by `afi cli cite .`, never committed
+.afi/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,19 @@
+# markdownlint-cli2 config for agentpypi.
+# markdownlint-cli2 stops walking at the git root, so a per-user global
+# config in the home directory isn't picked up from inside the repo.
+# Mirrors the afi-cli / cfafi / steward preset for workspace consistency.
+
+config:
+  default: true
+  # MD013: Line length — disabled. Prose lines wrap at the reader.
+  MD013: false
+  # MD060: Table pipe spacing — disabled (stylistic preference).
+  MD060: false
+  # MD024: Duplicate headings — allow under different parents so Keep a
+  # Changelog entries can each have ### Added / ### Changed / ### Fixed.
+  MD024:
+    siblings_only: true
+
+ignores:
+  - "node_modules/**"
+  - ".local/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,65 @@
+# Pre-commit hooks for agentpypi.
+#
+# Mirrors the lint chain in .github/workflows/tests.yml so locally-clean
+# work doesn't fail in CI. Modeled on ../afi-cli/.pre-commit-config.yaml
+# (which steward and the rest of the AgentCulture mesh share).
+#
+# Install once per checkout:
+#   uv run pre-commit install
+#
+# Run on demand:
+#   uv run pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-ast
+      - id: detect-private-key
+
+  - repo: local
+    hooks:
+      - id: markdownlint-cli2
+        name: markdownlint-cli2 (check)
+        description: Lint markdown (no auto-fix). Run scripts/lint-md.sh to fix.
+        entry: markdownlint-cli2
+        language: system
+        types: [markdown]
+
+      - id: black
+        name: black
+        entry: uv run black
+        language: system
+        types: [python]
+
+      - id: isort
+        name: isort
+        entry: uv run isort
+        language: system
+        types: [python]
+
+      - id: flake8
+        name: flake8
+        entry: uv run flake8 --config=.flake8
+        language: system
+        types: [python]
+
+      - id: bandit
+        name: bandit
+        entry: uv run bandit -c pyproject.toml -q
+        language: system
+        types: [python]
+        exclude: ^tests/
+
+      - id: portability-lint
+        name: portability-lint
+        description: Catch absolute home paths and per-user dotfile refs in committed files.
+        entry: bash .claude/skills/pr-review/scripts/portability-lint.sh
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/). This project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - 2026-04-28
+
+### Added
+
+- Toolchain bootstrap: `pyproject.toml` (hatchling, py3.12, zero runtime
+  deps, dev-dep set), `.flake8`, `.markdownlint-cli2.yaml`, dynamic
+  `__version__` via `importlib.metadata`. Coverage `fail_under = 60`.
+- Vendored steward skills (`version-bump`, `pr-review`) under
+  `.claude/skills/`. `.claude/skills.local.yaml.example` template +
+  `docs/skill-sources.md` upstream tracker.
+- AFI scaffold applied: `agentpypi/cli/{_errors,_output}.py` (stable
+  contract), `agentpypi/cli/__init__.py` (`_ArgumentParser` override +
+  `_dispatch`), `agentpypi/explain/{__init__,catalog}.py` (catalog
+  resolver + entries for every registered verb plus planned
+  online/local nouns).
+- Five verbs: `learn`, `explain`, `overview`, `doctor` (`--fix`-gated),
+  `whoami`. All support `--json`. Mutating verbs default to dry-run.
+- `agentpypi/_probes/` — uniform interface for known PyPI server
+  flavors (devpi:3141 `/+api`, pypiserver:8080 `/`); two-stage runtime
+  probe (TCP then HTTP) distinguishes up/down/absent.
+- Tests: 32 tests across `test_cli`, `test_probes`, `test_overview`,
+  `test_doctor`, `test_whoami`; in-process `http.server` thread fixture
+  in `conftest.py`. Coverage 92 %.
+- GitHub workflows: `tests.yml` (test/lint/version-check) and
+  `publish.yml` (TestPyPI on PR, PyPI on main, both via OIDC Trusted
+  Publishing).
+- Pre-commit hooks: black, isort, flake8 (+ bugbear, bandit), bandit -r,
+  markdownlint-cli2 (check), portability-lint.
+- `culture.yaml` registering agentpypi as a Culture-mesh agent.
+
+### Notes
+
+- `online`/`local` noun groups are catalog-known but NOT yet registered
+  as argparse subcommands. Calling them fails with `error: invalid
+  choice` + a `hint:` line. Implementations land in v0.1.0 (`online`)
+  and v0.2.0 (`local`).
+- AFI rubric `overview_cli_noun_exists` check fails for agentpypi
+  because the project has no `cli` noun (its nouns are `online` /
+  `local`). Accepted structural deviation; documented in
+  `docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2026-04-28
+
+### Changed
+
+- doctor: ok now derived from final post-fix probe statuses (was: start_command return codes only)
+- doctor: extracted `_apply_fix` and `_process_probe` helpers (S3776 cognitive complexity)
+- whoami: switched configparser to interpolation=None (RawConfigParser semantics) so `%` in URL-encoded credentials no longer crashes whoami
+- learn: extracted `_M_ONLINE` / `_M_LOCAL` constants for milestone strings (S1192)
+- _runtime: dropped redundant URLError catch (subclass of OSError) (S5713)
+- tests/test_whoami: switched fake HOME to pytest tmp_path (Copilot review)
+- tests/test_overview: switched bogus target to a tmp_path subpath (S5443)
+- tests/test_doctor: annotated yield fixture as Iterator[None] (S5886)
+
+### Fixed
+
+- doctor --fix exiting 0 even when a server was still down/absent after a successful start_command (Copilot + qodo bug report)
+- README + CLAUDE.md still describing the repo as warm-up despite v0.0.1 landing
+
 ## [0.0.1] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Status: warm-up
+
+This repository is a **freshly-initialised AgentCulture sibling**. The only
+checked-in files are `README.md`, `LICENSE`, `.gitignore`, and this file.
+There is no `pyproject.toml`, no package, no tests, and no CI yet.
+
+The contract this file captures is the **intended shape** for the first
+implementation PR — not a description of what is on disk today. When you
+edit, keep claims grounded in what is actually checked in: the moment a
+section drifts ahead of reality, mark it `(planned)` or move it under
+`## Roadmap`.
+
+Remote (planned): `https://github.com/agentculture/agentpypi`.
+
+## What this repo is
+
+`agentpypi` manages **both ends of the Python distribution pipe** for the
+AgentCulture mesh:
+
+- **Online PyPI** — release orchestration across AgentCulture siblings
+  (`afi-cli`, `cfafi`, `ghafi`, `shushu`, `steward`, `zehut`, …). Read PyPI
+  + TestPyPI state, diff against `CHANGELOG.md` / `main`, and trigger the
+  per-sibling `publish.yml` workflow that `ghafi` provisioned.
+- **Local PyPI** — a private PyPI-compatible index running on the Culture
+  mesh so agents can publish and pull intra-mesh wheels without leaving the
+  org's trust boundary.
+
+Sibling to [`afi-cli`](https://github.com/agentculture/afi-cli) (CLI shape
+this repo inherits), [`ghafi`](https://github.com/agentculture/ghafi)
+(provisions the PyPI / TestPyPI GitHub Environments this repo drives), and
+[`steward`](https://github.com/agentculture/steward) (alignment + skills
+supplier; `steward doctor --scope siblings` will audit this repo against
+the corpus baseline once code lands).
+
+Workspace context: see `../CLAUDE.md` (the multi-project workspace) and
+`/home/spark/.claude/CLAUDE.md` (user globals) when in doubt about
+conventions; do not duplicate them here.
+
+## Sibling pattern this repo MUST adopt
+
+The AgentCulture sibling pattern (canonical source:
+`../steward/docs/sibling-pattern.md`, baseline:
+`../steward/docs/perfect-patient.md`). The first implementation PR is
+expected to bring all twelve required artifacts in:
+
+| # | Artifact | Path |
+|---|----------|------|
+| 1 | Toolchain | `pyproject.toml` (hatchling, Python ≥ 3.12, zero runtime deps where possible) |
+| 2 | Top-level package | `agentpypi/__init__.py`, `agentpypi/__main__.py` (`__version__` via `importlib.metadata`) |
+| 3 | CLI scaffolding | `agentpypi/cli/__init__.py`, `cli/_errors.py`, `cli/_output.py`, `cli/_commands/` |
+| 4 | Agent-first verbs | `cli/_commands/{learn,explain,whoami}.py` |
+| 5 | Mutation safety | Every write verb defaults to **dry-run**; `--apply` to commit |
+| 6 | Tests | `tests/test_cli_*.py`, pytest-xdist, coverage |
+| 7 | CI | `.github/workflows/tests.yml`, `.github/workflows/publish.yml` (Trusted Publishing) |
+| 8 | Changelog | `CHANGELOG.md` (Keep-a-Changelog), bumped on every PR by the `version-bump` skill |
+| 9 | Skills | `.claude/skills/<name>/SKILL.md` + `scripts/` per skill |
+| 10 | Per-machine config | `.claude/skills.local.yaml.example` (committed) + `.claude/skills.local.yaml` (git-ignored) |
+| 11 | Lint configs | `.flake8`, `.markdownlint-cli2.yaml` (repo-local — no per-user home configs) |
+| 12 | This file | Project shape, build/test/publish commands, non-obvious invariants |
+
+`steward doctor --scope self` enforces a subset of these (portability,
+skills convention, etc.). Run it before opening the first PR:
+
+```bash
+(cd ../steward && uv run steward doctor --scope self ../agentpypi)
+```
+
+## Quality pipeline (planned)
+
+The dev-extras and pre-commit hook set every AgentCulture sibling ships
+with — copy from `shushu` or `ghafi` rather than re-deriving:
+
+- **Format:** `black`, `isort` (line length 100, target py312)
+- **Lint:** `flake8` (+ `flake8-bandit`, `flake8-bugbear`), `pylint --errors-only`
+- **Security:** `bandit -r agentpypi -c pyproject.toml`
+- **Markdown:** `markdownlint-cli2 "**/*.md"` (config: `.markdownlint-cli2.yaml` at repo root)
+- **Portability:** `bash .claude/skills/pr-review/scripts/portability-lint.sh`
+  (no `/home/<user>/...` paths, no `~/.<dotfile>` refs in committed configs)
+
+`.flake8` carries any per-file ignores (e.g. `tests/*:S101`). Don't broaden
+it to silence real findings — delete or fix the offending code.
+
+## Version discipline (planned)
+
+One source of truth: `pyproject.toml` `[project].version`.
+`agentpypi/__init__.py` resolves `__version__` dynamically via
+`importlib.metadata.version("agentpypi")`. No literal `__version__`
+elsewhere. Every PR bumps (`major` / `minor` / `patch`) using the
+vendored `version-bump` skill; CI's `version-check` job blocks merge
+otherwise.
+
+## Python floor
+
+`requires-python = ">=3.12"`. PEP 604 unions, frozen dataclasses,
+`tomllib`, `importlib.resources.files`. Do not lower the floor.
+
+## CLI shape (planned)
+
+Noun/verb, agent-first, identical in spirit to `afi-cli` / `cfafi` /
+`ghafi` / `shushu`:
+
+```text
+agentpypi <noun> <verb> [args] [--json] [--apply]
+```
+
+Required verbs (the agent-affordance trio):
+
+- `agentpypi learn` (and `learn --json`) — self-teaching prompt covering
+  every noun and verb, generated from the `explain/` catalog so it can
+  never lie.
+- `agentpypi explain <path>` — markdown for any noun, verb, or concept.
+- `agentpypi whoami` — smallest auth probe; reports which PyPI / TestPyPI
+  / local index the current env is pointed at.
+
+Two top-level nouns, mirroring the README:
+
+- `agentpypi online …` — read PyPI / TestPyPI state, diff siblings, trigger
+  the sibling-side `publish.yml`. Mutations require `--apply`.
+- `agentpypi local …` — run / mirror / publish to the in-mesh index.
+  `serve` is foreground-default; everything write-shaped is `--apply`-gated.
+
+The exact verb set is **not yet frozen** — brainstorm before coding.
+Use the `superpowers:brainstorming` skill on the first design PR.
+
+## Do not implement yet
+
+This repo is a warm-up. Until Ori asks for an implementation PR:
+
+- Do **not** create `pyproject.toml`, package directories, tests, workflows,
+  or skills.
+- Do **not** add a `culture.yaml` or join the mesh.
+- Do **not** invent verbs, exit-code tables, or threat models that aren't
+  reflected here.
+
+What you *can* do without permission: tighten this file or `README.md` if
+something is wrong, ambiguous, or has drifted from the linked sibling
+patterns.
+
+## Roadmap (high-level, agent-readable)
+
+1. **v0.0.1 — package skeleton.** `pyproject.toml`, top-level package,
+   argparse `main()` with `learn` / `explain` / `whoami`, tests for
+   `--version` and `learn --json`, CI `tests.yml`. Joins the mesh
+   (`culture.yaml`) and gets `pypi` / `testpypi` GH Environments via `ghafi`.
+2. **v0.1.0 — `online` noun.** Read-only verbs first
+   (`online status SIBLING`, `online list`), then mutations
+   (`online release SIBLING --apply` triggering the sibling's
+   `publish.yml`). PyPI + TestPyPI both addressable.
+3. **v0.2.0 — `local` noun.** Foreground `local serve` (PEP 503 simple
+   index), `local upload`, `local mirror PACKAGE`. Wire systemd unit
+   under `docs/deploy/`.
+4. **v1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
+   service registry; trust boundary documented in `docs/threat-model.md`.
+
+This roadmap is descriptive of intent, not a commitment. Reorder or
+replace as the design lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,19 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Status: warm-up
+## Status: v0.0.1 baseline landed
 
-This repository is a **freshly-initialised AgentCulture sibling**. The only
-checked-in files are `README.md`, `LICENSE`, `.gitignore`, and this file.
-There is no `pyproject.toml`, no package, no tests, and no CI yet.
+This repository is an **AgentCulture sibling with its initial baseline
+in place**. `pyproject.toml`, the `agentpypi/` package, `tests/`, the
+quality pipeline (lint configs + pre-commit + the two CI workflows),
+the vendored skills (`.claude/skills/{version-bump,pr-review}/`), and
+`culture.yaml` are all checked in.
 
-The contract this file captures is the **intended shape** for the first
-implementation PR — not a description of what is on disk today. When you
-edit, keep claims grounded in what is actually checked in: the moment a
+This file describes the repository **as it exists on disk today**. When
+you edit, keep claims grounded in checked-in reality; the moment a
 section drifts ahead of reality, mark it `(planned)` or move it under
 `## Roadmap`.
 
-Remote (planned): `https://github.com/agentculture/agentpypi`.
+Remote: `https://github.com/agentculture/agentpypi`.
 
 ## What this repo is
 
@@ -69,7 +70,7 @@ skills convention, etc.). Run it before opening the first PR:
 (cd ../steward && uv run steward doctor --scope self ../agentpypi)
 ```
 
-## Quality pipeline (planned)
+## Quality pipeline
 
 The dev-extras and pre-commit hook set every AgentCulture sibling ships
 with — copy from `shushu` or `ghafi` rather than re-deriving:
@@ -84,7 +85,7 @@ with — copy from `shushu` or `ghafi` rather than re-deriving:
 `.flake8` carries any per-file ignores (e.g. `tests/*:S101`). Don't broaden
 it to silence real findings — delete or fix the offending code.
 
-## Version discipline (planned)
+## Version discipline
 
 One source of truth: `pyproject.toml` `[project].version`.
 `agentpypi/__init__.py` resolves `__version__` dynamically via
@@ -98,7 +99,7 @@ otherwise.
 `requires-python = ">=3.12"`. PEP 604 unions, frozen dataclasses,
 `tomllib`, `importlib.resources.files`. Do not lower the floor.
 
-## CLI shape (planned)
+## CLI shape
 
 Noun/verb, agent-first, identical in spirit to `afi-cli` / `cfafi` /
 `ghafi` / `shushu`:
@@ -107,38 +108,50 @@ Noun/verb, agent-first, identical in spirit to `afi-cli` / `cfafi` /
 agentpypi <noun> <verb> [args] [--json] [--apply]
 ```
 
-Required verbs (the agent-affordance trio):
+Five flat verbs registered at v0.0.1 (no nouns yet):
 
-- `agentpypi learn` (and `learn --json`) — self-teaching prompt covering
-  every noun and verb, generated from the `explain/` catalog so it can
-  never lie.
-- `agentpypi explain <path>` — markdown for any noun, verb, or concept.
-- `agentpypi whoami` — smallest auth probe; reports which PyPI / TestPyPI
-  / local index the current env is pointed at.
+- `agentpypi learn` (and `learn --json`) — self-teaching prompt
+  generated from the `agentpypi/explain/catalog.py` catalog so it can
+  never describe a verb that isn't registered.
+- `agentpypi explain <path>` — markdown for any noun, verb, or planned
+  concept. `online` and `local` resolve to `status: planned` entries.
+- `agentpypi overview [TARGET] [--json]` — probe localhost for known
+  PyPI server flavors (`devpi:3141`, `pypiserver:8080`); JSON shape is
+  `{"subject", "sections": [...]}`. Read-only. Unknown TARGET → exit 0
+  with a stderr warning + zero-target report (per AFI rubric bundle 6).
+- `agentpypi doctor [--fix] [--json]` — same probes plus diagnoses;
+  with `--fix`, runs each probe's `start_command` and re-probes. Exits
+  `2` only when `--fix` was attempted and any server is still not up
+  after the re-probe.
+- `agentpypi whoami [--json]` — auth/env probe; reads
+  `$PIP_INDEX_URL` / `$UV_INDEX_URL` env vars and pip's global config
+  file, cross-references local probes. Exact paths inspected live in
+  `agentpypi/cli/_commands/whoami.py`.
 
-Two top-level nouns, mirroring the README:
+Two top-level nouns are catalog-known but **not** yet registered as
+argparse subcommands; calling them errors with `invalid choice` until
+the milestone lands:
 
-- `agentpypi online …` — read PyPI / TestPyPI state, diff siblings, trigger
-  the sibling-side `publish.yml`. Mutations require `--apply`.
-- `agentpypi local …` — run / mirror / publish to the in-mesh index.
-  `serve` is foreground-default; everything write-shaped is `--apply`-gated.
+- `agentpypi online …` (v0.1.0) — read PyPI / TestPyPI state, diff
+  siblings, trigger the sibling-side `publish.yml`. Mutations require
+  `--apply`.
+- `agentpypi local …` (v0.2.0) — run / mirror / publish to the in-mesh
+  index. `serve` is foreground-default; everything write-shaped is
+  `--apply`-gated.
 
-The exact verb set is **not yet frozen** — brainstorm before coding.
-Use the `superpowers:brainstorming` skill on the first design PR.
+## Roadmap discipline
 
-## Do not implement yet
+CLI changes follow the same discipline as the rest of the AgentCulture
+mesh: brainstorm with the `superpowers:brainstorming` skill before code,
+write a design doc under `docs/superpowers/specs/`, and bump the version
+on every PR (`version-bump` skill — CI's `version-check` job blocks
+merge otherwise).
 
-This repo is a warm-up. Until Ori asks for an implementation PR:
-
-- Do **not** create `pyproject.toml`, package directories, tests, workflows,
-  or skills.
-- Do **not** add a `culture.yaml` or join the mesh.
-- Do **not** invent verbs, exit-code tables, or threat models that aren't
-  reflected here.
-
-What you *can* do without permission: tighten this file or `README.md` if
-something is wrong, ambiguous, or has drifted from the linked sibling
-patterns.
+The first implementation PR (v0.0.1) brainstormed the noun set and
+shipped flat verbs instead of the `online` / `local` nouns CLAUDE.md
+originally sketched. That decision is captured in
+`docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md` under
+"Drift acknowledged".
 
 ## Roadmap (high-level, agent-readable)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ AgentCulture mesh:
 
 - **Online PyPI** — release orchestration across AgentCulture siblings
   (`afi-cli`, `cfafi`, `ghafi`, `shushu`, `steward`, `zehut`, …). Read PyPI
-  + TestPyPI state, diff against `CHANGELOG.md` / `main`, and trigger the
-  per-sibling `publish.yml` workflow that `ghafi` provisioned.
+  and TestPyPI state, diff against `CHANGELOG.md` / `main`, and trigger
+  the per-sibling `publish.yml` workflow that `ghafi` provisioned.
 - **Local PyPI** — a private PyPI-compatible index running on the Culture
   mesh so agents can publish and pull intra-mesh wheels without leaving the
   org's trust boundary.
@@ -36,9 +36,9 @@ this repo inherits), [`ghafi`](https://github.com/agentculture/ghafi)
 supplier; `steward doctor --scope siblings` will audit this repo against
 the corpus baseline once code lands).
 
-Workspace context: see `../CLAUDE.md` (the multi-project workspace) and
-`/home/spark/.claude/CLAUDE.md` (user globals) when in doubt about
-conventions; do not duplicate them here.
+Workspace context: see `../CLAUDE.md` (the multi-project workspace) for
+cross-project conventions; do not duplicate them here. Per-user globals
+load automatically through the agent harness if present.
 
 ## Sibling pattern this repo MUST adopt
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # agentpypi
 
-> **Status: warm-up.** Repo skeleton only — intent + conventions are written
-> down here so the first implementation PR has a target to aim at. No code,
-> `pyproject.toml`, or tests have landed yet.
+> **Status: v0.0.1 baseline landed.** Packaging metadata, the Python
+> package, tests, CI, and the agent-affordance verb surface are all
+> checked in. The roadmap below describes the *evolving* surface; any
+> verb listed under "Planned" is catalog-known but not yet registered as
+> an argparse subcommand.
 
 PyPI for the agents. `agentpypi` is the AgentCulture sibling that manages
 **both ends of the Python distribution pipe**:
@@ -24,7 +26,7 @@ scaffolder this repo will be built from), [`ghafi`](https://github.com/agentcult
 (GitHub-side bootstrapper), and [`steward`](https://github.com/agentculture/steward)
 (alignment / skills supplier).
 
-## Install (planned)
+## Install
 
 ```bash
 uv tool install agentpypi
@@ -32,40 +34,41 @@ agentpypi --version
 ```
 
 Python ≥ 3.12. `uv tool install` is the supported path — not `pip install`.
+First release lands on PyPI on merge of v0.0.1 via OIDC Trusted
+Publishing; until then, `uv pip install -e .` from a checkout works.
 
-## Intended surface (planned)
+## Surface (v0.0.1, with planned roadmap)
 
 Every verb defaults to dry-run; `--apply` to commit. Every command supports
 `--json`. Exit-code policy follows the [afi rubric](https://github.com/agentculture/afi-cli/blob/main/docs/rubric.md#exit-code-policy)
 (`0` success / `1` user error / `2` env error).
 
 ```bash
-# Self-teaching surface — same shape as every AgentCulture CLI
-agentpypi learn                       # markdown summary of every verb
-agentpypi learn --json                # structured payload for agents
-agentpypi explain release             # explain a verb
-agentpypi explain online              # explain a noun
+# Registered (v0.0.1) — agent-affordance + localhost introspection
+agentpypi learn                       # self-teaching prompt; --json supported
+agentpypi explain <path>              # markdown for any noun/verb (incl. planned)
+agentpypi overview                    # probe localhost: devpi:3141, pypiserver:8080
+agentpypi doctor [--fix]              # same probes + diagnoses; --fix starts servers
+agentpypi whoami                      # which PyPI / TestPyPI / local index am I on?
 
-# Auth probe
-agentpypi whoami                      # which PyPI / TestPyPI / local index am I talking to?
-
-# Online — orchestrate releases of AgentCulture siblings
+# Planned (v0.1.0) — orchestrate releases of AgentCulture siblings
 agentpypi online status SIBLING       # PyPI vs CHANGELOG vs main vs latest tag
 agentpypi online release SIBLING      # dry-run: would-be tag + workflow trigger
 agentpypi online release SIBLING --apply
 
-# Local — manage the in-mesh index
+# Planned (v0.2.0) — manage the in-mesh local PyPI index
 agentpypi local serve                 # run the local index (foreground)
 agentpypi local upload PATH           # publish a wheel/sdist to the local index
 agentpypi local mirror PACKAGE        # snapshot a public package into local
 agentpypi local list                  # what's hosted locally
 ```
 
-The exact verb set is **not frozen** — these are sketches, not contracts.
-The first implementation PR brainstorms the noun set with the
-`superpowers:brainstorming` skill before any code lands.
+`agentpypi explain online` and `agentpypi explain local` resolve to
+`status: planned` entries in the explain catalog at v0.0.1; calling the
+verbs themselves errors with argparse's `invalid choice` until the
+respective milestone lands.
 
-## Develop (planned)
+## Develop
 
 ```bash
 uv sync                          # install + dev deps

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # agentpypi
-Local pypi operated by agents
+
+> **Status: warm-up.** Repo skeleton only — intent + conventions are written
+> down here so the first implementation PR has a target to aim at. No code,
+> `pyproject.toml`, or tests have landed yet.
+
+PyPI for the agents. `agentpypi` is the AgentCulture sibling that manages
+**both ends of the Python distribution pipe**:
+
+- **Online PyPI** — release orchestration for AgentCulture siblings
+  (`afi-cli`, `cfafi`, `ghafi`, `shushu`, `steward`, `zehut`, …): version
+  checks, TestPyPI smoke installs, PyPI publishing dashboards. Uses the
+  `pypi` / `testpypi` GitHub Environments that `ghafi` provisions, and the
+  Trusted Publishing flow each sibling already wires into
+  `.github/workflows/publish.yml`.
+- **Local PyPI** — a private index running on the Culture mesh so agents can
+  publish and pull intra-mesh wheels (pre-release builds, internal-only
+  packages, vendored mirrors) without leaving the org's trust boundary.
+
+Part of the [AgentCulture](https://github.com/agentculture) OSS org —
+maintained jointly by agents and one human (Ori Nachum). Sibling to
+[`afi-cli`](https://github.com/agentculture/afi-cli) (the agent-first CLI
+scaffolder this repo will be built from), [`ghafi`](https://github.com/agentculture/ghafi)
+(GitHub-side bootstrapper), and [`steward`](https://github.com/agentculture/steward)
+(alignment / skills supplier).
+
+## Install (planned)
+
+```bash
+uv tool install agentpypi
+agentpypi --version
+```
+
+Python ≥ 3.12. `uv tool install` is the supported path — not `pip install`.
+
+## Intended surface (planned)
+
+Every verb defaults to dry-run; `--apply` to commit. Every command supports
+`--json`. Exit-code policy follows the [afi rubric](https://github.com/agentculture/afi-cli/blob/main/docs/rubric.md#exit-code-policy)
+(`0` success / `1` user error / `2` env error).
+
+```bash
+# Self-teaching surface — same shape as every AgentCulture CLI
+agentpypi learn                       # markdown summary of every verb
+agentpypi learn --json                # structured payload for agents
+agentpypi explain release             # explain a verb
+agentpypi explain online              # explain a noun
+
+# Auth probe
+agentpypi whoami                      # which PyPI / TestPyPI / local index am I talking to?
+
+# Online — orchestrate releases of AgentCulture siblings
+agentpypi online status SIBLING       # PyPI vs CHANGELOG vs main vs latest tag
+agentpypi online release SIBLING      # dry-run: would-be tag + workflow trigger
+agentpypi online release SIBLING --apply
+
+# Local — manage the in-mesh index
+agentpypi local serve                 # run the local index (foreground)
+agentpypi local upload PATH           # publish a wheel/sdist to the local index
+agentpypi local mirror PACKAGE        # snapshot a public package into local
+agentpypi local list                  # what's hosted locally
+```
+
+The exact verb set is **not frozen** — these are sketches, not contracts.
+The first implementation PR brainstorms the noun set with the
+`superpowers:brainstorming` skill before any code lands.
+
+## Develop (planned)
+
+```bash
+uv sync                          # install + dev deps
+uv run pytest -n auto -v         # tests
+uv run agentpypi --version       # smoke
+uv run pre-commit install        # enable lint hooks
+```
+
+Quality pipeline mirrors the rest of the AgentCulture mesh: `black`, `isort`,
+`flake8` (+ `flake8-bandit`, `flake8-bugbear`), `pylint`, `bandit`,
+`markdownlint-cli2`. CI runs on every PR + push to `main`.
+
+## Trusted Publishing
+
+Once `pyproject.toml` lands, `ghafi` provisions the `pypi` / `testpypi`
+GitHub Environments and `.github/workflows/publish.yml` follows the same
+OIDC Trusted Publishing pattern every sibling uses — no secrets in the repo.
+
+## License
+
+MIT. © 2026 Ori Nachum / AgentCulture.
+
+— Claude

--- a/agentpypi/__init__.py
+++ b/agentpypi/__init__.py
@@ -1,0 +1,10 @@
+"""agentpypi — both ends of the Python distribution pipe for the AgentCulture mesh."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("agentpypi")
+except PackageNotFoundError:  # pragma: no cover - only hit in source checkout w/o install
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/agentpypi/__main__.py
+++ b/agentpypi/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point for ``python -m agentpypi``."""
+
+from __future__ import annotations
+
+import sys
+
+from agentpypi.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agentpypi/_probes/__init__.py
+++ b/agentpypi/_probes/__init__.py
@@ -1,0 +1,16 @@
+"""PyPI server probes — one flavor per submodule.
+
+Each flavor exposes a ``PROBE`` (a :class:`Probe` instance). Add new
+flavors by importing them here and extending :data:`PROBES`.
+"""
+
+from __future__ import annotations
+
+from agentpypi._probes._probe import Probe
+from agentpypi._probes._runtime import ProbeResult, probe_status
+from agentpypi._probes.devpi import PROBE as devpi
+from agentpypi._probes.pypiserver import PROBE as pypiserver
+
+PROBES: tuple[Probe, ...] = (devpi, pypiserver)
+
+__all__ = ["PROBES", "Probe", "ProbeResult", "devpi", "probe_status", "pypiserver"]

--- a/agentpypi/_probes/_probe.py
+++ b/agentpypi/_probes/_probe.py
@@ -1,0 +1,36 @@
+"""Uniform interface for one flavor of PyPI server.
+
+Each `agentpypi/_probes/<flavor>.py` module instantiates one ``Probe`` and
+exposes it as ``PROBE``. The runtime checker in :mod:`._runtime` consumes
+``Probe`` instances; ``overview`` and ``doctor`` iterate
+:data:`agentpypi._probes.PROBES`.
+
+Adding a new flavor is one file: define another ``Probe`` and append to
+``PROBES`` in :mod:`agentpypi._probes`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Probe:
+    """One PyPI server flavor.
+
+    :param name: Stable identifier (``devpi``, ``pypiserver``, ...).
+    :param default_port: Conventional port for this flavor.
+    :param health_path: Path appended to the host:port for the health check
+        (e.g. ``/+api`` for devpi).
+    :param start_command: Argv tuple ``doctor --fix`` runs to bring the
+        server up. Empty tuple = no auto-start; ``doctor`` reports the
+        flavor as needing manual remediation.
+    """
+
+    name: str
+    default_port: int
+    health_path: str
+    start_command: tuple[str, ...]
+
+    def health_url(self, host: str = "127.0.0.1", port: int | None = None) -> str:
+        return f"http://{host}:{port if port is not None else self.default_port}{self.health_path}"

--- a/agentpypi/_probes/_runtime.py
+++ b/agentpypi/_probes/_runtime.py
@@ -71,7 +71,12 @@ def probe_status(
             "status": "down",
             "detail": f"http {err.code}",
         }
-    except (urllib.error.URLError, OSError) as err:  # TimeoutError is an OSError subclass
+    except OSError as err:
+        # OSError is the umbrella class here:
+        #   - urllib.error.URLError derives from OSError (covers DNS, refused, …)
+        #   - TimeoutError derives from OSError (covers urllib timeout=…)
+        # Catching just OSError keeps SonarRule python:S5713 happy and is
+        # exactly equivalent to the prior tuple.
         return {
             "name": probe.name,
             "port": p,

--- a/agentpypi/_probes/_runtime.py
+++ b/agentpypi/_probes/_runtime.py
@@ -1,0 +1,81 @@
+"""Runtime probe — TCP-then-HTTP check against one Probe.
+
+Two-stage so we can distinguish:
+
+* ``absent`` — nothing listening on the port (port closed)
+* ``down``   — something is listening but it isn't a healthy PyPI server
+* ``up``     — listening and HTTP responded 2xx
+
+Both stages enforce the caller's ``timeout`` so a hung host doesn't stall
+``overview``. No external deps; stdlib only.
+"""
+
+from __future__ import annotations
+
+import socket
+import urllib.error
+import urllib.request
+from typing import TypedDict
+
+from agentpypi._probes._probe import Probe
+
+
+class ProbeResult(TypedDict, total=False):
+    name: str
+    port: int
+    url: str
+    status: str  # "up" | "down" | "absent"
+    detail: str  # populated on "down" with the reason
+
+
+def _tcp_open(host: str, port: int, timeout: float) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def probe_status(
+    probe: Probe,
+    *,
+    host: str = "127.0.0.1",
+    port: int | None = None,
+    timeout: float = 1.0,
+) -> ProbeResult:
+    """Probe one server; return a structured status dict."""
+    p = port if port is not None else probe.default_port
+    url = probe.health_url(host=host, port=p)
+
+    if not _tcp_open(host, p, timeout):
+        return {"name": probe.name, "port": p, "url": url, "status": "absent"}
+
+    try:
+        # The URL is constructed from the Probe definition (literal `http://`
+        # scheme + host:port + health_path) — no caller-controlled scheme.
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 # nosec B310
+            if 200 <= resp.status < 300:
+                return {"name": probe.name, "port": p, "url": url, "status": "up"}
+            return {
+                "name": probe.name,
+                "port": p,
+                "url": url,
+                "status": "down",
+                "detail": f"http {resp.status}",
+            }
+    except urllib.error.HTTPError as err:
+        return {
+            "name": probe.name,
+            "port": p,
+            "url": url,
+            "status": "down",
+            "detail": f"http {err.code}",
+        }
+    except (urllib.error.URLError, OSError) as err:  # TimeoutError is an OSError subclass
+        return {
+            "name": probe.name,
+            "port": p,
+            "url": url,
+            "status": "down",
+            "detail": str(err),
+        }

--- a/agentpypi/_probes/devpi.py
+++ b/agentpypi/_probes/devpi.py
@@ -1,0 +1,12 @@
+"""devpi probe — `devpi-server` on port 3141, health endpoint `/+api`."""
+
+from __future__ import annotations
+
+from agentpypi._probes._probe import Probe
+
+PROBE = Probe(
+    name="devpi",
+    default_port=3141,
+    health_path="/+api",
+    start_command=("devpi-server", "--start"),
+)

--- a/agentpypi/_probes/pypiserver.py
+++ b/agentpypi/_probes/pypiserver.py
@@ -1,0 +1,16 @@
+"""pypiserver probe — `pypi-server` on port 8080, health endpoint `/`.
+
+`pypiserver` doesn't ship a JSON health endpoint; the simple-index root
+returns HTML 200 when the server is up.
+"""
+
+from __future__ import annotations
+
+from agentpypi._probes._probe import Probe
+
+PROBE = Probe(
+    name="pypiserver",
+    default_port=8080,
+    health_path="/",
+    start_command=("pypi-server", "run"),
+)

--- a/agentpypi/cli/__init__.py
+++ b/agentpypi/cli/__init__.py
@@ -1,0 +1,85 @@
+"""Unified CLI entry point for agentpypi.
+
+Noun-based command groups and globals are registered here. Top-level globals
+(``learn``, ``explain``, ``overview``, ``doctor``, ``whoami``) live under
+:mod:`agentpypi.cli._commands`.
+
+Error-propagation contract: every handler raises
+:class:`agentpypi.cli._errors.AfiError` on failure; :func:`main` catches it
+via :func:`_dispatch` and routes through :mod:`agentpypi.cli._output`.
+Unknown exceptions are wrapped so no Python traceback leaks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agentpypi import __version__
+from agentpypi.cli._commands import doctor as _doctor_cmd
+from agentpypi.cli._commands import explain as _explain_cmd
+from agentpypi.cli._commands import learn as _learn_cmd
+from agentpypi.cli._commands import overview as _overview_cmd
+from agentpypi.cli._commands import whoami as _whoami_cmd
+from agentpypi.cli._errors import EXIT_USER_ERROR, AfiError
+from agentpypi.cli._output import emit_error
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that emits errors via our structured format."""
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        err = AfiError(
+            code=EXIT_USER_ERROR,
+            message=message,
+            remediation=f"run '{self.prog} --help' to see valid arguments",
+        )
+        emit_error(err, json_mode=False)
+        raise SystemExit(err.code)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = _ArgumentParser(
+        prog="agentpypi",
+        description="agentpypi — agent-first CLI for the AgentCulture Python distribution pipe.",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    sub = parser.add_subparsers(dest="command")
+
+    _learn_cmd.register(sub)
+    _explain_cmd.register(sub)
+    _overview_cmd.register(sub)
+    _doctor_cmd.register(sub)
+    _whoami_cmd.register(sub)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        return args.func(args)
+    except AfiError as err:
+        emit_error(err, json_mode=json_mode)
+        return err.code
+    except Exception as err:  # noqa: BLE001 - last-resort
+        wrapped = AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"unexpected: {err.__class__.__name__}: {err}",
+            remediation="file a bug",
+        )
+        emit_error(wrapped, json_mode=json_mode)
+        return wrapped.code
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
+    return _dispatch(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agentpypi/cli/_commands/doctor.py
+++ b/agentpypi/cli/_commands/doctor.py
@@ -1,18 +1,164 @@
-"""``agentpypi doctor`` — placeholder; real implementation lands in step 5."""
+"""``agentpypi doctor`` — probe + diagnose; ``--fix`` starts configured servers.
+
+Default is dry-run: prints which servers would be started, returns the
+overview-style payload but with a ``diagnoses`` field per item. ``--fix``
+runs each ``down``/``absent`` server's ``start_command`` via
+``subprocess.run`` and re-probes.
+
+Mutating verbs default to dry-run (per CLAUDE.md "every write verb defaults
+to dry-run"). ``--fix`` is doctor's apply gate.
+
+Exit codes:
+
+* ``0`` — every server is up (or ``--fix`` brought every down/absent server up).
+* ``2`` — a ``--fix`` attempt failed (start_command not on PATH, non-zero exit, …).
+"""
 
 from __future__ import annotations
 
 import argparse
+import subprocess
+from typing import Callable
 
-from agentpypi.cli._errors import EXIT_ENV_ERROR, AfiError
+from agentpypi._probes import PROBES, probe_status
+from agentpypi._probes._probe import Probe
+from agentpypi._probes._runtime import ProbeResult
+from agentpypi.cli._errors import EXIT_ENV_ERROR, EXIT_SUCCESS, AfiError
+from agentpypi.cli._output import emit_diagnostic, emit_result
+
+_SUBJECT = "agentpypi doctor"
+
+# Indirection for tests: monkey-patch this to a FakeRunner instead of subprocess.run.
+RUN: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
 
 
-def cmd_doctor(args: argparse.Namespace) -> int:  # pragma: no cover - replaced in step 5
-    raise AfiError(
-        code=EXIT_ENV_ERROR,
-        message="doctor is not yet wired (step 3 placeholder)",
-        remediation="finish step 5 of the v0.0.1 plan",
-    )
+def _diagnose(item: ProbeResult, probe: Probe) -> dict[str, object]:
+    out: dict[str, object] = dict(item)
+    if item["status"] == "up":
+        out["diagnosis"] = "healthy"
+        out["remediation"] = None
+        return out
+    if not probe.start_command:
+        out["diagnosis"] = f"{item['status']}; no start_command configured"
+        out["remediation"] = "configure start_command in the probe definition"
+        return out
+    out["diagnosis"] = f"{item['status']}; would run start_command"
+    out["remediation"] = list(probe.start_command)
+    return out
+
+
+def _try_start(probe: Probe) -> tuple[bool, str]:
+    """Run ``probe.start_command``; return (ok, detail)."""
+    try:
+        completed = RUN(
+            list(probe.start_command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError as err:
+        return False, f"command not found: {err.filename}"
+    except (OSError, subprocess.SubprocessError) as err:
+        return False, f"{err.__class__.__name__}: {err}"
+    if completed.returncode != 0:
+        snippet = (completed.stderr or completed.stdout or "").strip().splitlines()
+        msg = snippet[0] if snippet else f"exit {completed.returncode}"
+        return False, f"exit {completed.returncode}: {msg}"
+    return True, "started"
+
+
+def _build_payload(*, fix: bool) -> tuple[dict[str, object], bool]:
+    """Return (payload, all_healthy). Mutates state when ``fix`` is True."""
+    items: list[dict[str, object]] = []
+    all_healthy = True
+    fix_failed = False
+    for probe in PROBES:
+        result = probe_status(probe)
+        item = _diagnose(result, probe)
+        if item["status"] != "up":
+            all_healthy = False
+            if fix and probe.start_command:
+                ok, detail = _try_start(probe)
+                item["fix_attempted"] = True
+                item["fix_ok"] = ok
+                item["fix_detail"] = detail
+                if not ok:
+                    fix_failed = True
+                else:
+                    # Re-probe after start_command returned successfully.
+                    rechecked = probe_status(probe)
+                    item["status"] = rechecked["status"]
+                    item["url"] = rechecked["url"]
+                    if rechecked.get("detail"):
+                        item["detail"] = rechecked["detail"]
+                    if rechecked["status"] == "up":
+                        item["diagnosis"] = "fixed"
+            else:
+                item["fix_attempted"] = False
+        items.append(item)
+
+    section = {"name": "local-pypi-servers", "summary": _summary(items), "items": items}
+    payload = {
+        "subject": _SUBJECT,
+        "sections": [section],
+        "fix_applied": fix,
+    }
+    return payload, (all_healthy or (fix and not fix_failed))
+
+
+def _summary(items: list[dict[str, object]]) -> str:
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[str(item["status"])] = counts.get(str(item["status"]), 0) + 1
+    return ", ".join(f"{n} {s}" for s, n in sorted(counts.items()))
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [f"# {payload['subject']}"]
+    for section in payload["sections"]:
+        lines.append("")
+        lines.append(f"## {section['name']}")
+        lines.append(f"summary: {section['summary']}")
+        lines.append("")
+        for item in section["items"]:
+            lines.append(f"  {item['name']:<12}  {item['status']:<7}  {item['diagnosis']}")
+            rem = item.get("remediation")
+            if isinstance(rem, list):
+                lines.append(f"      remediation: {' '.join(rem)}")
+            elif isinstance(rem, str):
+                lines.append(f"      remediation: {rem}")
+            if item.get("fix_attempted"):
+                ok = "ok" if item.get("fix_ok") else "FAILED"
+                lines.append(f"      fix: {ok} ({item.get('fix_detail')})")
+    if not payload["fix_applied"]:
+        lines.append("")
+        lines.append("(dry-run; pass --fix to apply remediations)")
+    return "\n".join(lines)
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    fix = bool(getattr(args, "fix", False))
+    json_mode = bool(getattr(args, "json", False))
+    payload, ok = _build_payload(fix=fix)
+
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        emit_result(_render_text(payload), json_mode=False)
+
+    if not ok:
+        # Only `--fix` failures escalate to a non-zero exit. Healthy-but-down
+        # in dry-run is a *report*, not an error: doctor's job is to surface,
+        # not enforce.
+        if fix:
+            emit_diagnostic("doctor: at least one --fix attempt failed")
+            raise AfiError(
+                code=EXIT_ENV_ERROR,
+                message="doctor: a --fix attempt failed",
+                remediation=("inspect the JSON payload's fix_detail field for the failing command"),
+            )
+    return EXIT_SUCCESS
 
 
 def register(sub: argparse._SubParsersAction) -> None:

--- a/agentpypi/cli/_commands/doctor.py
+++ b/agentpypi/cli/_commands/doctor.py
@@ -68,43 +68,52 @@ def _try_start(probe: Probe) -> tuple[bool, str]:
     return True, "started"
 
 
-def _build_payload(*, fix: bool) -> tuple[dict[str, object], bool]:
-    """Return (payload, all_healthy). Mutates state when ``fix`` is True."""
-    items: list[dict[str, object]] = []
-    all_healthy = True
-    fix_failed = False
-    for probe in PROBES:
-        result = probe_status(probe)
-        item = _diagnose(result, probe)
-        if item["status"] != "up":
-            all_healthy = False
-            if fix and probe.start_command:
-                ok, detail = _try_start(probe)
-                item["fix_attempted"] = True
-                item["fix_ok"] = ok
-                item["fix_detail"] = detail
-                if not ok:
-                    fix_failed = True
-                else:
-                    # Re-probe after start_command returned successfully.
-                    rechecked = probe_status(probe)
-                    item["status"] = rechecked["status"]
-                    item["url"] = rechecked["url"]
-                    if rechecked.get("detail"):
-                        item["detail"] = rechecked["detail"]
-                    if rechecked["status"] == "up":
-                        item["diagnosis"] = "fixed"
-            else:
-                item["fix_attempted"] = False
-        items.append(item)
+def _apply_fix(item: dict[str, object], probe: Probe) -> None:
+    """Run ``probe.start_command`` and re-probe, updating ``item`` in place."""
+    ok, detail = _try_start(probe)
+    item["fix_attempted"] = True
+    item["fix_ok"] = ok
+    item["fix_detail"] = detail
+    if not ok:
+        return
+    rechecked = probe_status(probe)
+    item["status"] = rechecked["status"]
+    item["url"] = rechecked["url"]
+    if rechecked.get("detail"):
+        item["detail"] = rechecked["detail"]
+    if rechecked["status"] == "up":
+        item["diagnosis"] = "fixed"
 
+
+def _process_probe(probe: Probe, *, fix: bool) -> dict[str, object]:
+    """Diagnose one probe; under ``--fix``, attempt remediation and re-probe."""
+    item = _diagnose(probe_status(probe), probe)
+    if item["status"] == "up":
+        return item
+    if fix and probe.start_command:
+        _apply_fix(item, probe)
+    else:
+        item["fix_attempted"] = False
+    return item
+
+
+def _build_payload(*, fix: bool) -> tuple[dict[str, object], bool]:
+    """Return (payload, ok). When ``fix`` is True, runs start_commands.
+
+    ``ok`` is computed from the **final post-fix probe statuses**, not from
+    the start_command return codes. This is the contract `learn` /
+    `explain doctor` document: a `--fix` attempt is only successful if the
+    server is `up` after the re-probe.
+    """
+    items = [_process_probe(probe, fix=fix) for probe in PROBES]
     section = {"name": "local-pypi-servers", "summary": _summary(items), "items": items}
     payload = {
         "subject": _SUBJECT,
         "sections": [section],
         "fix_applied": fix,
     }
-    return payload, (all_healthy or (fix and not fix_failed))
+    ok = all(item["status"] == "up" for item in items)
+    return payload, ok
 
 
 def _summary(items: list[dict[str, object]]) -> str:
@@ -147,17 +156,20 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     else:
         emit_result(_render_text(payload), json_mode=False)
 
-    if not ok:
-        # Only `--fix` failures escalate to a non-zero exit. Healthy-but-down
-        # in dry-run is a *report*, not an error: doctor's job is to surface,
-        # not enforce.
-        if fix:
-            emit_diagnostic("doctor: at least one --fix attempt failed")
-            raise AfiError(
-                code=EXIT_ENV_ERROR,
-                message="doctor: a --fix attempt failed",
-                remediation=("inspect the JSON payload's fix_detail field for the failing command"),
-            )
+    if fix and not ok:
+        # `--fix` did not bring every server up (either start_command itself
+        # failed, or it returned 0 but the post-fix re-probe still reports
+        # down/absent). Either case violates the documented contract.
+        # Dry-run never escalates: doctor's job is to surface, not enforce.
+        emit_diagnostic("doctor: at least one server is still not up after --fix")
+        raise AfiError(
+            code=EXIT_ENV_ERROR,
+            message="doctor: --fix did not bring every server up",
+            remediation=(
+                "inspect the JSON payload's fix_detail field (when present) and"
+                " each item's final status to identify the failing server"
+            ),
+        )
     return EXIT_SUCCESS
 
 

--- a/agentpypi/cli/_commands/doctor.py
+++ b/agentpypi/cli/_commands/doctor.py
@@ -1,0 +1,25 @@
+"""``agentpypi doctor`` — placeholder; real implementation lands in step 5."""
+
+from __future__ import annotations
+
+import argparse
+
+from agentpypi.cli._errors import EXIT_ENV_ERROR, AfiError
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:  # pragma: no cover - replaced in step 5
+    raise AfiError(
+        code=EXIT_ENV_ERROR,
+        message="doctor is not yet wired (step 3 placeholder)",
+        remediation="finish step 5 of the v0.0.1 plan",
+    )
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "doctor",
+        help="Probe + diagnose local PyPI servers; with --fix, start them.",
+    )
+    p.add_argument("--fix", action="store_true", help="Apply remediations (start servers).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_doctor)

--- a/agentpypi/cli/_commands/explain.py
+++ b/agentpypi/cli/_commands/explain.py
@@ -1,0 +1,38 @@
+"""``agentpypi explain <path>...`` — global markdown catalog lookup (stable-contract).
+
+``explain`` is global (not nested under a noun). It takes zero or more path
+tokens and resolves them via the catalog in :mod:`agentpypi.explain`.
+Unknown paths raise :class:`AfiError` with a remediation hint.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from agentpypi.cli._output import emit_result
+from agentpypi.explain import resolve
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    path = tuple(args.path) if args.path else ()
+    markdown = resolve(path)
+    json_mode = bool(getattr(args, "json", False))
+    if json_mode:
+        emit_result({"path": list(path), "markdown": markdown}, json_mode=True)
+    else:
+        emit_result(markdown, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "explain",
+        help="Print markdown docs for a noun/verb path (e.g. 'agentpypi explain overview').",
+    )
+    p.add_argument(
+        "path",
+        nargs="*",
+        help="Command path tokens; empty = root (same as 'agentpypi').",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_explain)

--- a/agentpypi/cli/_commands/learn.py
+++ b/agentpypi/cli/_commands/learn.py
@@ -15,6 +15,12 @@ import argparse
 from agentpypi import __version__
 from agentpypi.cli._output import emit_result
 
+# Roadmap milestones — kept as constants so `learn`'s `planned` array
+# can never drift out of sync with `agentpypi explain online` /
+# `... explain local`. Update together when a milestone slides.
+_M_ONLINE = "v0.1.0"
+_M_LOCAL = "v0.2.0"
+
 _TEXT = """\
 agentpypi — both ends of the Python distribution pipe for the AgentCulture mesh.
 
@@ -93,11 +99,11 @@ def _as_json_payload() -> dict[str, object]:
             },
         ],
         "planned": [
-            {"path": ["online", "status"], "milestone": "v0.1.0"},
-            {"path": ["online", "release"], "milestone": "v0.1.0"},
-            {"path": ["local", "serve"], "milestone": "v0.2.0"},
-            {"path": ["local", "upload"], "milestone": "v0.2.0"},
-            {"path": ["local", "mirror"], "milestone": "v0.2.0"},
+            {"path": ["online", "status"], "milestone": _M_ONLINE},
+            {"path": ["online", "release"], "milestone": _M_ONLINE},
+            {"path": ["local", "serve"], "milestone": _M_LOCAL},
+            {"path": ["local", "upload"], "milestone": _M_LOCAL},
+            {"path": ["local", "mirror"], "milestone": _M_LOCAL},
         ],
         "exit_codes": {
             "0": "success",

--- a/agentpypi/cli/_commands/learn.py
+++ b/agentpypi/cli/_commands/learn.py
@@ -1,0 +1,126 @@
+"""``agentpypi learn`` — the learnability affordance (shape-adapt).
+
+Self-teaching prompt for an agent that wants to use agentpypi. Generated
+from the same explain catalog so it can never describe a command that
+isn't registered.
+
+Must satisfy the agent-first rubric: >=200 chars and mention purpose,
+command map, exit codes, --json, explain.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from agentpypi import __version__
+from agentpypi.cli._output import emit_result
+
+_TEXT = """\
+agentpypi — both ends of the Python distribution pipe for the AgentCulture mesh.
+
+Purpose
+-------
+Manage local and online PyPI surfaces for AgentCulture siblings. v0.0.1
+ships local-host introspection and the agent-affordance verbs; the
+`online` (sibling release orchestration) and `local` (mesh-resident
+private index) noun groups are planned for later milestones.
+
+Commands
+--------
+  agentpypi learn              Print this self-teaching prompt. Supports --json.
+  agentpypi explain <path>...  Print markdown docs for any noun/verb path.
+                               Supports --json.
+  agentpypi overview           Probe localhost for known PyPI server flavors
+                               (devpi:3141, pypiserver:8080); report up/down.
+                               Read-only. Supports --json.
+  agentpypi doctor [--fix]     Same probes plus diagnoses; with --fix, start
+                               configured servers. Default is dry-run.
+                               Supports --json.
+  agentpypi whoami             Auth/env probe — which PyPI / TestPyPI /
+                               local index is the active environment pointing
+                               at? Supports --json.
+
+Planned (not yet registered)
+----------------------------
+  agentpypi online status SIBLING       (v0.1.0)
+  agentpypi online release SIBLING      (v0.1.0)
+  agentpypi local serve | upload | mirror (v0.2.0)
+
+Use `agentpypi explain online` or `agentpypi explain local` to read the
+roadmap entry for either noun.
+
+Machine-readable output
+-----------------------
+Every command supports --json. Errors in JSON mode emit
+{"code", "message", "remediation"} to stderr. Stdout and stderr are never
+mixed.
+
+Exit-code policy
+----------------
+  0 success
+  1 user-input error (bad flag, bad path, missing arg)
+  2 environment / setup error
+  3+ reserved
+
+More detail
+-----------
+  agentpypi explain agentpypi
+"""
+
+
+def _as_json_payload() -> dict[str, object]:
+    return {
+        "tool": "agentpypi",
+        "version": __version__,
+        "purpose": (
+            "Manage local and online PyPI surfaces for AgentCulture siblings; "
+            "v0.0.1 ships local-host introspection and agent-affordance verbs."
+        ),
+        "commands": [
+            {"path": ["learn"], "summary": "Self-teaching prompt."},
+            {"path": ["explain"], "summary": "Markdown docs by path."},
+            {
+                "path": ["overview"],
+                "summary": "Probe localhost for PyPI server processes; report up/down.",
+            },
+            {
+                "path": ["doctor"],
+                "summary": ("Probe + diagnose local PyPI servers; with --fix, start them."),
+            },
+            {
+                "path": ["whoami"],
+                "summary": "Report configured PyPI / TestPyPI / local index.",
+            },
+        ],
+        "planned": [
+            {"path": ["online", "status"], "milestone": "v0.1.0"},
+            {"path": ["online", "release"], "milestone": "v0.1.0"},
+            {"path": ["local", "serve"], "milestone": "v0.2.0"},
+            {"path": ["local", "upload"], "milestone": "v0.2.0"},
+            {"path": ["local", "mirror"], "milestone": "v0.2.0"},
+        ],
+        "exit_codes": {
+            "0": "success",
+            "1": "user-input error",
+            "2": "environment/setup error",
+        },
+        "json_support": True,
+        "explain_pointer": "agentpypi explain <path>",
+    }
+
+
+def cmd_learn(args: argparse.Namespace) -> int:
+    if getattr(args, "json", False):
+        emit_result(_as_json_payload(), json_mode=True)
+    else:
+        emit_result(_TEXT, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "learn",
+        help="Print a structured self-teaching prompt for agent consumers.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_learn)

--- a/agentpypi/cli/_commands/overview.py
+++ b/agentpypi/cli/_commands/overview.py
@@ -1,24 +1,100 @@
-"""``agentpypi overview`` — placeholder; real implementation lands in step 5."""
+"""``agentpypi overview`` — probe localhost for known PyPI server flavors.
+
+Read-only descriptive verb. Iterates :data:`agentpypi._probes.PROBES` and
+emits a structured report (one section per scanned target).
+
+Surface contract (AFI rubric, bundle 6):
+
+* ``agentpypi overview`` — exit 0, non-empty stdout, full localhost probe.
+* ``agentpypi overview --json`` — exit 0, ``{"subject", "sections"}`` shape.
+* ``agentpypi overview <unknown-target>`` — exit 0, zero-target report,
+  warning on stderr (the descriptive verb falls back gracefully; hard
+  failure is ``verify``'s job).
+
+v0.0.1 recognises no targets — a positional argument always degrades to
+the zero-target report. Future milestones may interpret targets as
+``host[:port]`` or probe-name selectors.
+"""
 
 from __future__ import annotations
 
 import argparse
 
-from agentpypi.cli._errors import EXIT_ENV_ERROR, AfiError
+from agentpypi._probes import PROBES, probe_status
+from agentpypi._probes._runtime import ProbeResult
+from agentpypi.cli._output import emit_diagnostic, emit_result
+
+_SUBJECT = "agentpypi overview"
 
 
-def cmd_overview(args: argparse.Namespace) -> int:  # pragma: no cover - replaced in step 5
-    raise AfiError(
-        code=EXIT_ENV_ERROR,
-        message="overview is not yet wired (step 3 placeholder)",
-        remediation="finish step 5 of the v0.0.1 plan",
-    )
+def _probe_section() -> dict[str, object]:
+    items: list[ProbeResult] = [probe_status(p) for p in PROBES]
+    counts = {"up": 0, "down": 0, "absent": 0}
+    for item in items:
+        counts[item["status"]] = counts.get(item["status"], 0) + 1
+    summary = ", ".join(f"{n} {s}" for s, n in counts.items())
+    return {
+        "name": "local-pypi-servers",
+        "summary": summary,
+        "items": list(items),
+    }
+
+
+def _build_payload(target: str | None) -> dict[str, object]:
+    if target is None:
+        return {"subject": _SUBJECT, "sections": [_probe_section()]}
+    return {
+        "subject": _SUBJECT,
+        "sections": [],
+        "target": target,
+        "note": (
+            f"target {target!r} not recognised at v0.0.1; emitting zero-target "
+            "report (use `agentpypi overview` with no arg for the default scan)"
+        ),
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [f"# {payload['subject']}"]
+    sections = payload["sections"]
+    if not sections:
+        lines.append("")
+        lines.append("(no targets scanned)")
+        return "\n".join(lines)
+    for section in sections:
+        lines.append("")
+        lines.append(f"## {section['name']}")
+        lines.append(f"summary: {section['summary']}")
+        lines.append("")
+        for item in section.get("items", []):
+            detail = f" ({item['detail']})" if item.get("detail") else ""
+            lines.append(f"  {item['name']:<12}  {item['status']:<7}  {item['url']}{detail}")
+    return "\n".join(lines)
+
+
+def cmd_overview(args: argparse.Namespace) -> int:
+    target = args.target if args.target else None
+    payload = _build_payload(target)
+    json_mode = bool(getattr(args, "json", False))
+    if target is not None:
+        emit_diagnostic(f"warning: {payload['note']}")
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        emit_result(_render_text(payload), json_mode=False)
+    return 0
 
 
 def register(sub: argparse._SubParsersAction) -> None:
     p = sub.add_parser(
         "overview",
         help="Probe localhost for known PyPI server flavors; report up/down.",
+    )
+    p.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        help="(reserved) future selector for a custom host or probe; ignored at v0.0.1.",
     )
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_overview)

--- a/agentpypi/cli/_commands/overview.py
+++ b/agentpypi/cli/_commands/overview.py
@@ -1,0 +1,24 @@
+"""``agentpypi overview`` — placeholder; real implementation lands in step 5."""
+
+from __future__ import annotations
+
+import argparse
+
+from agentpypi.cli._errors import EXIT_ENV_ERROR, AfiError
+
+
+def cmd_overview(args: argparse.Namespace) -> int:  # pragma: no cover - replaced in step 5
+    raise AfiError(
+        code=EXIT_ENV_ERROR,
+        message="overview is not yet wired (step 3 placeholder)",
+        remediation="finish step 5 of the v0.0.1 plan",
+    )
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "overview",
+        help="Probe localhost for known PyPI server flavors; report up/down.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_overview)

--- a/agentpypi/cli/_commands/whoami.py
+++ b/agentpypi/cli/_commands/whoami.py
@@ -1,18 +1,127 @@
-"""``agentpypi whoami`` — placeholder; real implementation lands in step 5."""
+"""``agentpypi whoami`` — auth/env probe.
+
+Reports which PyPI / TestPyPI / local index the current shell environment
+is pointing at, and which Python virtualenv is active. Read-only.
+
+Sources inspected (in priority order):
+
+* ``$PIP_INDEX_URL`` / ``$PIP_EXTRA_INDEX_URL``
+* ``$UV_INDEX_URL`` / ``$UV_EXTRA_INDEX_URL``
+* ``~/.config/pip/pip.conf`` ``[global]`` ``index-url`` / ``extra-index-url``
+* ``$VIRTUAL_ENV`` and ``$UV_PROJECT_ENVIRONMENT`` (active env locator)
+"""
 
 from __future__ import annotations
 
 import argparse
+import configparser
+import os
+from pathlib import Path
 
-from agentpypi.cli._errors import EXIT_ENV_ERROR, AfiError
+from agentpypi._probes import PROBES, probe_status
+from agentpypi.cli._output import emit_result
+
+_SUBJECT = "agentpypi whoami"
+
+_DEFAULT_PYPI = "https://pypi.org/simple"
+_DEFAULT_TESTPYPI = "https://test.pypi.org/simple"
 
 
-def cmd_whoami(args: argparse.Namespace) -> int:  # pragma: no cover - replaced in step 5
-    raise AfiError(
-        code=EXIT_ENV_ERROR,
-        message="whoami is not yet wired (step 3 placeholder)",
-        remediation="finish step 5 of the v0.0.1 plan",
+def _read_pip_conf() -> dict[str, str]:
+    """Return ``{global.index-url, global.extra-index-url, ...}`` from pip.conf, or ``{}``."""
+    candidates = [
+        Path.home() / ".config" / "pip" / "pip.conf",
+        Path.home() / ".pip" / "pip.conf",  # legacy on some distros
+    ]
+    parser = configparser.ConfigParser()
+    for path in candidates:
+        if path.exists():
+            try:
+                parser.read(path)
+            except configparser.Error:
+                continue
+            break
+    out: dict[str, str] = {}
+    if parser.has_section("global"):
+        for key in ("index-url", "extra-index-url"):
+            if parser.has_option("global", key):
+                out[key] = parser.get("global", key)
+    return out
+
+
+def _resolved_index() -> dict[str, object]:
+    pip_conf = _read_pip_conf()
+    return {
+        "pip": {
+            "index_url_env": os.environ.get("PIP_INDEX_URL"),
+            "extra_index_url_env": os.environ.get("PIP_EXTRA_INDEX_URL"),
+            "index_url_conf": pip_conf.get("index-url"),
+            "extra_index_url_conf": pip_conf.get("extra-index-url"),
+        },
+        "uv": {
+            "index_url_env": os.environ.get("UV_INDEX_URL"),
+            "extra_index_url_env": os.environ.get("UV_EXTRA_INDEX_URL"),
+        },
+        "active_env": {
+            "VIRTUAL_ENV": os.environ.get("VIRTUAL_ENV"),
+            "UV_PROJECT_ENVIRONMENT": os.environ.get("UV_PROJECT_ENVIRONMENT"),
+        },
+    }
+
+
+def _effective_default(idx: dict[str, dict[str, object]]) -> str:
+    pip = idx["pip"]
+    uv = idx["uv"]
+    return (
+        pip.get("index_url_env")
+        or uv.get("index_url_env")
+        or pip.get("index_url_conf")
+        or _DEFAULT_PYPI
     )
+
+
+def _local_indexes_seen() -> list[dict[str, object]]:
+    """Cross-reference: which configured local PyPI servers are *also* up right now?"""
+    return [dict(probe_status(p)) for p in PROBES]
+
+
+def _build_payload() -> dict[str, object]:
+    indexes = _resolved_index()
+    return {
+        "subject": _SUBJECT,
+        "sections": [
+            {
+                "name": "indexes",
+                "summary": f"effective default: {_effective_default(indexes)}",
+                "items": [indexes],
+            },
+            {
+                "name": "local-pypi-servers",
+                "summary": "cross-reference with `overview` probes",
+                "items": _local_indexes_seen(),
+            },
+        ],
+        "defaults": {"pypi": _DEFAULT_PYPI, "testpypi": _DEFAULT_TESTPYPI},
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [f"# {payload['subject']}"]
+    for section in payload["sections"]:
+        lines.append("")
+        lines.append(f"## {section['name']}")
+        lines.append(f"summary: {section['summary']}")
+    return "\n".join(lines)
+
+
+def cmd_whoami(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    payload = _build_payload()
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        emit_result(_render_text(payload), json_mode=False)
+    return 0
 
 
 def register(sub: argparse._SubParsersAction) -> None:

--- a/agentpypi/cli/_commands/whoami.py
+++ b/agentpypi/cli/_commands/whoami.py
@@ -28,12 +28,18 @@ _DEFAULT_TESTPYPI = "https://test.pypi.org/simple"
 
 
 def _read_pip_conf() -> dict[str, str]:
-    """Return ``{global.index-url, global.extra-index-url, ...}`` from pip.conf, or ``{}``."""
+    """Return ``{global.index-url, global.extra-index-url, ...}`` from pip.conf, or ``{}``.
+
+    ``interpolation=None`` (RawConfigParser semantics) is required because
+    pip.conf URLs commonly contain percent-encoded characters in credentials
+    (e.g. ``%3A`` for ``:``); the default ``BasicInterpolation`` raises
+    ``InterpolationSyntaxError`` on bare ``%``.
+    """
     candidates = [
         Path.home() / ".config" / "pip" / "pip.conf",
         Path.home() / ".pip" / "pip.conf",  # legacy on some distros
     ]
-    parser = configparser.ConfigParser()
+    parser = configparser.ConfigParser(interpolation=None)
     for path in candidates:
         if path.exists():
             try:
@@ -44,8 +50,15 @@ def _read_pip_conf() -> dict[str, str]:
     out: dict[str, str] = {}
     if parser.has_section("global"):
         for key in ("index-url", "extra-index-url"):
-            if parser.has_option("global", key):
-                out[key] = parser.get("global", key)
+            try:
+                if parser.has_option("global", key):
+                    out[key] = parser.get("global", key)
+            except configparser.Error:
+                # Defensive: any residual parser error here (interpolation,
+                # malformed value, encoding) is treated as "value not present"
+                # rather than crashing whoami. The verb is read-only and
+                # advisory; degrading gracefully is the right call.
+                continue
     return out
 
 

--- a/agentpypi/cli/_commands/whoami.py
+++ b/agentpypi/cli/_commands/whoami.py
@@ -1,0 +1,24 @@
+"""``agentpypi whoami`` — placeholder; real implementation lands in step 5."""
+
+from __future__ import annotations
+
+import argparse
+
+from agentpypi.cli._errors import EXIT_ENV_ERROR, AfiError
+
+
+def cmd_whoami(args: argparse.Namespace) -> int:  # pragma: no cover - replaced in step 5
+    raise AfiError(
+        code=EXIT_ENV_ERROR,
+        message="whoami is not yet wired (step 3 placeholder)",
+        remediation="finish step 5 of the v0.0.1 plan",
+    )
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "whoami",
+        help="Report configured PyPI / TestPyPI / local index from pip/uv config.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_whoami)

--- a/agentpypi/cli/_errors.py
+++ b/agentpypi/cli/_errors.py
@@ -1,0 +1,41 @@
+"""AfiError and exit-code policy (stable-contract — copy verbatim).
+
+Every failure inside agentpypi raises :class:`AfiError`. The CLI entry
+point catches it and exits with :attr:`AfiError.code`. Guarantees:
+
+* no Python traceback leaks to stderr;
+* every error has shape ``{code, message, remediation}``;
+* the exit-code policy is centralised.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Exit-code policy (documented in ``agentpypi learn`` output).
+# 0  = success
+# 1  = user-input error (bad flag, bad path, missing arg)
+# 2  = environment / setup error
+# 3+ = reserved
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 1
+EXIT_ENV_ERROR = 2
+
+
+@dataclass
+class AfiError(Exception):
+    """Structured error with a remediation hint for agents."""
+
+    code: int
+    message: str
+    remediation: str = ""
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "remediation": self.remediation,
+        }

--- a/agentpypi/cli/_output.py
+++ b/agentpypi/cli/_output.py
@@ -1,0 +1,53 @@
+"""stdout / stderr helpers with a strict split (stable-contract).
+
+Rule: **results go to stdout, diagnostics and errors go to stderr.** Agents
+parsing output can rely on this invariant. JSON mode routes structured
+payloads to the same streams — never mixes them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, TextIO
+
+from agentpypi.cli._errors import AfiError
+
+
+def emit_result(data: Any, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write a command result to stdout (or ``stream``)."""
+    s = stream if stream is not None else sys.stdout
+    if json_mode:
+        json.dump(data, s, ensure_ascii=False)
+        s.write("\n")
+        return
+    text = data if isinstance(data, str) else str(data)
+    s.write(text)
+    if not text.endswith("\n"):
+        s.write("\n")
+
+
+def emit_error(err: AfiError, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write an :class:`AfiError` to stderr.
+
+    Text mode renders as two lines when a remediation is present::
+
+        error: <message>
+        hint: <remediation>
+
+    The ``hint:`` prefix is required by the agent-first error rubric.
+    """
+    s = stream if stream is not None else sys.stderr
+    if json_mode:
+        json.dump(err.to_dict(), s, ensure_ascii=False)
+        s.write("\n")
+        return
+    s.write(f"error: {err.message}\n")
+    if err.remediation:
+        s.write(f"hint: {err.remediation}\n")
+
+
+def emit_diagnostic(message: str, *, stream: TextIO | None = None) -> None:
+    """Write a human diagnostic (progress, summary) to stderr."""
+    s = stream if stream is not None else sys.stderr
+    s.write(message if message.endswith("\n") else message + "\n")

--- a/agentpypi/explain/__init__.py
+++ b/agentpypi/explain/__init__.py
@@ -1,0 +1,24 @@
+"""Explain catalog — markdown keyed by command-path tuples (stable-contract).
+
+Every noun/verb registered in the CLI should have a catalog entry.
+"""
+
+from __future__ import annotations
+
+from agentpypi.cli._errors import EXIT_USER_ERROR, AfiError
+from agentpypi.explain.catalog import ENTRIES
+
+
+def resolve(path: tuple[str, ...]) -> str:
+    if path in ENTRIES:
+        return ENTRIES[path]
+    display = " ".join(path) if path else "<root>"
+    raise AfiError(
+        code=EXIT_USER_ERROR,
+        message=f"no explain entry for: {display}",
+        remediation="list known entries with: agentpypi explain agentpypi",
+    )
+
+
+def known_paths() -> list[tuple[str, ...]]:
+    return list(ENTRIES.keys())

--- a/agentpypi/explain/catalog.py
+++ b/agentpypi/explain/catalog.py
@@ -1,0 +1,219 @@
+"""Markdown catalog for ``agentpypi explain <path>``.
+
+Each entry is verbatim markdown. Keys are command-path tuples. The empty
+tuple and ``("agentpypi",)`` both resolve to the root entry.
+
+Keep bodies self-contained: an agent reading one entry should get enough
+context without chaining reads.
+"""
+
+from __future__ import annotations
+
+_ROOT = """\
+# agentpypi
+
+agentpypi manages both ends of the Python distribution pipe for the
+AgentCulture mesh: an in-mesh local PyPI index for intra-org wheels, and
+release orchestration for AgentCulture siblings against PyPI / TestPyPI.
+
+v0.0.1 ships local-host introspection plus the agent-affordance verbs.
+The `online` and `local` noun groups are planned for later milestones.
+
+## Verbs
+
+- `agentpypi learn` — structured self-teaching prompt.
+- `agentpypi explain <path>` — markdown docs for any noun/verb.
+- `agentpypi overview` — probe localhost for known PyPI server flavors.
+- `agentpypi doctor [--fix]` — probe + diagnose; `--fix` starts servers.
+- `agentpypi whoami` — auth/env probe; reports configured indexes.
+
+## Planned
+
+- `agentpypi online status SIBLING` — v0.1.0
+- `agentpypi online release SIBLING [--apply]` — v0.1.0
+- `agentpypi local serve | upload | mirror` — v0.2.0
+
+## Exit-code policy
+
+- `0` success
+- `1` user-input error
+- `2` environment / setup error
+- `3+` reserved
+
+## See also
+
+- `agentpypi explain learn`
+- `agentpypi explain explain`
+- `agentpypi explain overview`
+- `agentpypi explain doctor`
+- `agentpypi explain whoami`
+- `agentpypi explain online`
+- `agentpypi explain local`
+"""
+
+_LEARN = """\
+# agentpypi learn
+
+Prints a structured self-teaching prompt covering agentpypi's purpose,
+command map, exit-code policy, `--json` support, and `explain` pointer.
+
+## Usage
+
+    agentpypi learn
+    agentpypi learn --json
+
+The JSON payload includes a `planned` array enumerating verbs that are
+catalog-known but not yet registered as argparse subcommands. An agent
+consuming `learn --json` can therefore reason about the roadmap without
+chasing a separate doc.
+"""
+
+_EXPLAIN = """\
+# agentpypi explain <path>
+
+Prints markdown documentation for any noun/verb path. Unlike `--help`
+(terse, positional), `explain` is global and addressable by path.
+
+## Usage
+
+    agentpypi explain agentpypi
+    agentpypi explain learn
+    agentpypi explain overview
+    agentpypi explain --json overview
+
+Unknown paths exit `1` with `error: no explain entry for: <path>` and a
+`hint:` line listing the discovery command.
+"""
+
+_OVERVIEW = """\
+# agentpypi overview
+
+Probes `127.0.0.1` for known PyPI server flavors and reports up/down/absent.
+
+Recognised flavors:
+
+- `devpi` on port `3141` (`/+api`)
+- `pypiserver` on port `8080` (`/`)
+
+Read-only — no mutation flags. Use `agentpypi doctor --fix` to start
+servers.
+
+## Usage
+
+    agentpypi overview
+    agentpypi overview --json
+
+JSON payload:
+
+    {
+      "servers": [
+        {"name": "devpi", "port": 3141, "url": "...", "status": "up|down|absent",
+         "version": "..."}
+      ]
+    }
+
+## Exit codes
+
+- `0` always (probe failures are reported as `down`/`absent`, not exit codes).
+"""
+
+_DOCTOR = """\
+# agentpypi doctor
+
+Same probes as `overview`, plus per-server diagnoses (`port in use`,
+`unexpected response`, `server not installed`). Default is dry-run: prints
+the would-be remediation command. With `--fix`, runs each server's
+configured `start_command`.
+
+## Usage
+
+    agentpypi doctor                # dry-run; no mutations
+    agentpypi doctor --fix          # start any server reporting `down`
+    agentpypi doctor --json
+    agentpypi doctor --fix --json
+
+## Exit codes
+
+- `0` all servers healthy (or `--fix` brought every reporting `down` server up).
+- `2` a `--fix` attempt failed (e.g. `start_command` not on `$PATH`).
+"""
+
+_WHOAMI = """\
+# agentpypi whoami
+
+Auth / environment probe. Reports which PyPI, TestPyPI, and local index
+the current shell environment is pointing at. Cross-references the same
+probe machinery `overview` uses to flag local indexes that are
+*configured* but *down*.
+
+## Sources inspected
+
+- `$PIP_INDEX_URL`, `$PIP_EXTRA_INDEX_URL`
+- `$UV_INDEX_URL`, `$UV_EXTRA_INDEX_URL`
+- `~/.config/pip/pip.conf` `[global] index-url` / `extra-index-url`
+- Active virtualenv (`$VIRTUAL_ENV`) and uv project (`$UV_PROJECT_ENVIRONMENT`)
+- Local probes (cross-reference with `overview`)
+
+## Usage
+
+    agentpypi whoami
+    agentpypi whoami --json
+
+Read-only.
+"""
+
+_ONLINE = """\
+# agentpypi online (planned, v0.1.0)
+
+Release orchestration for AgentCulture siblings (`afi-cli`, `cfafi`,
+`ghafi`, `shushu`, `steward`, `zehut`, …). Reads PyPI + TestPyPI state,
+diffs against `CHANGELOG.md` / `main`, and triggers each sibling's
+`publish.yml` workflow over OIDC Trusted Publishing.
+
+This noun is **not yet registered** in v0.0.1. The catalog entry exists so
+agents querying the roadmap get an honest answer.
+
+## Planned verbs
+
+- `agentpypi online status SIBLING` — read-only diff: PyPI vs CHANGELOG vs
+  main vs latest tag.
+- `agentpypi online release SIBLING [--apply]` — dry-run by default;
+  `--apply` triggers the sibling's `publish.yml`.
+
+Track at https://github.com/agentculture/agentpypi/milestones — milestone
+v0.1.0.
+"""
+
+_LOCAL = """\
+# agentpypi local (planned, v0.2.0)
+
+Run / mirror / publish to an in-mesh PyPI index so AgentCulture agents can
+exchange wheels without leaving the org's trust boundary.
+
+This noun is **not yet registered** in v0.0.1. v0.0.1 ships `overview`
+and `doctor` instead, which probe localhost for PyPI server flavors but
+don't yet manage one.
+
+## Planned verbs
+
+- `agentpypi local serve` — foreground PEP 503 simple index.
+- `agentpypi local upload PATH [--apply]` — publish a wheel/sdist.
+- `agentpypi local mirror PACKAGE [--apply]` — snapshot a public package.
+- `agentpypi local list` — show locally hosted distributions.
+
+Track at https://github.com/agentculture/agentpypi/milestones — milestone
+v0.2.0.
+"""
+
+
+ENTRIES: dict[tuple[str, ...], str] = {
+    (): _ROOT,
+    ("agentpypi",): _ROOT,
+    ("learn",): _LEARN,
+    ("explain",): _EXPLAIN,
+    ("overview",): _OVERVIEW,
+    ("doctor",): _DOCTOR,
+    ("whoami",): _WHOAMI,
+    ("online",): _ONLINE,
+    ("local",): _LOCAL,
+}

--- a/culture.yaml
+++ b/culture.yaml
@@ -1,0 +1,2 @@
+suffix: agentpypi
+backend: claude

--- a/docs/afi-setup.md
+++ b/docs/afi-setup.md
@@ -1,0 +1,134 @@
+# AFI setup
+
+`afi-cli` is the **Agent First Interface** scaffolder. It emits the
+canonical agent-first CLI tree (errors module, output module, `learn`,
+`explain`, `whoami`, tests) so siblings don't re-derive the rubric. This
+repo is built *from* that scaffold — not by hand.
+
+Sibling location: `../afi-cli`. Reference rubric:
+[`docs/rubric.md`](https://github.com/agentculture/afi-cli/blob/main/docs/rubric.md).
+
+## Install
+
+```bash
+uv tool install afi-cli
+afi --version
+```
+
+Or use the workspace checkout directly (useful if you're tracking
+unreleased afi-cli changes):
+
+```bash
+uv pip install -e ../afi-cli
+afi --version
+```
+
+## Cite the reference tree
+
+From the agentpypi repo root:
+
+```bash
+afi cli cite .
+```
+
+What this does (per `../afi-cli/README.md`):
+
+> `afi cli cite` writes only under `.afi/` plus one line in `.gitignore`
+> — it never modifies the rest of the target project. The emitted tree
+> has literal `{{project_name}}`, `{{slug}}`, `{{module}}` tokens; an
+> agent reads the accompanying `AGENT.md` and applies the pattern to
+> the host project on its own terms.
+
+Output lands in `.afi/reference/python-cli/`. The append to `.gitignore`
+is idempotent — safe to re-run when afi-cli evolves.
+
+## Read the emitted `AGENT.md`
+
+`.afi/reference/python-cli/AGENT.md` is the canonical instruction set —
+*it*, not this file, tells you what to do with the scaffold. Read it
+end-to-end before applying anything.
+
+This file describes the *intent* of the apply step; `AGENT.md` is the
+authority on the mechanics.
+
+## Apply: stable-contract vs shape-adapt
+
+The reference tree splits files into two buckets.
+
+### Stable-contract — copy verbatim into `agentpypi/cli/`
+
+These encode the rubric and shouldn't be rewritten. Substitute only the
+tokens (`{{project_name}}` → `agentpypi`, `{{slug}}` → `agentpypi`,
+`{{module}}` → `agentpypi`):
+
+- `_errors.py` — `AgentpypiError` + exit-code constants. Exit-code policy
+  follows the afi rubric (`0` success / `1` user error / `2` env error).
+  Per `../CLAUDE.md`'s "CLI shape", the trio is non-negotiable.
+- `_output.py` — stdout/stderr split, `--json` plumbing.
+- `explain.py` — markdown rendering for any noun/verb path. Generated
+  from a catalog so it can never lie about what the CLI actually exposes.
+
+### Shape-adapt — model and rewrite
+
+These show the *structure*; you rewrite them to fit agentpypi's nouns
+(`online`, `local`) and verb set:
+
+- `__init__.py` — `__version__` via `importlib.metadata.version("agentpypi")`.
+  No literal version string anywhere else (per `../CLAUDE.md` Version
+  discipline).
+- `__main__.py` — argparse entry that routes `python -m agentpypi`.
+- `learn.py` — generates self-teaching prompt from the explain catalog.
+- `whoami.py` — smallest auth probe. For agentpypi: report which
+  PyPI / TestPyPI / local index the current env is pointed at.
+- `_commands/` — one module per noun. Stub `online.py` and `local.py`
+  with `NotImplementedError` raised through the `AgentpypiError`
+  sentinel until the noun design lands (per `../CLAUDE.md` "Do not
+  implement yet" — verb sets are not frozen).
+- `tests/test_cli_*.py` — model the assertion shape, but adapt to
+  agentpypi's verbs. The non-negotiable smoke tests at v0.0.1
+  (per `../CLAUDE.md` Roadmap) are `--version` and `learn --json`.
+
+## Wire the entry point
+
+In `pyproject.toml` (see `./quality-pipeline.md` for the full template):
+
+```toml
+[project.scripts]
+agentpypi = "agentpypi.cli:main"
+```
+
+Smoke check:
+
+```bash
+uv run agentpypi --version
+uv run agentpypi learn --json | head
+uv run python -m agentpypi --version
+```
+
+All three should succeed.
+
+## Verify
+
+`afi cli verify` is the same rubric the upstream uses on itself:
+
+```bash
+afi cli verify .              # human-readable report
+afi cli verify . --json       # structured for tooling
+afi cli verify . --strict     # treat warnings as failures
+```
+
+Fix every failing check before opening the first PR. Per
+`../afi-cli/README.md`:
+
+> `afi cli verify` is a hybrid auditor: static checks for repo structure
+> (`pyproject.toml`, `tests/`) and black-box subprocess probes for
+> behavior (`learn`, `--json`, error discipline, `explain`). Every
+> failure includes a concrete `remediation` pointer.
+
+## Re-citing later
+
+`afi cli cite .` is idempotent. When `afi-cli` ships a new reference
+tree (rubric tightened, new bundle added), re-cite, re-read the diff
+in `.afi/reference/python-cli/`, and re-apply the deltas. The applied
+copies under `agentpypi/cli/` don't auto-update — that's the
+"cite-don't-import" tradeoff.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,102 @@
+# Onboarding runbook
+
+Welcome, agentpypi.
+
+This folder is your **order-of-operations** for becoming a well-formed
+AgentCulture sibling. The *spec* lives in `../CLAUDE.md` (the twelve required
+artifacts, the CLI shape, the python floor, the do-not-implement-yet line);
+this runbook tells you *how to acquire each piece in the right order*.
+
+Read `../CLAUDE.md` first, then come back here. Nothing in this folder
+overrides `CLAUDE.md` — when they disagree, `CLAUDE.md` wins and the doc
+here is wrong (open a fix-up PR).
+
+The canonical artifact list is intentionally **not** repeated here. See
+`./sibling-pattern-pointer.md` for the pointer to the source of truth in
+`../steward/docs/sibling-pattern.md`.
+
+## Sequence
+
+### Step 0 — Read the spec
+
+- Read `../CLAUDE.md` end-to-end. Twelve required artifacts. CLI noun/verb
+  shape. Python floor (≥3.12). The "do not implement yet" line.
+- Read `../README.md` for the agent-facing pitch and intended verb sketches.
+- Read `./sibling-pattern-pointer.md` to learn how `steward doctor`
+  audits siblings against the canonical pattern.
+
+### Step 1 — Skills setup
+
+Vendor the canonical skills from steward (`version-bump`, `pr-review`).
+Create `.claude/skills.local.yaml.example`. Stand up
+`docs/skill-sources.md` so future re-syncs are deterministic.
+
+→ See `./skills-setup.md`.
+
+### Step 2 — AFI scaffold
+
+`afi-cli` is the agent-first CLI scaffolder this repo is built from. Run
+`afi cli cite .`, read the emitted `AGENT.md`, and apply the
+stable-contract / shape-adapt split. This produces the package layout
+(`agentpypi/`, `agentpypi/cli/`, `tests/`) that `CLAUDE.md` requires.
+
+→ See `./afi-setup.md`.
+
+### Step 3 — Quality pipeline
+
+Lay down `pyproject.toml`, `.flake8`, `.markdownlint-cli2.yaml`,
+`CHANGELOG.md`, and the two GitHub workflows
+(`tests.yml`, `publish.yml`). Wire **before** the first real PR — the
+`version-check` job blocks merge if the version doesn't move, and the
+TestPyPI publish step needs Trusted Publishing in place.
+
+→ See `./quality-pipeline.md`.
+
+### Step 4 — Diagnose against the corpus
+
+From the steward checkout (sibling-relative path):
+
+```bash
+cd ../steward
+uv run steward doctor --scope self ../agentpypi
+```
+
+Exit 0 with no findings means portability + skills-convention are clean.
+Fix any finding before opening the first PR.
+
+Once `culture.yaml` lands (v0.0.1 in the roadmap), also run:
+
+```bash
+uv run steward doctor --scope siblings
+```
+
+This regenerates `../steward/docs/perfect-patient.md` and writes
+per-target feedback to `docs/steward/steward-suggestions.md` *inside this
+repo*. Treat that file as advisory — corpus mode never blocks.
+
+### Step 5 — Hold
+
+`CLAUDE.md` says: do **not** invent verbs, exit-code tables, or threat
+models that aren't reflected there yet. The first implementation PR
+brainstorms the noun set with `superpowers:brainstorming` before any
+code lands. This runbook scaffolds the *frame*; Ori signals the
+implementation kick-off.
+
+What you may do without permission: tighten `CLAUDE.md`, `README.md`, or
+any file in this `docs/` folder when you spot drift from the linked
+sibling patterns.
+
+## What "done" looks like for onboarding
+
+- `.claude/skills/version-bump/` and `.claude/skills/pr-review/` exist
+  with `SKILL.md` + `scripts/`.
+- `.claude/skills.local.yaml.example` is committed; `.gitignore` lists
+  `.claude/skills.local.yaml`.
+- `pyproject.toml`, `CHANGELOG.md`, `.flake8`, `.markdownlint-cli2.yaml`
+  exist.
+- `.github/workflows/tests.yml` and `publish.yml` exist.
+- `agentpypi/`, `agentpypi/cli/`, `tests/` exist with the afi scaffold
+  applied.
+- `steward doctor --scope self ../agentpypi` is clean.
+
+After that, wait for kick-off.

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -1,0 +1,399 @@
+# Quality pipeline
+
+Wire this **before** the first PR. The `version-check` job blocks merges
+when `pyproject.toml`'s version equals `main`'s, and the `publish.yml`
+TestPyPI step needs Trusted Publishing already configured by the time a
+PR opens.
+
+The shape below mirrors `../steward/` (the canonical Culture-sibling
+template) with adjustments for agentpypi's own opinions in
+`../CLAUDE.md` (pre-commit hooks; `flake8-bandit` + `flake8-bugbear`;
+`pylint --errors-only`).
+
+## 1. `pyproject.toml`
+
+Paste-ready template. Adjust only the marked lines and the dev-dep set
+if `../CLAUDE.md` later tightens the toolchain.
+
+```toml
+[project]
+name = "agentpypi"
+version = "0.0.1"
+description = "agentpypi — both ends of the Python distribution pipe for the AgentCulture mesh."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [{name = "AgentCulture"}]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    # Keep zero runtime deps where possible. Add only when a verb needs
+    # something the stdlib can't do.
+]
+
+[project.urls]
+Homepage = "https://github.com/agentculture/agentpypi"
+Issues = "https://github.com/agentculture/agentpypi/issues"
+
+[project.scripts]
+agentpypi = "agentpypi.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["agentpypi"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.0",
+    "pytest-cov>=4.1",
+    "bandit>=1.7.5",
+    "flake8>=6.1",
+    "flake8-bugbear>=24.0",
+    "flake8-bandit>=4.1",
+    "isort>=5.12.0",
+    "black>=23.7.0",
+    "pylint>=3.0",
+    "pre-commit>=3.6",
+]
+
+[tool.coverage.run]
+source = ["agentpypi"]
+omit = ["agentpypi/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 60
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+known_first_party = ["agentpypi"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101", "B404", "B603"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+```
+
+Notes:
+
+- **`name = "agentpypi"`** matches the README's `uv tool install agentpypi`.
+  If PyPI returns a name conflict at first publish, rename to
+  `agentpypi-cli` and update `[project.scripts]` accordingly.
+- **No runtime deps** at v0.0.1. Add only when a verb needs something
+  stdlib can't do.
+- **`fail_under = 60`** is steward's threshold; tighten as coverage
+  organically grows.
+
+## 2. Lint configs
+
+### `.flake8` (repo-local)
+
+```ini
+[flake8]
+# Match black's line length so flake8 and black agree.
+max-line-length = 100
+
+# E203: whitespace before ':' — conflicts with black's slice formatting.
+# W503: line break before binary operator — black does the opposite (W504-style).
+extend-ignore = E203, W503
+```
+
+If a test file legitimately needs a per-file ignore (e.g. `tests/*:S101`
+for `assert` statements when bandit is run via flake8-bandit), add it
+narrowly. Per `../CLAUDE.md`: "Don't broaden it to silence real
+findings — delete or fix the offending code."
+
+### `.markdownlint-cli2.yaml` (repo-local)
+
+Vendored verbatim from steward — keeps formatting consistent across
+the mesh:
+
+```yaml
+# markdownlint-cli2 config for agentpypi.
+# markdownlint-cli2 stops walking at the git root, so a per-user global
+# config in the home directory isn't picked up from inside the repo.
+# Mirrors the afi-cli / cfafi / steward preset for workspace consistency.
+
+config:
+  default: true
+  # MD013: Line length — disabled. Prose lines wrap at the reader.
+  MD013: false
+  # MD060: Table pipe spacing — disabled (stylistic preference).
+  MD060: false
+  # MD024: Duplicate headings — allow under different parents so Keep a
+  # Changelog entries can each have ### Added / ### Changed / ### Fixed.
+  MD024:
+    siblings_only: true
+
+ignores:
+  - "node_modules/**"
+  - ".local/**"
+```
+
+## 3. `CHANGELOG.md`
+
+Keep-a-Changelog header. The `version-bump` skill prepends entries on
+every PR.
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/). This project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - YYYY-MM-DD
+
+### Added
+
+- Initial scaffold.
+```
+
+## 4. `.github/workflows/tests.yml`
+
+Three jobs: `test`, `lint`, `version-check`. Adapt steward's verbatim,
+substituting `steward` → `agentpypi` everywhere:
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - run: uv run pytest -n auto --cov=agentpypi --cov-report=xml:coverage.xml --cov-report=term -v
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - name: black --check
+        run: uv run black --check agentpypi tests
+      - name: isort --check
+        run: uv run isort --check-only agentpypi tests
+      - name: flake8
+        run: uv run flake8 agentpypi tests
+      - name: pylint --errors-only
+        run: uv run pylint --errors-only agentpypi
+      - name: bandit
+        run: uv run bandit -c pyproject.toml -r agentpypi
+      - name: markdownlint-cli2
+        run: |
+          npm install -g markdownlint-cli2@0.21.0
+          markdownlint-cli2 "**/*.md" "#node_modules" "#.local"
+      - name: portability-lint
+        run: bash .claude/skills/pr-review/scripts/portability-lint.sh
+
+  version-check:
+    # Only run on PR events. On push to main after merge, HEAD == origin/main
+    # and the comparison would always fail.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - run: git fetch origin main
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Check version bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # AgentCulture rule: every PR bumps the version — even docs/config/CI.
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAIN_VERSION=$(git show origin/main:pyproject.toml 2>/dev/null | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])" 2>/dev/null || echo "")
+
+          if [ -z "$MAIN_VERSION" ]; then
+            echo "No pyproject.toml on main yet — skipping version check (initial scaffold)."
+            exit 0
+          fi
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            MARKER="<!-- version-check -->"
+            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Bump before merging to avoid a failed PyPI publish.
+
+          $MARKER"
+            EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --jq '.[] | select(.body | contains("<!-- version-check -->")) | .id' | head -1)
+            if [ -n "$EXISTING" ]; then
+              gh api repos/${{ github.repository }}/issues/comments/$EXISTING -X PATCH -f body="$BODY" > /dev/null
+            else
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" || true
+            fi
+            echo "::error::Version $PR_VERSION matches main. Bump before merging."
+            exit 1
+          else
+            echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
+          fi
+```
+
+## 5. `.github/workflows/publish.yml`
+
+PRs publish a `.dev<run_number>` to TestPyPI; merges to `main` publish
+to PyPI. Both via OIDC Trusted Publishing — no API tokens.
+
+`ghafi` provisions the `pypi` and `testpypi` GitHub Environments and
+the Trusted Publishing claims pointing at `agentculture/agentpypi`.
+That setup must be in place before this workflow can succeed; if you
+own the repo, run `ghafi` first (see `../ghafi/README.md`).
+
+```yaml
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "agentpypi/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "agentpypi/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - run: uv run pytest -n auto -v
+
+  test-publish:
+    # Skip on fork PRs — no OIDC context, the publish step would fail.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: test
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - name: Set dev version
+        run: |
+          BASE=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Publishing ${DEV_VERSION} to TestPyPI"
+      - name: Build and publish to TestPyPI
+        run: |
+          uv build
+          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
+      - name: Print install commands
+        if: always()
+        run: |
+          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match agentpypi==${DEV_VERSION}"
+
+  publish:
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - run: uv python install 3.12
+      - run: uv sync
+      - name: Build and publish to PyPI
+        run: |
+          uv build
+          uv publish --trusted-publishing always --check-url https://pypi.org/simple/
+```
+
+## 6. Pre-commit (optional but expected)
+
+`../CLAUDE.md` mentions a pre-commit hook set every sibling ships with.
+Steward doesn't ship one yet, so look at `../shushu/.pre-commit-config.yaml`
+or `../ghafi/.pre-commit-config.yaml` for the canonical layout. Wire
+`black`, `isort`, `flake8`, `bandit`, `markdownlint-cli2` (in
+check-only mode), and the portability lint.
+
+## Verification
+
+After committing all of the above:
+
+```bash
+# Local end-to-end smoke
+uv sync
+uv run pytest -n auto -v
+uv run black --check agentpypi tests
+uv run isort --check-only agentpypi tests
+uv run flake8 agentpypi tests
+uv run bandit -c pyproject.toml -r agentpypi
+markdownlint-cli2 "**/*.md" "#node_modules"
+bash .claude/skills/pr-review/scripts/portability-lint.sh
+
+# Steward's external diagnosis
+(cd ../steward && uv run steward doctor --scope self ../agentpypi)
+```
+
+Open a no-op PR (typo fix in README) once Trusted Publishing is wired,
+and confirm:
+
+1. `tests`, `lint`, `version-check` all run.
+2. `version-check` *fails* until you bump the version (run
+   `python3 .claude/skills/version-bump/scripts/bump.py patch`).
+3. `test-publish` succeeds and a `0.0.1.dev<n>` shows up on TestPyPI.
+
+If all three are green, the pipeline is wired.

--- a/docs/sibling-pattern-pointer.md
+++ b/docs/sibling-pattern-pointer.md
@@ -1,0 +1,69 @@
+# Sibling pattern — pointer
+
+agentpypi follows the AgentCulture sibling pattern enforced by
+`steward doctor`. The canonical artifact list and the machine-checkable
+invariants live in **`../steward/docs/sibling-pattern.md`** — read that
+file rather than re-quoting it here.
+
+The cross-corpus baseline (synthesized across every known sibling, with
+field/skill/CLAUDE-section frequency) is
+**`../steward/docs/perfect-patient.md`**. It is regenerated on every
+`steward doctor --scope siblings` run, so what you see today reflects
+the corpus as of the last run, not a frozen contract.
+
+## Why a pointer instead of a copy
+
+The artifact list and invariants change as the mesh evolves
+(`changelog-format`, `lint-config-local`, etc. are listed `(planned)`
+in steward today). Vendoring the list into agentpypi would make the
+two drift the moment steward tightens. The agreement here is: **steward
+owns the contract; agentpypi reads it from steward**.
+
+If steward ever moves the canonical contract elsewhere (e.g. publishes
+`sibling-pattern.json` for machine consumption), update this pointer —
+not by copying the contents in.
+
+## Running the diagnosis
+
+Self-scope (single-repo invariants — portability + skills-convention):
+
+```bash
+cd ../steward
+uv run steward doctor --scope self ../agentpypi
+```
+
+- Exit 0 + no findings: invariants pass.
+- Exit non-zero: read each finding on stderr, fix, re-run. `--json`
+  emits the structured findings list to stdout.
+
+Corpus scope (advisory; never blocks):
+
+```bash
+cd ../steward
+uv run steward doctor --scope siblings
+```
+
+This walks every `culture.yaml` in the workspace, regenerates
+`../steward/docs/perfect-patient.md`, and writes per-target feedback
+into `<target>/docs/steward/steward-suggestions.md` (gated by a marker
+line so any hand-written content there is preserved).
+
+agentpypi's `culture.yaml` lands at v0.0.1 per `../CLAUDE.md` Roadmap.
+Until then, `--scope siblings` simply won't include this repo.
+
+## On `culture.yaml`
+
+`culture.yaml` declares an agent to the Culture mesh; it is **not**
+required for every sibling. Steward itself doesn't have one — it's a
+CLI/tools repo, not a Culture-managed resident agent. agentpypi's
+roadmap (per `../CLAUDE.md`) puts `culture.yaml` at v0.0.1 because
+agentpypi *will* run as a mesh-resident process (the local PyPI index
+listens on the mesh). When you write it, model it after `../daria/culture.yaml`
+or `../shushu/culture.yaml` rather than from scratch.
+
+## On `steward doctor --apply`
+
+`--apply` repair mode is **planned**, not implemented. The contract for
+which findings will become auto-repairs lives in `../steward/docs/sibling-pattern.md`
+under "Repairs". Until it ships, treat doctor's output as a punch list
+to fix by hand.

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -1,0 +1,28 @@
+# Skill upstream sources
+
+agentpypi vendors its `.claude/skills/` from steward (the canonical
+sibling-pattern owner). This file tracks provenance so re-syncs are
+deterministic.
+
+| Skill | Upstream | Downstream copies (known) | Notes |
+|-------|----------|---------------------------|-------|
+| `version-bump` | `../steward/.claude/skills/version-bump/` | `agentpypi` (this repo) | Pure-Python; CWD-aware. Re-sync when steward bumps the script. Identifier comments adapted (steward-cli → AgentCulture sibling convention). |
+| `pr-review` | `../steward/.claude/skills/pr-review/` | `agentpypi` (this repo) — adapted | Workflow shape kept verbatim; identifiers (`Steward` → `agentpypi`) and recurring-bug framing generalized. Reviewer wiring (Qodo / Copilot) is the workspace default. |
+
+## Re-sync procedure
+
+```bash
+# Diff against upstream before pulling:
+diff -ru ../steward/.claude/skills/version-bump .claude/skills/version-bump
+diff -ru ../steward/.claude/skills/pr-review    .claude/skills/pr-review
+
+# Pull (overwrite identifier-only adapted scripts and re-apply the rename):
+cp -R ../steward/.claude/skills/version-bump .claude/skills/
+cp -R ../steward/.claude/skills/pr-review    .claude/skills/
+# Re-apply identifier substitutions (search-replace `steward` → `agentpypi`,
+# `Steward` → `agentpypi`).
+```
+
+If a re-sync would lose the agentpypi adaptation, lift the change upstream
+into steward first (per `../steward/docs/skill-sources.md` "When a skill
+should be promoted upstream") and re-vendor.

--- a/docs/skills-setup.md
+++ b/docs/skills-setup.md
@@ -1,0 +1,152 @@
+# Skills setup
+
+This repo will host its own `.claude/skills/` tree. Skills are **vendored**
+(copy-paste owned), not symlinked or pip-installed. Steward owns the
+canonical copies; this file walks you through pulling them in and standing
+up the local-config plumbing.
+
+## Why vendor (not symlink)
+
+From `../steward/CLAUDE.md` "Skills convention":
+
+> Every skill in `.claude/skills/<name>/` ships:
+>
+> 1. `SKILL.md` — explains *why* and *when* to use it. Frontmatter + short
+>    prose; no inline 10-step walk-throughs.
+> 2. `scripts/<entry-point>.sh` (or `.py`) — the script that automates the
+>    workflow. Following the skill should be "run this script," not "do
+>    these ten manual steps." If a skill doesn't have a script, write one
+>    before relying on it.
+> 3. **No external path dependencies.** Scripts must not reach into
+>    another skill's home-directory copy or any other location outside
+>    this repo. If a skill needs functionality from elsewhere, vendor it
+>    into the skill's own `scripts/` directory. This makes skills
+>    portable across Culture projects (Steward's mission is alignment;
+>    that requires copy-paste portability).
+
+Symlinks across repos break copy-paste portability. Vendor.
+
+## Which skills to vendor
+
+Sourced from `../steward/docs/skill-sources.md`:
+
+| Skill | Vendor? | Why |
+|-------|---------|-----|
+| `version-bump` | **Yes** | Pure Python, no per-repo customization. CI's `version-check` job depends on it. |
+| `pr-review` | **Yes** (with light adaptation) | Steward owns the canonical PR workflow. Adapt the reviewer wiring (Qodo / Copilot / agentpypi-specific reviewers) and the `portability-lint.sh` paths if needed. |
+| `agent-config` | No | Steward-specific (resolves Culture agent suffixes). Not portable as-is. |
+| `doc-test-alignment` | No | Stub. Real implementation TBD. Re-evaluate when steward graduates it. |
+
+If `agentpypi` later writes a novel skill that has no per-product
+assumptions and a second sibling copies it, promote it upstream to
+steward. See "When a skill should be promoted upstream" in
+`../steward/docs/skill-sources.md`.
+
+## Vendor procedure
+
+From the agentpypi repo root:
+
+```bash
+mkdir -p .claude/skills
+
+cp -R ../steward/.claude/skills/version-bump .claude/skills/
+cp -R ../steward/.claude/skills/pr-review    .claude/skills/
+
+# Verify each carries SKILL.md + scripts/ entry-point.
+test -f .claude/skills/version-bump/SKILL.md
+test -d .claude/skills/version-bump/scripts
+test -f .claude/skills/pr-review/SKILL.md
+test -d .claude/skills/pr-review/scripts
+```
+
+### Adapt `pr-review`
+
+Open every script under `.claude/skills/pr-review/scripts/` and replace
+any literal references to the `steward` repo or its package
+(`steward.cli`, `steward/`, `agentculture/steward`, etc.) with the
+agentpypi equivalents. Keep the **shape** of the workflow (branch,
+commit, push, wait for reviewers, triage, fix, reply, resolve); only the
+identifiers change.
+
+If agentpypi's PR reviewers differ from steward's (Qodo / Copilot /
+something else), update the wait-loop accordingly.
+
+The `portability-lint.sh` carve-outs (`~/.claude/skills/.../scripts/`,
+`~/.culture/`) stay as-is — they're general policy, not steward-specific.
+
+### Adapt `version-bump` (rare)
+
+`version-bump` is intentionally pure-Python and project-agnostic. The
+script reads `pyproject.toml` + `CHANGELOG.md` from CWD; nothing to
+adapt. If the script grows a path constant pointing at `steward/`, that's
+a bug — fix it upstream in steward and re-vendor here.
+
+## Per-machine config
+
+Steward's per-machine config lives in
+`.claude/skills.local.yaml` (git-ignored) and is documented by a
+committed `.claude/skills.local.yaml.example`. Mirror that here.
+
+### Create `.claude/skills.local.yaml.example`
+
+Vendor steward's template verbatim, adjusting only the comment header:
+
+```yaml
+# Per-machine config for agentpypi's skills.
+# Copy this to skills.local.yaml (git-ignored) and adjust for your environment.
+# Skills read skills.local.yaml first, falling back to this example.
+
+# Path to the Culture server's agent manifest (suffix → directory mapping).
+# Used by: agent-config (if vendored later) and any skill that resolves
+# a registered agent suffix to its repo dir.
+culture_server_yaml: ~/.culture/server.yaml
+
+# Sibling project paths checked during the pr-review alignment-delta step.
+# Workspace-relative paths (../foo) are preferred. Skills skip entries
+# that don't exist on disk, so commenting out missing ones isn't required.
+sibling_projects:
+  - ../afi-cli
+  - ../ghafi
+  - ../steward
+```
+
+### Update `.gitignore`
+
+Append:
+
+```text
+.claude/skills.local.yaml
+```
+
+(Already covered by the existing `.gitignore` if it has a broad
+`.claude/*.local.*` glob; check before adding.)
+
+## Stand up `docs/skill-sources.md`
+
+Even though agentpypi only vendors two skills today, record them in a
+local upstream tracker so future re-syncs are deterministic. The schema
+(from `../steward/docs/skill-sources.md`):
+
+```markdown
+# Skill upstream sources
+
+| Skill | Upstream | Downstream copies (known) | Notes |
+|-------|----------|---------------------------|-------|
+| `version-bump` | `steward` (`.claude/skills/version-bump/`) | `agentpypi` (this repo) | Re-sync when steward bumps the script. |
+| `pr-review`    | `steward` (`.claude/skills/pr-review/`)    | `agentpypi` (this repo) — adapted | Reviewer wiring may diverge. Note divergence in this repo's `SKILL.md` `description`. |
+```
+
+## Smoke test
+
+Run the version-bump script end-to-end after `pyproject.toml` lands
+(see `./quality-pipeline.md` for that):
+
+```bash
+python3 .claude/skills/version-bump/scripts/bump.py patch
+git diff --stat   # expect changes in pyproject.toml + CHANGELOG.md
+git checkout -- pyproject.toml CHANGELOG.md   # revert the smoke test
+```
+
+If the script can't find `pyproject.toml`, you ran it from the wrong
+directory (run from repo root) or the toolchain artifact hasn't landed
+yet — finish `./quality-pipeline.md` first and come back.

--- a/docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md
+++ b/docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md
@@ -1,9 +1,8 @@
 # agentpypi v0.0.1 — design
 
-**Status:** approved 2026-04-28. Tracks
-`/home/spark/.claude/plans/you-have-in-docs-vectorized-parnas.md` (the
-implementation plan); this file is the project-side spec. If they drift,
-the plan file is rebuilt from this one.
+**Status:** approved 2026-04-28. The Claude Code planning harness wrote a
+machine-side plan file outside the repo; this file is the project-side
+spec, committed and authoritative. If they drift, the spec wins.
 
 ## Context
 

--- a/docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md
+++ b/docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md
@@ -1,0 +1,127 @@
+# agentpypi v0.0.1 — design
+
+**Status:** approved 2026-04-28. Tracks
+`/home/spark/.claude/plans/you-have-in-docs-vectorized-parnas.md` (the
+implementation plan); this file is the project-side spec. If they drift,
+the plan file is rebuilt from this one.
+
+## Context
+
+`agentpypi` is a warm-up repo: only `README.md`, `LICENSE`, `.gitignore`,
+`CLAUDE.md`, and `docs/` exist before this PR. v0.0.1 lands the twelve
+required AgentCulture sibling artifacts plus the agent-affordance verbs.
+The user's framing: **the quality pipeline is the central deliverable**.
+
+## Surface (v0.0.1)
+
+Five flat verbs. All support `--json`. Mutating verbs are dry-run by
+default (`overview`/`whoami` are read-only; `doctor` requires `--fix`).
+Exit codes: `0` success / `1` user error / `2` env error (AFI rubric).
+
+| Verb | Behavior |
+|------|----------|
+| `overview` | Probe `127.0.0.1` for known PyPI server flavors (devpi:3141, pypiserver:8080); report up/down/absent. Read-only. |
+| `doctor` | Same probes + diagnoses + (with `--fix`) start/restart configured servers. |
+| `learn` | Markdown self-teaching guide for an agent using agentpypi. Generated from the explain catalog. |
+| `explain <topic>` | Markdown drilldown for any verb or planned noun. `online`/`local` resolve to `status: planned` entries. |
+| `whoami` | Auth/env probe — reports configured PyPI / TestPyPI / local index from `pip` / `uv` config. |
+
+`online` and `local` are NOT registered as argparse subcommands at
+v0.0.1 — only present in the explain catalog as roadmap entries.
+
+## Architecture
+
+```text
+agentpypi/
+├── __init__.py            # __version__ via importlib.metadata
+├── __main__.py
+├── cli/
+│   ├── __init__.py        # main(); argparse top-level
+│   ├── _errors.py         # AgentpypiError + exit codes — STABLE
+│   ├── _output.py         # stdout/stderr split, --json — STABLE
+│   ├── _explain_catalog.py
+│   └── _commands/
+│       ├── overview.py
+│       ├── doctor.py
+│       ├── learn.py
+│       ├── explain.py
+│       └── whoami.py
+└── _probes/
+    ├── __init__.py
+    ├── devpi.py
+    └── pypiserver.py
+```
+
+Zero runtime deps; stdlib only.
+
+## Quality pipeline (the centerpiece)
+
+Eight gates, every one a hard CI block; pre-commit mirrors the lint chain
+to prevent local/CI drift.
+
+| Gate | Pre-commit | tests.yml | publish.yml |
+|------|:----------:|:---------:|:-----------:|
+| black | ✓ | lint | — |
+| isort | ✓ | lint | — |
+| flake8 (+bandit, +bugbear) | ✓ | lint | — |
+| pylint --errors-only | — | lint | — |
+| bandit -r agentpypi | ✓ | lint | — |
+| markdownlint-cli2 | ✓ (check) | lint | — |
+| portability-lint | ✓ | lint | — |
+| pytest + 60 % coverage | — | test | test |
+| version-check (vs main) | — | version-check | — |
+| OIDC Trusted Publishing | — | — | test-publish / publish |
+
+Configs land verbatim from `docs/quality-pipeline.md`.
+
+## Implementation order
+
+1. Toolchain bootstrap (pyproject + lint configs + dynamic `__version__`).
+2. Vendor steward's `version-bump` + `pr-review` skills.
+3. AFI cite + apply (`afi cli cite .` → write stable-contract files
+   verbatim, shape-adapt the rest).
+4. `_probes/` (devpi, pypiserver) + thread-server fixture.
+5. `overview` / `doctor` / `whoami` implementations + tests.
+6. `CHANGELOG.md`.
+7. `.github/workflows/tests.yml`, `.github/workflows/publish.yml`.
+8. `.pre-commit-config.yaml`.
+9. `steward doctor --scope self ../agentpypi` clean.
+10. `afi cli verify . --strict` clean.
+11. `culture.yaml` via `culture agent learn` → `culture agent create`.
+12. End-to-end smoke + version bump + open PR.
+
+## Drift acknowledged
+
+CLAUDE.md sketches `online`/`local` nouns; v0.0.1 ships flat verbs. The
+implementation PR includes a small CLAUDE.md edit moving `online`/`local`
+into the Roadmap section and reflecting the actual five-verb v0.0.1
+surface. `whoami` stays as required by the AFI rubric.
+
+## Verification
+
+```bash
+uv sync
+uv run pytest -n auto --cov=agentpypi --cov-report=term -v
+uv run black --check agentpypi tests
+uv run isort --check-only agentpypi tests
+uv run flake8 agentpypi tests
+uv run pylint --errors-only agentpypi
+uv run bandit -c pyproject.toml -r agentpypi
+markdownlint-cli2 "**/*.md" "#node_modules"
+bash .claude/skills/pr-review/scripts/portability-lint.sh
+
+uv run agentpypi --version
+uv run agentpypi learn --json | head
+uv run agentpypi overview
+uv run agentpypi doctor
+uv run agentpypi explain learn
+uv run agentpypi whoami
+uv run python -m agentpypi --version
+
+(cd ../steward && uv run steward doctor --scope self ../agentpypi)
+afi cli verify . --strict
+uv run pre-commit run --all-files
+```
+
+After PR: `tests`, `lint`, `version-check` green; `test-publish` ships
+`0.0.1.dev<n>` to TestPyPI; on merge, `publish` ships `0.0.1` to PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentpypi"
-version = "0.0.1"
+version = "0.0.2"
 description = "agentpypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[project]
+name = "agentpypi"
+version = "0.0.1"
+description = "agentpypi — both ends of the Python distribution pipe for the AgentCulture mesh."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [{name = "AgentCulture"}]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    # Zero runtime deps at v0.0.1. Stdlib only (argparse, json, tomllib,
+    # urllib.request, socket, subprocess). Add only when a verb needs
+    # something stdlib can't do.
+]
+
+[project.urls]
+Homepage = "https://github.com/agentculture/agentpypi"
+Issues = "https://github.com/agentculture/agentpypi/issues"
+
+[project.scripts]
+agentpypi = "agentpypi.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["agentpypi"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.0",
+    "pytest-cov>=4.1",
+    "bandit>=1.7.5",
+    "flake8>=6.1",
+    "flake8-bugbear>=24.0",
+    "flake8-bandit>=4.1",
+    "isort>=5.12.0",
+    "black>=23.7.0",
+    "pylint>=3.0",
+    "pre-commit>=3.6",
+]
+
+[tool.coverage.run]
+source = ["agentpypi"]
+omit = ["agentpypi/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 60
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+known_first_party = ["agentpypi"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101", "B404", "B603"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures for agentpypi tests.
+
+Provides an in-process HTTP server fixture so probe tests don't depend on
+any external port/process. Stdlib only — no aiohttp/Flask/etc.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Callable, Iterator
+
+import pytest
+
+# Type for a handler-factory: takes a status code, returns a request-handler class.
+HandlerFactory = Callable[[int], type[BaseHTTPRequestHandler]]
+
+
+def _handler_for(status: int) -> type[BaseHTTPRequestHandler]:
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - http.server contract
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok": true}\n')
+
+        def log_message(self, fmt: str, *args: object) -> None:  # noqa: A002
+            # Silence the default stderr access log.
+            return
+
+    return _Handler
+
+
+@pytest.fixture
+def fake_http_server() -> Iterator[Callable[[int], tuple[str, int]]]:
+    """Yield a callable: ``start(status_code) -> (host, port)``.
+
+    Multiple servers can be started in one test. All are torn down on exit.
+    """
+    servers: list[HTTPServer] = []
+
+    def start(status: int = 200) -> tuple[str, int]:
+        server = HTTPServer(("127.0.0.1", 0), _handler_for(status))
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+        host, port = server.server_address[0], server.server_address[1]
+        return host, port
+
+    yield start
+
+    for s in servers:
+        s.shutdown()
+        s.server_close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,119 @@
+"""Smoke tests for agentpypi's CLI (AFI rubric)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentpypi import __version__
+from agentpypi.cli import main
+
+
+def test_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--version"])
+    assert exc.value.code == 0
+    assert __version__ in capsys.readouterr().out
+
+
+def test_help_no_subcommand(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "agentpypi" in out
+    assert "learn" in out
+
+
+def test_learn_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["learn"]) == 0
+    out = capsys.readouterr().out
+    assert len(out) >= 200
+    for marker in ["purpose", "commands", "exit", "--json", "explain"]:
+        assert marker.lower() in out.lower()
+
+
+def test_learn_json_parseable(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["learn", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tool"] == "agentpypi"
+    assert payload["version"] == __version__
+    assert payload["json_support"] is True
+    assert payload["exit_codes"]["0"] == "success"
+    paths = {tuple(c["path"]) for c in payload["commands"]}
+    assert {("learn",), ("explain",), ("overview",), ("doctor",), ("whoami",)} <= paths
+    planned = {tuple(p["path"]) for p in payload["planned"]}
+    assert ("online", "status") in planned
+    assert ("local", "serve") in planned
+
+
+def test_explain_self(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["explain", "agentpypi"]) == 0
+    assert capsys.readouterr().out.lstrip().startswith("#")
+
+
+def test_explain_root_no_args(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["explain"]) == 0
+    assert capsys.readouterr().out.lstrip().startswith("#")
+
+
+def test_explain_each_registered_verb(capsys: pytest.CaptureFixture[str]) -> None:
+    for verb in ("learn", "explain", "overview", "doctor", "whoami"):
+        capsys.readouterr()  # drain
+        assert main(["explain", verb]) == 0, f"explain {verb} failed"
+        out = capsys.readouterr().out
+        assert verb in out.lower()
+
+
+def test_explain_planned_nouns(capsys: pytest.CaptureFixture[str]) -> None:
+    for noun in ("online", "local"):
+        capsys.readouterr()
+        assert main(["explain", noun]) == 0
+        out = capsys.readouterr().out
+        assert "planned" in out.lower()
+
+
+def test_explain_unknown_path_fails_with_hint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["explain", "zzz-not-a-real-noun"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "hint:" in err
+
+
+def test_explain_unknown_path_json_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["explain", "--json", "zzz-not-a-real-noun"])
+    assert rc != 0
+    err = json.loads(capsys.readouterr().err)
+    assert err["code"] == 1
+    assert "no explain entry" in err["message"]
+    assert err["remediation"]
+
+
+def test_module_main_dispatches() -> None:
+    """`python -m agentpypi --version` should also work."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "agentpypi", "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert __version__ in result.stdout
+
+
+def test_unknown_top_level_verb_fails(capsys: pytest.CaptureFixture[str]) -> None:
+    """`agentpypi online ...` is in the catalog but not registered as a subcommand."""
+    with pytest.raises(SystemExit) as exc:
+        main(["online", "status", "shushu"])
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "hint:" in err

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,98 @@
+"""Tests for `agentpypi doctor`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Callable
+
+import pytest
+
+from agentpypi.cli import _commands, main
+
+
+def _set_runner(runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    """Monkey-patch the doctor's RUN indirection to a fake."""
+    _commands.doctor.RUN = runner
+
+
+def _restore_runner() -> None:
+    _commands.doctor.RUN = subprocess.run
+
+
+@pytest.fixture(autouse=True)
+def _restore_doctor_runner() -> None:
+    yield
+    _restore_runner()
+
+
+def test_doctor_dry_run_text(capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry-run is the default; no fix is attempted."""
+    invocations: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ANN001 - test indirection
+        invocations.append(list(argv))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    _set_runner(fake_run)
+    rc = main(["doctor"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert invocations == []  # dry-run never invokes start_command
+    assert "(dry-run" in out
+
+
+def test_doctor_dry_run_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["doctor", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["subject"] == "agentpypi doctor"
+    assert payload["fix_applied"] is False
+    items = payload["sections"][0]["items"]
+    for item in items:
+        assert "diagnosis" in item
+        # Dry-run never recorded a fix attempt.
+        assert item.get("fix_attempted") in (False, None)
+
+
+def test_doctor_fix_invokes_start_command_for_down_servers(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    invocations: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ANN001
+        invocations.append(list(argv))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    _set_runner(fake_run)
+    main(["doctor", "--fix", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    items = payload["sections"][0]["items"]
+    # Each down/absent probe should have one start_command invocation.
+    expected_invocations = sum(1 for item in items if item["status"] != "up")
+    # If everything came up "up" the test still passes — assert consistency only.
+    assert len(invocations) == expected_invocations or len(invocations) == sum(
+        1 for item in items if item.get("fix_attempted")
+    )
+
+
+def test_doctor_fix_failure_exits_two(capsys: pytest.CaptureFixture[str]) -> None:
+    """When start_command returns non-zero, exit with EXIT_ENV_ERROR (2)."""
+
+    def fake_run(argv, **kwargs):  # noqa: ANN001
+        return subprocess.CompletedProcess(args=argv, returncode=1, stdout="", stderr="boom\n")
+
+    _set_runner(fake_run)
+    rc = main(["doctor", "--fix", "--json"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    items = payload["sections"][0]["items"]
+    if all(item["status"] == "up" for item in items):
+        # No fixes attempted; exit code is 0. Re-run with a forced down state
+        # would require mocking probes — skip in that case.
+        pytest.skip("no servers were down; nothing to fix")
+    assert rc == 2
+    # Error JSON should also be on stderr.
+    err_line = captured.err.strip().splitlines()[-1]
+    err = json.loads(err_line)
+    assert err["code"] == 2

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from typing import Callable
+from typing import Callable, Iterator
 
 import pytest
 
@@ -21,7 +21,7 @@ def _restore_runner() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _restore_doctor_runner() -> None:
+def _restore_doctor_runner() -> Iterator[None]:
     yield
     _restore_runner()
 

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,54 @@
+"""Tests for `agentpypi overview` (AFI rubric bundle 6)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentpypi.cli import main
+
+
+def test_overview_text_no_args(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["overview"]) == 0
+    out = capsys.readouterr().out
+    assert out.strip()
+    assert "agentpypi overview" in out
+    assert "local-pypi-servers" in out
+
+
+def test_overview_json_shape(capsys: pytest.CaptureFixture[str]) -> None:
+    """AFI rubric: top-level keys `subject` and `sections` are required."""
+    assert main(["overview", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, dict)
+    assert payload["subject"] == "agentpypi overview"
+    assert isinstance(payload["sections"], list)
+    assert len(payload["sections"]) >= 1
+    section = payload["sections"][0]
+    assert section["name"] == "local-pypi-servers"
+    assert "items" in section
+    for item in section["items"]:
+        assert {"name", "port", "url", "status"} <= set(item.keys())
+        assert item["status"] in {"up", "down", "absent"}
+
+
+def test_overview_graceful_on_unknown_target(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AFI rubric: unknown target -> exit 0, zero-target report, warning."""
+    rc = main(["overview", "/tmp/no-such-path-zzz"])  # noqa: S108
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert "agentpypi overview" in captured.out
+
+
+def test_overview_graceful_on_unknown_target_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["overview", "--json", "/tmp/no-such-path-zzz"])  # noqa: S108
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sections"] == []
+    assert "note" in payload

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -35,9 +35,11 @@ def test_overview_json_shape(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_overview_graceful_on_unknown_target(
     capsys: pytest.CaptureFixture[str],
+    tmp_path,
 ) -> None:
     """AFI rubric: unknown target -> exit 0, zero-target report, warning."""
-    rc = main(["overview", "/tmp/no-such-path-zzz"])  # noqa: S108
+    bogus = str(tmp_path / "no-such-path-zzz")  # never created; pytest cleans the parent
+    rc = main(["overview", bogus])
     assert rc == 0
     captured = capsys.readouterr()
     assert "warning" in captured.err.lower()
@@ -46,8 +48,10 @@ def test_overview_graceful_on_unknown_target(
 
 def test_overview_graceful_on_unknown_target_json(
     capsys: pytest.CaptureFixture[str],
+    tmp_path,
 ) -> None:
-    rc = main(["overview", "--json", "/tmp/no-such-path-zzz"])  # noqa: S108
+    bogus = str(tmp_path / "no-such-path-zzz")
+    rc = main(["overview", "--json", bogus])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["sections"] == []

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,84 @@
+"""Tests for the probe runtime and per-flavor definitions."""
+
+from __future__ import annotations
+
+import socket
+from typing import Callable
+
+from agentpypi._probes import PROBES, devpi, probe_status, pypiserver
+from agentpypi._probes._probe import Probe
+
+
+def _free_port() -> int:
+    """Return a port that's free at the moment of the call."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_known_flavors_registered() -> None:
+    """The Probe registry exposes both shipped flavors."""
+    names = {p.name for p in PROBES}
+    assert names == {"devpi", "pypiserver"}
+
+
+def test_devpi_definition() -> None:
+    assert devpi.name == "devpi"
+    assert devpi.default_port == 3141
+    assert devpi.health_path == "/+api"
+    assert devpi.start_command == ("devpi-server", "--start")
+
+
+def test_pypiserver_definition() -> None:
+    assert pypiserver.name == "pypiserver"
+    assert pypiserver.default_port == 8080
+    assert pypiserver.start_command == ("pypi-server", "run")
+
+
+def test_health_url_format() -> None:
+    assert devpi.health_url("h", 1234) == "http://h:1234/+api"
+    assert devpi.health_url() == "http://127.0.0.1:3141/+api"
+
+
+def test_probe_up_when_server_returns_2xx(
+    fake_http_server: Callable[[int], tuple[str, int]],
+) -> None:
+    host, port = fake_http_server(200)
+    result = probe_status(devpi, host=host, port=port, timeout=2.0)
+    assert result["status"] == "up"
+    assert result["name"] == "devpi"
+    assert result["port"] == port
+    assert result["url"].startswith("http://")
+
+
+def test_probe_down_when_server_returns_5xx(
+    fake_http_server: Callable[[int], tuple[str, int]],
+) -> None:
+    host, port = fake_http_server(500)
+    result = probe_status(devpi, host=host, port=port, timeout=2.0)
+    assert result["status"] == "down"
+    assert "500" in result.get("detail", "")
+
+
+def test_probe_absent_when_nothing_listens() -> None:
+    port = _free_port()
+    # Nothing is listening on `port` between the bind/release above and now;
+    # there's a tiny race window but it's been reliable in CI for siblings.
+    result = probe_status(devpi, port=port, timeout=0.5)
+    assert result["status"] == "absent"
+
+
+def test_probe_returns_typed_keys() -> None:
+    result = probe_status(devpi, port=_free_port(), timeout=0.5)
+    assert set(result.keys()) >= {"name", "port", "url", "status"}
+
+
+def test_custom_probe_can_be_constructed() -> None:
+    """The Probe interface accepts new flavors without code changes elsewhere."""
+    custom = Probe(
+        name="custom",
+        default_port=9999,
+        health_path="/health",
+        start_command=("custom-server", "start"),
+    )
+    assert custom.health_url() == "http://127.0.0.1:9999/health"

--- a/tests/test_whoami.py
+++ b/tests/test_whoami.py
@@ -32,6 +32,7 @@ def test_whoami_text(
 def test_whoami_json_default_index(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     for k in (
         "PIP_INDEX_URL",
@@ -40,9 +41,10 @@ def test_whoami_json_default_index(
         "UV_EXTRA_INDEX_URL",
     ):
         monkeypatch.delenv(k, raising=False)
-    # Pretend pip.conf doesn't exist so the env-only path is exercised.
-    fake_home = str(getattr(monkeypatch, "path", lambda: "/tmp")())  # noqa: S108
-    monkeypatch.setenv("HOME", fake_home)
+    # Point HOME at a guaranteed-empty pytest tmp dir so neither
+    # ~/.config/pip/pip.conf nor ~/.pip/pip.conf can be picked up. This
+    # exercises the env-only resolution path deterministically.
+    monkeypatch.setenv("HOME", str(tmp_path))
     rc = main(["whoami", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_whoami.py
+++ b/tests/test_whoami.py
@@ -1,0 +1,64 @@
+"""Tests for `agentpypi whoami`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentpypi.cli import main
+
+
+def test_whoami_text(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Force a known env shape so the test is deterministic regardless of the
+    # developer's actual pip/uv config.
+    for k in (
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "UV_INDEX_URL",
+        "UV_EXTRA_INDEX_URL",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    rc = main(["whoami"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "agentpypi whoami" in out
+    assert "indexes" in out
+
+
+def test_whoami_json_default_index(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for k in (
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+        "UV_INDEX_URL",
+        "UV_EXTRA_INDEX_URL",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    # Pretend pip.conf doesn't exist so the env-only path is exercised.
+    fake_home = str(getattr(monkeypatch, "path", lambda: "/tmp")())  # noqa: S108
+    monkeypatch.setenv("HOME", fake_home)
+    rc = main(["whoami", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["subject"] == "agentpypi whoami"
+    assert payload["defaults"]["pypi"] == "https://pypi.org/simple"
+    indexes_section = next(s for s in payload["sections"] if s["name"] == "indexes")
+    assert indexes_section["summary"].endswith("https://pypi.org/simple")
+
+
+def test_whoami_picks_up_pip_index_url_env(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PIP_INDEX_URL", "https://example.test/simple")
+    rc = main(["whoami", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    indexes_section = next(s for s in payload["sections"] if s["name"] == "indexes")
+    assert "https://example.test/simple" in indexes_section["summary"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,644 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "agentpypi"
+version = "0.0.1"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "black" },
+    { name = "flake8" },
+    { name = "flake8-bandit" },
+    { name = "flake8-bugbear" },
+    { name = "isort" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.7.5" },
+    { name = "black", specifier = ">=23.7.0" },
+    { name = "flake8", specifier = ">=6.1" },
+    { name = "flake8-bandit", specifier = ">=4.1" },
+    { name = "flake8-bugbear", specifier = ">=24.0" },
+    { name = "isort", specifier = ">=5.12.0" },
+    { name = "pre-commit", specifier = ">=3.6" },
+    { name = "pylint", specifier = ">=3.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+]
+
+[[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "flake8-bandit"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bandit" },
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/1c/4f66a7a52a246d6c64312b5c40da3af3630cd60b27af81b137796af3c0bc/flake8_bandit-4.1.1.tar.gz", hash = "sha256:068e09287189cbfd7f986e92605adea2067630b75380c6b5733dab7d87f9a84e", size = 5403, upload-time = "2022-08-29T13:48:41.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/5f/55bab0ac89f9ad9f4c6e38087faa80c252daec4ccb7776b4dac216ca9e3f/flake8_bandit-4.1.1-py3-none-any.whl", hash = "sha256:4c8a53eb48f23d4ef1e59293657181a3c989d0077c9952717e98a0eace43e06d", size = 4828, upload-time = "2022-08-29T13:48:39.737Z" },
+]
+
+[[package]]
+name = "flake8-bugbear"
+version = "25.11.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/2a996e2fca7810bd1b031901d65fc4292630895afcb946ebd00568bdc669/flake8_bugbear-25.11.29.tar.gz", hash = "sha256:b5d06710f3d26e595541ad303ad4d5cb52578bd4bccbb2c2c0b2c72e243dafc8", size = 84896, upload-time = "2025-11-29T20:51:57.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/42/c18f199780d99a6f6a64c4a36f4ad28a445d9e11968a6025b21d0c8b6802/flake8_bugbear-25.11.29-py3-none-any.whl", hash = "sha256:9bf15e2970e736d2340da4c0a70493db964061c9c38f708cfe1f7b2d87392298", size = 37861, upload-time = "2025-11-29T20:51:56.439Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentpypi"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

First implementation PR for `agentpypi`. Lands the twelve required
AgentCulture sibling artifacts plus five flat verbs, with the **quality
pipeline as the central deliverable** per the user's framing.

- Toolchain (pyproject + lint configs + dynamic `__version__`), vendored
  steward skills (`version-bump`, `pr-review`), AFI scaffold applied via
  `afi cli cite`, two GitHub workflows (`tests.yml` + `publish.yml`),
  pre-commit hooks, `CHANGELOG.md`, `culture.yaml` (joins the mesh as
  `spark-agentpypi`).
- Five verbs: `learn`, `explain`, `overview`, `doctor` (`--fix`-gated),
  `whoami`. All support `--json`. Mutating verbs default to dry-run.
- `agentpypi/_probes/` introspects localhost for known PyPI server
  flavors (devpi:3141, pypiserver:8080); two-stage TCP-then-HTTP probe
  distinguishes `up` / `down` / `absent`.
- `online` and `local` noun groups are catalog-known but NOT yet
  registered as argparse subcommands. `learn --json`'s `planned` array
  enumerates them honestly. Implementation lands in v0.1.0 / v0.2.0.

## Test plan

- [x] `uv sync && uv run pytest -n auto --cov=agentpypi` — 32 / 32 pass,
  coverage 92.21 % (gate is 60 %).
- [x] Lint chain clean: `black --check`, `isort --check-only`, `flake8`,
  `pylint --errors-only`, `bandit -c pyproject.toml -r agentpypi`,
  `markdownlint-cli2 "**/*.md"`, `portability-lint.sh`.
- [x] `uv run pre-commit run --all-files` — every hook passes.
- [x] `(cd ../steward && uv run steward doctor --scope self
  ../agentpypi)` — clean, 2/2 checks.
- [x] CLI smoke: `--version`, `learn`, `learn --json`, `overview`,
  `overview --json`, `doctor`, `explain online`, `python -m agentpypi
  --version` all behave as documented.
- [ ] CI verifies `tests`, `lint`, `version-check`, `test-publish` all
  green on this PR.
- [ ] On merge, `publish` job ships `0.0.1` to PyPI via OIDC Trusted
  Publishing.

## Accepted deviations

Documented in
`docs/superpowers/specs/2026-04-28-agentpypi-v0.0.1-design.md` and
`CHANGELOG.md`:

- AFI rubric `overview_cli_noun_exists` fails — checks for a `cli` noun
  agentpypi doesn't have (its nouns will be `online` / `local` at later
  milestones). Fixing this would require an artificial `cli` noun.
- AFI `stderr_clean_on_success` warns 195 chars — emitted by `uv` itself
  when `afi cli verify` invokes `uv run --with ../agentpypi`, not by
  agentpypi. Empty stderr in normal use.

CLAUDE.md sketches `online` / `local` as v0.0.1 nouns with `whoami` as
the auth probe; brainstorming pivoted to a five-flat-verb shape
(`overview` / `doctor` / `learn` / `explain` / `whoami`). A small
follow-up PR will reconcile CLAUDE.md's "CLI shape" section with what
this PR actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude