### PR TITLE
v0.5.0: lifecycle verbs (auntie up / down / restart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-30
+
+### Added
+
+- `auntie up <name>` / `auntie up --all` — start a declared server, or every supervised declaration. Bare `auntie up` is reserved for v0.6.0's first-party server.
+- `auntie down <name>` / `auntie down --all` — stop a declared server. For `managed_by=command`: SIGTERM with 5 s grace, then SIGKILL. PID-tracked via XDG state directory.
+- `auntie restart <name>` / `auntie restart --all` — atomic for `systemd-user` (`systemctl --user restart`); stop+start for `command`. Re-spawns from current pyproject argv (sidecar argv is advisory; drift logged).
+- `_actions/_pid.py` — PID file + sidecar (`<slug>.pid`, `<slug>.json`) with atomic write via `tempfile.mkstemp` + `os.replace`. Liveness check via `os.kill(pid, 0)`; stale records cleaned up on read.
+- `_actions/_pid.find_by_port` — Linux-only port-walk fallback for `command.stop` when no PID file exists. Argv-match guard prevents accidentally killing an unrelated process bound to the same port.
+- `_reprobe.probe(*, desired="up"|"down")` — extended polling loop supports stop-path verification; `desired="down"` matches both "down" and "absent".
+- `auntie explain up` / `down` / `restart` catalog entries with shared lifecycle preamble.
+
+### Changed
+
+- `_actions/<strategy>.apply` → `_actions/<strategy>.start` (internal rename). The single-action contract is replaced by sibling `start` / `stop` / `restart` per strategy.
+- `_actions.dispatch` widened to `dispatch(action, detection, declaration)`. `ACTIONS` is now `dict[str, dict[str, Strategy]]` keyed on `(managed_by, action)`. Doctor's `--apply` rewires to `dispatch("start", ...)`.
+- `learn` and the explain catalog now describe the three new verbs; the v0.4.0 drift-detection test continues to pass.
+
 ## [0.4.0] - 2026-04-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ auntie <verb> [args] [--json]
 Both `auntie` and `auntiepypi` are registered console scripts pointing
 at the same `auntiepypi.cli:main`.
 
-Active verbs registered at v0.4.0:
+Active verbs registered at v0.5.0:
 
 - `auntie learn` (and `learn --json`) — self-teaching prompt generated
   from the `auntiepypi/explain/catalog.py` catalog so it can never
@@ -148,6 +148,21 @@ Active verbs registered at v0.4.0:
   resolves a duplicate-name ambiguity before acting. TARGET drills into
   one server. Exits `2` when `--apply` was attempted and any actionable
   server is still down after re-probe.
+- `auntie up [TARGET | --all] [--decide=...] [--json]` — start a
+  declared server. Bare invocation (no TARGET, no `--all`) exits `1`
+  with a forward-pointing message reserving the bare form for v0.6.0's
+  first-party server. `--all` acts on every supervised declaration
+  (managed_by ∈ {systemd-user, command}); other modes are skipped with
+  a stderr note. Per-target refusal for unsupervised modes.
+- `auntie down [TARGET | --all] [--decide=...] [--json]` — stop a
+  declared server. For `command`: SIGTERM with 5 s grace, SIGKILL
+  fallback, then PID file cleanup. Linux-only port-walk + argv-match
+  fallback when no PID file exists. Idempotent: nothing-to-stop is
+  `ok=True, detail="already stopped"`.
+- `auntie restart [TARGET | --all] [--decide=...] [--json]` — atomic
+  for `systemd-user` (`systemctl --user restart`); stop+start for
+  `command`, re-spawning from the **current** pyproject `command`.
+  Sidecar argv drift is logged but never blocks the action.
 - `auntie whoami [--json]` — auth/env probe; reads `$PIP_INDEX_URL` /
   `$UV_INDEX_URL` env vars and pip's global config file. Exact paths
   inspected live in `auntiepypi/cli/_commands/whoami.py`.
@@ -194,10 +209,16 @@ burned on the `agentpypi → auntiepypi` rename. The table below uses
    `--decide` registry; `packages` noun removed; `_probes/` removed.
    Numbered `.bak` snapshots before any `pyproject.toml` mutation. See spec
    `docs/superpowers/specs/2026-04-30-auntiepypi-v0.4.0-doctor-lifecycle-design.md`.
-5. **semver 0.5.0 — own server + lifecycle commands.** `auntie up` / `auntie
-   down` / `auntie restart`; PID-file tracking; first-party PEP 503
-   simple-index for mesh-private use. HTTPS surface introduced here.
-6. **semver 1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
+5. **semver 0.5.0 — lifecycle verbs (shipped).** `auntie up` / `auntie
+   down` / `auntie restart` against declared servers. Strategy contract
+   widened to sibling start/stop/restart. PID-file + sidecar tracking
+   for `command`; argv-matched port-walk fallback. Bare invocation
+   reserved for v0.6.0. See spec
+   `docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md`.
+6. **semver 0.6.0 — own server.** First-party PEP 503 simple-index for
+   mesh-private use; bare `auntie up` / `down` / `restart` start/stop
+   the in-process server. HTTPS surface introduced here.
+7. **semver 1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
    service registry; trust boundary documented in `docs/threat-model.md`.
 
 This roadmap is descriptive of intent, not a commitment. Reorder or

--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@
 > auntie (Python distribution: `auntiepypi`) is both a CLI and an agent
 > that maintains, uses, and serves the CLI for managing PyPI packages.
 > It overviews packages on pypi.org, detects PyPI-flavored servers
-> running locally, and can start declared servers — informational
-> first, actionable with `--apply`. Stop/restart lands in v0.5.0.
+> running locally, and starts/stops/restarts declared servers —
+> informational first, actionable on demand.
 
-**Status:** v0.4.0 — doctor lifecycle landed. `auntie doctor` is now a
-managed_by-aware lifecycle dispatcher: `--apply` replaces `--fix`,
-`_actions/` provides `systemd-user` and `command` strategies,
-numbered `.bak` snapshots guard every `pyproject.toml` mutation. The
-`packages` noun is removed — use `auntie overview <PKG>` instead.
+**Status:** v0.5.0 — lifecycle verbs landed. `auntie up`,
+`auntie down`, and `auntie restart` are first-class verbs against
+declared servers (`managed_by ∈ {systemd-user, command}`). The
+`_actions/` strategy contract has widened from a single `apply()` to
+sibling `start` / `stop` / `restart` per strategy. `command`-managed
+servers are now PID-tracked (`$XDG_STATE_HOME/auntiepypi/<slug>.pid`)
+with a Linux port-walk fallback. The bare invocation (`auntie up`
+with no target) is reserved for v0.6.0's first-party PyPI server.
 
 ## Quick start
 
@@ -21,6 +24,9 @@ auntie overview --json | jq '.sections[] | select(.category == "servers")'
 auntie overview requests            # deep-dive into a PyPI package
 auntie doctor                       # diagnose declared servers (dry-run)
 auntie doctor --apply               # act on actionable remediations
+auntie up <name>                    # start one declared server
+auntie down --all                   # stop every supervised server
+auntie restart <name>               # atomic for systemd-user; stop+start for command
 ```
 
 Example servers-section output (one declared server):

--- a/auntiepypi/_actions/__init__.py
+++ b/auntiepypi/_actions/__init__.py
@@ -1,31 +1,42 @@
-"""Lifecycle strategies, keyed on `managed_by`.
+"""Lifecycle strategies, keyed on `managed_by` and lifecycle action.
 
-Each strategy module under this package exposes an ``apply(detection,
-declaration) -> ActionResult`` function. ``dispatch()`` is the only
-caller-facing entry point; it never raises — unimplemented or "manual"
-modes return a uniform ``ActionResult`` so doctor's loop can handle
-every case the same way.
+Each strategy module under this package exposes three functions —
+``start(detection, declaration)``, ``stop(detection, declaration)``,
+``restart(detection, declaration)`` — each returning ``ActionResult``.
+``dispatch(action, ...)`` is the only caller-facing entry point; it
+never raises — unimplemented or "manual" modes return a uniform
+``ActionResult`` so callers can handle every case the same way.
 
 Adding a strategy: drop a new file under ``_actions/<managed_by>.py``
-exposing ``apply``, then add it to ``ACTIONS`` below. No other surgery
-needed.
+exposing ``start``, ``stop``, ``restart``, then add it to ``ACTIONS``
+below. No other surgery needed.
 """
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Literal
 
+from auntiepypi._actions import command as _command
+from auntiepypi._actions import systemd_user as _systemd_user
 from auntiepypi._actions._action import ActionResult
-from auntiepypi._actions.command import apply as _command_apply
-from auntiepypi._actions.systemd_user import apply as _systemd_user_apply
 from auntiepypi._detect._config import ServerSpec
 from auntiepypi._detect._detection import Detection
 
+Action = Literal["start", "stop", "restart"]
 Strategy = Callable[[Detection, ServerSpec], ActionResult]
+StrategyMap = dict[str, Strategy]
 
-ACTIONS: dict[str, Strategy] = {
-    "systemd-user": _systemd_user_apply,
-    "command": _command_apply,
+ACTIONS: dict[str, StrategyMap] = {
+    "systemd-user": {
+        "start": _systemd_user.start,
+        "stop": _systemd_user.stop,
+        "restart": _systemd_user.restart,
+    },
+    "command": {
+        "start": _command.start,
+        "stop": _command.stop,
+        "restart": _command.restart,
+    },
 }
 
 # Modes that are validated as legal but are intentionally "no strategy".
@@ -34,18 +45,18 @@ _NOT_IMPLEMENTED: frozenset[str] = frozenset({"docker", "compose"})
 __all__ = ["ACTIONS", "ActionResult", "dispatch"]
 
 
-def dispatch(detection: Detection, declaration: ServerSpec) -> ActionResult:
-    """Route to the strategy for ``declaration.managed_by``.
+def dispatch(action: Action, detection: Detection, declaration: ServerSpec) -> ActionResult:
+    """Route to the strategy/action for ``declaration.managed_by``.
 
     Never raises. Unknown / unsupervised modes return a uniform result.
     """
     mode = declaration.managed_by
     if mode in ACTIONS:
-        return ACTIONS[mode](detection, declaration)
+        return ACTIONS[mode][action](detection, declaration)
     if mode in _NOT_IMPLEMENTED:
         return ActionResult(
             ok=False,
-            detail=f"managed_by={mode!r} not implemented in v0.4.0",
+            detail=f"managed_by={mode!r} not implemented",
         )
     # mode is None ("manual" by spec) or "manual"
     return ActionResult(

--- a/auntiepypi/_actions/__init__.py
+++ b/auntiepypi/_actions/__init__.py
@@ -49,10 +49,18 @@ def dispatch(action: Action, detection: Detection, declaration: ServerSpec) -> A
     """Route to the strategy/action for ``declaration.managed_by``.
 
     Never raises. Unknown / unsupervised modes return a uniform result.
+    Unknown action keys (or strategy maps missing an action) likewise
+    return ActionResult(ok=False, ...) instead of KeyError.
     """
     mode = declaration.managed_by
     if mode in ACTIONS:
-        return ACTIONS[mode][action](detection, declaration)
+        strategies = ACTIONS[mode]
+        if action not in strategies:
+            return ActionResult(
+                ok=False,
+                detail=f"action={action!r} not supported for managed_by={mode!r}",
+            )
+        return strategies[action](detection, declaration)
     if mode in _NOT_IMPLEMENTED:
         return ActionResult(
             ok=False,

--- a/auntiepypi/_actions/_action.py
+++ b/auntiepypi/_actions/_action.py
@@ -1,8 +1,9 @@
 """Uniform return value for any lifecycle strategy.
 
 Strategies live in `auntiepypi/_actions/<managed_by>.py`. Each exposes
-``apply(detection, declaration) -> ActionResult``. `dispatch()` in
-``_actions/__init__.py`` routes on `managed_by`.
+``start(detection, declaration)``, ``stop(detection, declaration)``,
+``restart(detection, declaration)`` — all returning ``ActionResult``.
+`dispatch()` in ``_actions/__init__.py`` routes on (action, managed_by).
 """
 
 from __future__ import annotations
@@ -15,7 +16,8 @@ class ActionResult:
     """Result of one strategy attempt.
 
     :param ok: True iff the post-action re-probe (or strategy-internal
-        success criterion) confirms the server is up.
+        success criterion) confirms the server reached the desired
+        state ("up" for start/restart, "down" for stop).
     :param detail: One-line human-readable summary; merged into JSON
         envelope as ``fix_detail``.
     :param log_path: Where the strategy wrote logs (``command`` only;

--- a/auntiepypi/_actions/_pid.py
+++ b/auntiepypi/_actions/_pid.py
@@ -1,0 +1,241 @@
+"""PID-file + sidecar tracking for `managed_by=command` lifecycle.
+
+Files cluster with the v0.4.0 log file at
+``$XDG_STATE_HOME/auntiepypi/<slug>.{log,pid,json}`` (slug derivation
+reuses :func:`auntiepypi._actions._logs.slugify`).
+
+- ``<slug>.pid`` — raw integer PID (newline-terminated text).
+- ``<slug>.json`` — sidecar with pid/argv/started_at/port for `down`'s
+  argv-match heuristic + diagnostics.
+
+Atomic writes via ``tempfile.mkstemp`` + ``os.replace`` to avoid the
+SonarCloud S2083 path-traversal class that bit ``_config_edit`` in v0.4.0.
+
+``find_by_port`` is the Linux-only fallback for ``command.stop`` when
+no PID file exists (e.g. server was started outside ``auntie up``).
+Non-Linux platforms get None — documented degradation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from auntiepypi._actions._logs import slugify, state_root
+from auntiepypi._detect._proc import (
+    _inodes_for_pid,
+    parse_proc_net_tcp,
+    scan_proc_root,
+)
+
+_PROC_DEFAULT = Path("/proc")
+
+
+@dataclass(frozen=True)
+class PidRecord:
+    """Parsed contents of ``<slug>.pid`` + ``<slug>.json``."""
+
+    pid: int
+    argv: tuple[str, ...]
+    started_at: str  # ISO 8601 UTC
+    port: int
+
+
+def _pid_path(name: str) -> Path:
+    return state_root() / f"{slugify(name)}.pid"
+
+
+def _sidecar_path(name: str) -> Path:
+    return state_root() / f"{slugify(name)}.json"
+
+
+def _atomic_write(target: Path, payload: bytes) -> None:
+    """Write `payload` to `target` atomically: tempfile → fsync → os.replace."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent),
+        prefix=f"{target.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, target)
+    except OSError:
+        # Best-effort cleanup of the temp file if replace fails
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write(name: str, *, pid: int, argv: Sequence[str], port: int) -> None:
+    """Write ``<name>.pid`` and ``<name>.json`` atomically."""
+    started_at = datetime.now(timezone.utc).isoformat()
+    sidecar = {
+        "pid": pid,
+        "argv": list(argv),
+        "started_at": started_at,
+        "port": port,
+    }
+    _atomic_write(_sidecar_path(name), json.dumps(sidecar).encode("utf-8"))
+    _atomic_write(_pid_path(name), f"{pid}\n".encode("ascii"))
+
+
+def _is_alive(pid: int) -> bool:
+    """Probe liveness via ``os.kill(pid, 0)``. ESRCH → dead. EPERM → live but not ours."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def read(name: str) -> Optional[PidRecord]:
+    """Return the parsed record, or None if absent / stale (cleans up stale)."""
+    pid_path = _pid_path(name)
+    sidecar_path = _sidecar_path(name)
+    try:
+        pid_text = pid_path.read_text(encoding="ascii").strip()
+    except OSError:
+        return None
+    try:
+        pid = int(pid_text)
+    except ValueError:
+        clear(name)
+        return None
+
+    try:
+        sidecar_raw = sidecar_path.read_text(encoding="utf-8")
+    except OSError:
+        sidecar = {}
+    else:
+        try:
+            sidecar = json.loads(sidecar_raw)
+        except json.JSONDecodeError:
+            sidecar = {}
+
+    if not _is_alive(pid):
+        clear(name)
+        return None
+
+    argv_list = sidecar.get("argv") or []
+    return PidRecord(
+        pid=pid,
+        argv=tuple(str(a) for a in argv_list),
+        started_at=str(sidecar.get("started_at") or ""),
+        port=int(sidecar.get("port") or 0),
+    )
+
+
+def clear(name: str) -> None:
+    """Delete ``<name>.pid`` and ``<name>.json``. Idempotent."""
+    for p in (_pid_path(name), _sidecar_path(name)):
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+
+def _argv_matches(discovered: Sequence[str], expected: Sequence[str]) -> bool:
+    """Heuristic argv match for the port-walk fallback.
+
+    True iff:
+    1. ``basename(discovered[0]) == basename(expected[0])``, AND
+    2. every non-flag token in `expected` (skipping tokens starting with
+       '-') appears somewhere in `discovered`.
+
+    The flag-skipping rule is what lets ``["pypi-server","run","-p","8080","."]``
+    match against a discovered argv that uses ``--port 8080`` instead of ``-p``.
+    """
+    if not discovered or not expected:
+        return False
+    if os.path.basename(discovered[0]) != os.path.basename(expected[0]):
+        return False
+    discovered_set = set(discovered)
+    for tok in expected[1:]:
+        if tok.startswith("-"):
+            continue
+        if tok not in discovered_set:
+            return False
+    return True
+
+
+def _cmdline_for_pid(proc_root: Path, pid: int) -> tuple[str, ...]:
+    """Read ``/proc/<pid>/cmdline``; return argv tuple or empty."""
+    try:
+        raw = (proc_root / str(pid) / "cmdline").read_bytes()
+    except OSError:
+        return ()
+    parts = raw.split(b"\x00")
+    return tuple(p.decode("utf-8", errors="replace") for p in parts if p)
+
+
+def find_by_port(
+    port: int,
+    *,
+    expected_argv: Sequence[str],
+    proc_root: Optional[Path] = None,
+) -> Optional[int]:
+    """Linux-only: PID of the listener on `port` whose argv matches `expected_argv`.
+
+    Returns None on non-Linux, no listener, or argv mismatch. The argv
+    match (`_argv_matches`) prevents accidentally killing an unrelated
+    process bound to the same port.
+    """
+    if proc_root is None and sys.platform != "linux":
+        return None
+    root = proc_root if proc_root is not None else _PROC_DEFAULT
+    if not root.is_dir():
+        return None
+
+    listeners = parse_proc_net_tcp(root / "net" / "tcp")
+    if not listeners:
+        return None
+    # Invert: port -> inode (we want to find the inode for OUR port)
+    target_inodes = {inode for inode, p in listeners.items() if p == port}
+    if not target_inodes:
+        return None
+
+    # Walk every PID whose fd/* contains one of those inodes
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return None
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        if not (target_inodes & _inodes_for_pid(entry)):
+            continue
+        argv = _cmdline_for_pid(root, pid)
+        if _argv_matches(argv, expected_argv):
+            return pid
+    return None
+
+
+# Re-export for tests that want to spy on the underlying scanner.
+__all__ = [
+    "PidRecord",
+    "clear",
+    "find_by_port",
+    "read",
+    "scan_proc_root",
+    "write",
+]

--- a/auntiepypi/_actions/_pid.py
+++ b/auntiepypi/_actions/_pid.py
@@ -48,12 +48,12 @@ class PidRecord:
     port: int
 
 
-def _pid_path(name: str) -> Path:
-    return state_root() / f"{slugify(name)}.pid"
+def _pid_path(name: str, port: int) -> Path:
+    return state_root() / f"{slugify(name)}_{port}.pid"
 
 
-def _sidecar_path(name: str) -> Path:
-    return state_root() / f"{slugify(name)}.json"
+def _sidecar_path(name: str, port: int) -> Path:
+    return state_root() / f"{slugify(name)}_{port}.json"
 
 
 def _atomic_write(target: Path, payload: bytes) -> None:
@@ -80,7 +80,15 @@ def _atomic_write(target: Path, payload: bytes) -> None:
 
 
 def write(name: str, *, pid: int, argv: Sequence[str], port: int) -> None:
-    """Write ``<name>.pid`` and ``<name>.json`` atomically."""
+    """Write ``<name>_<port>.pid`` and ``<name>_<port>.json`` atomically.
+
+    Files are keyed on ``(name, port)`` so duplicate-named declarations
+    (lenient mode) don't clobber each other's PID tracking.
+
+    Order: PID file first, sidecar second. If the sidecar write fails
+    after the PID landed, the orphan PID file is cleaned up so we don't
+    leave half-written state behind.
+    """
     started_at = datetime.now(timezone.utc).isoformat()
     sidecar = {
         "pid": pid,
@@ -88,14 +96,25 @@ def write(name: str, *, pid: int, argv: Sequence[str], port: int) -> None:
         "started_at": started_at,
         "port": port,
     }
-    _atomic_write(_sidecar_path(name), json.dumps(sidecar).encode("utf-8"))
-    _atomic_write(_pid_path(name), f"{pid}\n".encode("ascii"))
+    pid_path = _pid_path(name, port)
+    sidecar_path = _sidecar_path(name, port)
+    _atomic_write(pid_path, f"{pid}\n".encode("ascii"))
+    try:
+        _atomic_write(sidecar_path, json.dumps(sidecar).encode("utf-8"))
+    except OSError:
+        try:
+            pid_path.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def _is_alive(pid: int) -> bool:
     """Probe liveness via ``os.kill(pid, 0)``. ESRCH → dead. EPERM → live but not ours."""
     try:
-        os.kill(pid, 0)
+        # Signal 0 does not actually signal the process — it's the standard
+        # POSIX idiom for liveness/permission probing. Not a real signal.
+        os.kill(pid, 0)  # NOSONAR python:S4828
     except ProcessLookupError:
         return False
     except PermissionError:
@@ -105,10 +124,10 @@ def _is_alive(pid: int) -> bool:
     return True
 
 
-def read(name: str) -> Optional[PidRecord]:
+def read(name: str, port: int) -> Optional[PidRecord]:
     """Return the parsed record, or None if absent / stale (cleans up stale)."""
-    pid_path = _pid_path(name)
-    sidecar_path = _sidecar_path(name)
+    pid_path = _pid_path(name, port)
+    sidecar_path = _sidecar_path(name, port)
     try:
         pid_text = pid_path.read_text(encoding="ascii").strip()
     except OSError:
@@ -116,7 +135,7 @@ def read(name: str) -> Optional[PidRecord]:
     try:
         pid = int(pid_text)
     except ValueError:
-        clear(name)
+        clear(name, port)
         return None
 
     try:
@@ -130,21 +149,38 @@ def read(name: str) -> Optional[PidRecord]:
             sidecar = {}
 
     if not _is_alive(pid):
-        clear(name)
+        clear(name, port)
+        return None
+
+    # Sidecar fields can be corrupted by user edits; treat any parse
+    # failure as an invalid record rather than crashing.
+    try:
+        sidecar_port = int(sidecar.get("port") or 0)
+    except (ValueError, TypeError):
+        clear(name, port)
+        return None
+
+    # If the sidecar's recorded port doesn't match what the caller is
+    # asking about, the file is for a different declaration — treat as
+    # stale. (Belt-and-braces; the filename already disambiguates.)
+    if sidecar_port and sidecar_port != port:
+        clear(name, port)
         return None
 
     argv_list = sidecar.get("argv") or []
+    if not isinstance(argv_list, list):
+        argv_list = []
     return PidRecord(
         pid=pid,
         argv=tuple(str(a) for a in argv_list),
         started_at=str(sidecar.get("started_at") or ""),
-        port=int(sidecar.get("port") or 0),
+        port=sidecar_port,
     )
 
 
-def clear(name: str) -> None:
-    """Delete ``<name>.pid`` and ``<name>.json``. Idempotent."""
-    for p in (_pid_path(name), _sidecar_path(name)):
+def clear(name: str, port: int) -> None:
+    """Delete ``<name>_<port>.pid`` and ``<name>_<port>.json``. Idempotent."""
+    for p in (_pid_path(name, port), _sidecar_path(name, port)):
         try:
             p.unlink()
         except FileNotFoundError:

--- a/auntiepypi/_actions/_reprobe.py
+++ b/auntiepypi/_actions/_reprobe.py
@@ -1,8 +1,9 @@
 """Post-spawn re-probe loop.
 
 Polls a server at increasing intervals within a caller-supplied wall-clock
-budget. The first "up" result exits early; on budget exhaustion the final
-attempt's result is returned.
+budget. Exits early when the observed status matches the caller's
+``desired`` state (``"up"`` for start/restart; ``"down"`` for stop).
+On budget exhaustion the final attempt's result is returned.
 
 Poll offsets (seconds): 0.5, 1.0, 2.0, 3.5, 5.0
 """
@@ -12,6 +13,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal
 
 from auntiepypi._detect._detection import Detection
 from auntiepypi._detect._http import content_type, probe_endpoint
@@ -55,20 +57,31 @@ def _attempt(detection: Detection) -> ReprobeResult:
     return ReprobeResult(status="up")
 
 
+def _matches_desired(status: str, desired: Literal["up", "down"]) -> bool:
+    """``desired="up"`` matches only "up"; ``desired="down"`` matches "down" or "absent"."""
+    if desired == "up":
+        return status == "up"
+    return status in ("down", "absent")
+
+
 def probe(
     detection: Detection,
     *,
     budget_seconds: float = 5.0,
+    desired: Literal["up", "down"] = "up",
     _sleep: Callable[[float], None] = time.sleep,
     _now: Callable[[], float] = time.monotonic,
 ) -> ReprobeResult:
-    """Poll *detection* until "up" or *budget_seconds* is exhausted.
+    """Poll *detection* until ``status`` matches ``desired`` or budget exhausted.
 
     Attempt offsets are 0.5 s, 1.0 s, 2.0 s, 3.5 s, 5.0 s from start.
-    First "up" wins; the last attempt's result is returned on exhaustion.
+    First match wins; the last attempt's result is returned on exhaustion.
 
     :param detection: Server description to probe.
     :param budget_seconds: Wall-clock ceiling; attempts past this are skipped.
+    :param desired: Target state — ``"up"`` for start/restart (default;
+        v0.4.0 behavior); ``"down"`` for stop. ``"down"`` matches both
+        "down" and "absent".
     :param _sleep: Injectable sleep callable (for tests).
     :param _now: Injectable monotonic clock (for tests).
     """
@@ -86,7 +99,7 @@ def probe(
             _sleep(wait)
 
         result = _attempt(detection)
-        if result.status == "up":
+        if _matches_desired(result.status, desired):
             return result
 
     return result

--- a/auntiepypi/_actions/_reprobe.py
+++ b/auntiepypi/_actions/_reprobe.py
@@ -58,10 +58,15 @@ def _attempt(detection: Detection) -> ReprobeResult:
 
 
 def _matches_desired(status: str, desired: Literal["up", "down"]) -> bool:
-    """``desired="up"`` matches only "up"; ``desired="down"`` matches "down" or "absent"."""
+    """``desired="up"`` matches only "up"; ``desired="down"`` matches only "absent".
+
+    "down" with TCP open (HTTP error / non-2xx / flavor mismatch) means the
+    server is still listening — `stop` shouldn't claim victory. We require
+    "absent" (TCP closed; port truly unbound) to confirm shutdown.
+    """
     if desired == "up":
         return status == "up"
-    return status in ("down", "absent")
+    return status == "absent"
 
 
 def probe(

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -138,10 +138,31 @@ def _spawn_error(err: OSError, declaration: ServerSpec, log_path: Path) -> Actio
 def _resolve_target_pid(declaration: ServerSpec) -> tuple[int | None, str]:
     """Find the PID to signal. Returns (pid, source) where source is
     "pid-file" or "port-walk", or (None, "") when no target is found.
+
+    PID-file path: cross-check on Linux that the recorded PID is the
+    listener on the declared port. PID reuse can leave a live-but-stale
+    PID in the file; signaling it would kill an unrelated process.
+    When the cross-check fails, clear the PID file and fall through to
+    the port-walk fallback.
     """
-    record = _pid.read(declaration.name)
+    record = _pid.read(declaration.name, declaration.port)
     if record is not None:
-        return record.pid, "pid-file"
+        if declaration.command:
+            verified = _pid.find_by_port(
+                declaration.port,
+                expected_argv=list(declaration.command),
+            )
+            # If find_by_port returns None on non-Linux, trust the PID
+            # file (best we can do without /proc). On Linux, require the
+            # PID file's PID to match the actual listener.
+            import sys as _sys
+
+            if _sys.platform == "linux" and verified is not None and verified != record.pid:
+                # Stale-but-live PID in the file; the actual listener is a
+                # different process. Clear and fall through.
+                _pid.clear(declaration.name, declaration.port)
+            else:
+                return record.pid, "pid-file"
     if declaration.command:
         pid = _pid.find_by_port(
             declaration.port,
@@ -170,7 +191,7 @@ def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
                     f"declaration; refusing to kill"
                 ),
             )
-        _pid.clear(declaration.name)
+        _pid.clear(declaration.name, declaration.port)
         return ActionResult(ok=True, detail="already stopped")
 
     # Send SIGTERM, then poll for the port to unbind.
@@ -178,7 +199,7 @@ def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
         KILL(target_pid, signal.SIGTERM)
     except ProcessLookupError:
         # Process died between read() and kill() — treat as success
-        _pid.clear(declaration.name)
+        _pid.clear(declaration.name, declaration.port)
         return ActionResult(ok=True, detail="already stopped (race)")
     except OSError as err:
         return ActionResult(
@@ -187,8 +208,8 @@ def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
         )
 
     result = probe(detection, desired="down", budget_seconds=5.0)
-    if result.status in ("down", "absent"):
-        _pid.clear(declaration.name)
+    if result.status == "absent":
+        _pid.clear(declaration.name, declaration.port)
         suffix = "" if source == "pid-file" else f" (found via {source})"
         return ActionResult(ok=True, detail=f"stopped (SIGTERM){suffix}", pid=target_pid)
 
@@ -196,14 +217,14 @@ def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
     try:
         KILL(target_pid, signal.SIGKILL)
     except ProcessLookupError:
-        _pid.clear(declaration.name)
+        _pid.clear(declaration.name, declaration.port)
         return ActionResult(ok=True, detail="stopped (SIGTERM, race on SIGKILL)", pid=target_pid)
     except OSError as err:
         return ActionResult(ok=False, detail=f"SIGKILL failed (pid={target_pid}): {err}")
 
     result = probe(detection, desired="down", budget_seconds=2.0)
-    if result.status in ("down", "absent"):
-        _pid.clear(declaration.name)
+    if result.status == "absent":
+        _pid.clear(declaration.name, declaration.port)
         return ActionResult(
             ok=True,
             detail="stopped (SIGKILL after timeout)",
@@ -219,7 +240,7 @@ def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
 def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
     """`stop` then `start`. New spawn uses current `declaration.command`."""
     # Detect drift before stop (so we can log against the existing log file).
-    record = _pid.read(declaration.name)
+    record = _pid.read(declaration.name, declaration.port)
     if record is not None and tuple(record.argv) != tuple(declaration.command or ()):
         try:
             log_path = path_for(declaration.name)

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -15,6 +15,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+from auntiepypi._actions import _pid
 from auntiepypi._actions._action import ActionResult
 from auntiepypi._actions._logs import path_for
 from auntiepypi._actions._reprobe import probe
@@ -66,6 +67,19 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     pid = proc.pid
     result = probe(detection)
     if result.status == "up":
+        # Persist PID + sidecar for future `auntie down` / `restart`.
+        try:
+            _pid.write(
+                declaration.name,
+                pid=pid,
+                argv=list(declaration.command),
+                port=declaration.port,
+            )
+        except OSError:
+            # PID file write failed; the start itself succeeded so we keep
+            # ok=True. The fallback path-walk in `command.stop` will still
+            # find the process by port + argv match.
+            pass
         return ActionResult(
             ok=True,
             detail="started",

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -146,23 +147,23 @@ def _resolve_target_pid(declaration: ServerSpec) -> tuple[int | None, str]:
     the port-walk fallback.
     """
     record = _pid.read(declaration.name, declaration.port)
-    if record is not None:
-        if declaration.command:
-            verified = _pid.find_by_port(
-                declaration.port,
-                expected_argv=list(declaration.command),
-            )
-            # If find_by_port returns None on non-Linux, trust the PID
-            # file (best we can do without /proc). On Linux, require the
-            # PID file's PID to match the actual listener.
-            import sys as _sys
-
-            if _sys.platform == "linux" and verified is not None and verified != record.pid:
-                # Stale-but-live PID in the file; the actual listener is a
-                # different process. Clear and fall through.
-                _pid.clear(declaration.name, declaration.port)
-            else:
-                return record.pid, "pid-file"
+    if record is not None and declaration.command:
+        verified = _pid.find_by_port(
+            declaration.port,
+            expected_argv=list(declaration.command),
+        )
+        # If find_by_port returns None on non-Linux, trust the PID
+        # file (best we can do without /proc). On Linux, require the
+        # PID file's PID to match the actual listener.
+        if sys.platform == "linux" and verified is not None and verified != record.pid:
+            # Stale-but-live PID in the file; the actual listener is a
+            # different process. Clear and fall through.
+            _pid.clear(declaration.name, declaration.port)
+        else:
+            return record.pid, "pid-file"
+    elif record is not None:
+        # No declared command to verify against; trust the record.
+        return record.pid, "pid-file"
     if declaration.command:
         pid = _pid.find_by_port(
             declaration.port,

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -1,17 +1,28 @@
 """Strategy for `managed_by = "command"`: detached Popen + sync re-probe.
 
-Spawns the configured argv with `start_new_session=True` (new process
-group, immune to doctor's exit), redirects stdio to
+`start` spawns the configured argv with `start_new_session=True` (new
+process group, immune to doctor's exit), redirects stdio to
 ``$XDG_STATE_HOME/auntiepypi/<slug>.log``, and returns once the
-re-probe loop confirms ``up`` or the 5 s budget is exhausted.
+re-probe loop confirms ``up`` or the 5 s budget is exhausted. On
+success it writes a PID file + sidecar via :mod:`_pid`.
 
-Doctor does NOT track the child past spawn. ``auntie down`` (v0.5.0)
-will own process-tracking.
+`stop` reads the PID file (or falls back to a port-walk + argv-match
+lookup), sends SIGTERM with a 5 s grace, escalates to SIGKILL if the
+port is still bound, then clears the PID file. Idempotent: a missing
+PID file with no listener on the declared port is treated as
+"already stopped."
+
+`restart` is `stop` then `start`. The new spawn re-uses the **current**
+``declaration.command`` from pyproject (not the sidecar argv); drift
+is logged for diagnostics but never blocks the action.
 """
 
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -24,6 +35,9 @@ from auntiepypi._detect._detection import Detection
 
 # Indirection for tests: monkey-patch this to a FakePopen.
 POPEN = subprocess.Popen
+# Indirection for tests: monkey-patch to capture signal calls without
+# affecting real processes.
+KILL = os.kill
 
 
 def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
@@ -121,13 +135,113 @@ def _spawn_error(err: OSError, declaration: ServerSpec, log_path: Path) -> Actio
     return ActionResult(ok=False, detail=detail, log_path=str(log_path))
 
 
+def _resolve_target_pid(declaration: ServerSpec) -> tuple[int | None, str]:
+    """Find the PID to signal. Returns (pid, source) where source is
+    "pid-file" or "port-walk", or (None, "") when no target is found.
+    """
+    record = _pid.read(declaration.name)
+    if record is not None:
+        return record.pid, "pid-file"
+    if declaration.command:
+        pid = _pid.find_by_port(
+            declaration.port,
+            expected_argv=list(declaration.command),
+        )
+        if pid is not None:
+            return pid, "port-walk"
+    return None, ""
+
+
 def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
-    """Stop a `managed_by=command` server. Implementation lands in task 6."""
-    _ = (detection, declaration)
-    return ActionResult(ok=False, detail="command.stop not yet implemented")
+    """SIGTERM the tracked process; SIGKILL escalation; clear PID file."""
+    target_pid, source = _resolve_target_pid(declaration)
+
+    if target_pid is None:
+        # No PID file AND port-walk found no argv-matching listener.
+        # Distinguish "nothing listening" from "something listening but
+        # wrong argv": if the port is currently up, refuse to kill (a
+        # different process owns it); otherwise treat as already-stopped.
+        liveness = probe(detection, desired="up", budget_seconds=0.5)
+        if liveness.status == "up":
+            return ActionResult(
+                ok=False,
+                detail=(
+                    f"port {declaration.port} listener argv does not match "
+                    f"declaration; refusing to kill"
+                ),
+            )
+        _pid.clear(declaration.name)
+        return ActionResult(ok=True, detail="already stopped")
+
+    # Send SIGTERM, then poll for the port to unbind.
+    try:
+        KILL(target_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        # Process died between read() and kill() — treat as success
+        _pid.clear(declaration.name)
+        return ActionResult(ok=True, detail="already stopped (race)")
+    except OSError as err:
+        return ActionResult(
+            ok=False,
+            detail=f"SIGTERM failed (pid={target_pid}): {err}",
+        )
+
+    result = probe(detection, desired="down", budget_seconds=5.0)
+    if result.status in ("down", "absent"):
+        _pid.clear(declaration.name)
+        suffix = "" if source == "pid-file" else f" (found via {source})"
+        return ActionResult(ok=True, detail=f"stopped (SIGTERM){suffix}", pid=target_pid)
+
+    # Still up after 5s grace — escalate to SIGKILL.
+    try:
+        KILL(target_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        _pid.clear(declaration.name)
+        return ActionResult(ok=True, detail="stopped (SIGTERM, race on SIGKILL)", pid=target_pid)
+    except OSError as err:
+        return ActionResult(ok=False, detail=f"SIGKILL failed (pid={target_pid}): {err}")
+
+    result = probe(detection, desired="down", budget_seconds=2.0)
+    if result.status in ("down", "absent"):
+        _pid.clear(declaration.name)
+        return ActionResult(
+            ok=True,
+            detail="stopped (SIGKILL after timeout)",
+            pid=target_pid,
+        )
+    return ActionResult(
+        ok=False,
+        detail=f"SIGKILL sent but port still bound after 2s (pid={target_pid})",
+        pid=target_pid,
+    )
 
 
 def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
-    """Restart a `managed_by=command` server. Implementation lands in task 7."""
-    _ = (detection, declaration)
-    return ActionResult(ok=False, detail="command.restart not yet implemented")
+    """`stop` then `start`. New spawn uses current `declaration.command`."""
+    # Detect drift before stop (so we can log against the existing log file).
+    record = _pid.read(declaration.name)
+    if record is not None and tuple(record.argv) != tuple(declaration.command or ()):
+        try:
+            log_path = path_for(declaration.name)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, "ab") as logf:
+                logf.write(
+                    (
+                        f"\n=== {datetime.now(timezone.utc).isoformat()}: "
+                        f"argv changed since last start ===\n"
+                        f"prev: {list(record.argv)}\n"
+                        f"cur:  {list(declaration.command or [])}\n"
+                    ).encode()
+                )
+        except OSError:
+            pass
+
+    stop_result = stop(detection, declaration)
+    if not stop_result.ok:
+        # Couldn't stop — surface that error; don't try to start on top.
+        return stop_result
+
+    # Stop succeeded (or was a no-op). Pause briefly to let the OS reclaim
+    # the port before we start a fresh listener.
+    time.sleep(0.05)
+    return start(detection, declaration)

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -25,7 +25,7 @@ from auntiepypi._detect._detection import Detection
 POPEN = subprocess.Popen
 
 
-def apply(detection: Detection, declaration: ServerSpec) -> ActionResult:
+def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     """Spawn the command, re-probe, return result. See module docstring."""
     if not declaration.command:
         return ActionResult(ok=False, detail="managed_by=command but `command` not set")
@@ -105,3 +105,15 @@ def _spawn_error(err: OSError, declaration: ServerSpec, log_path: Path) -> Actio
     else:
         detail = f"{type(err).__name__}: {err}"
     return ActionResult(ok=False, detail=detail, log_path=str(log_path))
+
+
+def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    """Stop a `managed_by=command` server. Implementation lands in task 6."""
+    _ = (detection, declaration)
+    return ActionResult(ok=False, detail="command.stop not yet implemented")
+
+
+def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    """Restart a `managed_by=command` server. Implementation lands in task 7."""
+    _ = (detection, declaration)
+    return ActionResult(ok=False, detail="command.restart not yet implemented")

--- a/auntiepypi/_actions/systemd_user.py
+++ b/auntiepypi/_actions/systemd_user.py
@@ -20,7 +20,7 @@ from auntiepypi._detect._detection import Detection
 RUN: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
 
 
-def apply(detection: Detection, declaration: ServerSpec) -> ActionResult:
+def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     """Run `systemctl --user start <unit>`, then re-probe."""
     if not declaration.unit:
         return ActionResult(ok=False, detail="managed_by=systemd-user but `unit` not set")
@@ -62,3 +62,15 @@ def apply(detection: Detection, declaration: ServerSpec) -> ActionResult:
             f"(check unit logs: journalctl --user -u {declaration.unit})"
         ),
     )
+
+
+def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    """Stop a `managed_by=systemd-user` server. Implementation lands in task 8."""
+    _ = (detection, declaration)
+    return ActionResult(ok=False, detail="systemd_user.stop not yet implemented")
+
+
+def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    """Restart a `managed_by=systemd-user` server. Implementation lands in task 9."""
+    _ = (detection, declaration)
+    return ActionResult(ok=False, detail="systemd_user.restart not yet implemented")

--- a/auntiepypi/_actions/systemd_user.py
+++ b/auntiepypi/_actions/systemd_user.py
@@ -19,11 +19,15 @@ from auntiepypi._detect._detection import Detection
 # Indirection for tests.
 RUN: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
 
+_UNIT_REQUIRED = "managed_by=systemd-user but `unit` not set"
+_SYSTEMCTL_NOT_FOUND = "systemctl not found; install systemd-user or use managed_by=command"
+_SYSTEMCTL_TIMEOUT = "systemctl timed out"
+
 
 def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     """Run `systemctl --user start <unit>`, then re-probe."""
     if not declaration.unit:
-        return ActionResult(ok=False, detail="managed_by=systemd-user but `unit` not set")
+        return ActionResult(ok=False, detail=_UNIT_REQUIRED)
 
     try:
         completed = RUN(
@@ -36,10 +40,10 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     except FileNotFoundError:
         return ActionResult(
             ok=False,
-            detail="systemctl not found; install systemd-user or use managed_by=command",
+            detail=_SYSTEMCTL_NOT_FOUND,
         )
     except subprocess.TimeoutExpired:
-        return ActionResult(ok=False, detail="systemctl timed out")
+        return ActionResult(ok=False, detail=_SYSTEMCTL_TIMEOUT)
     except (OSError, subprocess.SubprocessError) as err:
         return ActionResult(ok=False, detail=f"{type(err).__name__}: {err}")
 
@@ -77,10 +81,10 @@ def _run_systemctl(unit: str, verb: str) -> ActionResult | subprocess.CompletedP
     except FileNotFoundError:
         return ActionResult(
             ok=False,
-            detail="systemctl not found; install systemd-user or use managed_by=command",
+            detail=_SYSTEMCTL_NOT_FOUND,
         )
     except subprocess.TimeoutExpired:
-        return ActionResult(ok=False, detail="systemctl timed out")
+        return ActionResult(ok=False, detail=_SYSTEMCTL_TIMEOUT)
     except (OSError, subprocess.SubprocessError) as err:
         return ActionResult(ok=False, detail=f"{type(err).__name__}: {err}")
     return completed
@@ -98,7 +102,7 @@ def _systemctl_failure_detail(completed: subprocess.CompletedProcess[str]) -> st
 def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
     """Run `systemctl --user stop <unit>`, then re-probe with desired=down."""
     if not declaration.unit:
-        return ActionResult(ok=False, detail="managed_by=systemd-user but `unit` not set")
+        return ActionResult(ok=False, detail=_UNIT_REQUIRED)
 
     completed = _run_systemctl(declaration.unit, "stop")
     if isinstance(completed, ActionResult):
@@ -121,7 +125,7 @@ def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
 def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
     """Run `systemctl --user restart <unit>` (atomic), then re-probe with desired=up."""
     if not declaration.unit:
-        return ActionResult(ok=False, detail="managed_by=systemd-user but `unit` not set")
+        return ActionResult(ok=False, detail=_UNIT_REQUIRED)
 
     completed = _run_systemctl(declaration.unit, "restart")
     if isinstance(completed, ActionResult):

--- a/auntiepypi/_actions/systemd_user.py
+++ b/auntiepypi/_actions/systemd_user.py
@@ -64,13 +64,78 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     )
 
 
+def _run_systemctl(unit: str, verb: str) -> ActionResult | subprocess.CompletedProcess[str]:
+    """Wrap `systemctl --user <verb> <unit>`; map exec-time errors to ActionResult."""
+    try:
+        completed = RUN(
+            ["systemctl", "--user", verb, unit],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        return ActionResult(
+            ok=False,
+            detail="systemctl not found; install systemd-user or use managed_by=command",
+        )
+    except subprocess.TimeoutExpired:
+        return ActionResult(ok=False, detail="systemctl timed out")
+    except (OSError, subprocess.SubprocessError) as err:
+        return ActionResult(ok=False, detail=f"{type(err).__name__}: {err}")
+    return completed
+
+
+def _systemctl_failure_detail(completed: subprocess.CompletedProcess[str]) -> str:
+    """Format a non-zero systemctl exit into a one-line detail."""
+    first_line = (completed.stderr or completed.stdout or "").strip().splitlines()
+    snippet = first_line[0] if first_line else ""
+    if snippet:
+        return f"systemctl exit {completed.returncode}: {snippet}"
+    return f"systemctl exit {completed.returncode}"
+
+
 def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
-    """Stop a `managed_by=systemd-user` server. Implementation lands in task 8."""
-    _ = (detection, declaration)
-    return ActionResult(ok=False, detail="systemd_user.stop not yet implemented")
+    """Run `systemctl --user stop <unit>`, then re-probe with desired=down."""
+    if not declaration.unit:
+        return ActionResult(ok=False, detail="managed_by=systemd-user but `unit` not set")
+
+    completed = _run_systemctl(declaration.unit, "stop")
+    if isinstance(completed, ActionResult):
+        return completed
+    if completed.returncode != 0:
+        return ActionResult(ok=False, detail=_systemctl_failure_detail(completed))
+
+    result = probe(detection, desired="down")
+    if result.status in ("down", "absent"):
+        return ActionResult(ok=True, detail="stopped")
+    return ActionResult(
+        ok=False,
+        detail=(
+            "systemctl ok but server still responding "
+            f"(check unit logs: journalctl --user -u {declaration.unit})"
+        ),
+    )
 
 
 def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
-    """Restart a `managed_by=systemd-user` server. Implementation lands in task 9."""
-    _ = (detection, declaration)
-    return ActionResult(ok=False, detail="systemd_user.restart not yet implemented")
+    """Run `systemctl --user restart <unit>` (atomic), then re-probe with desired=up."""
+    if not declaration.unit:
+        return ActionResult(ok=False, detail="managed_by=systemd-user but `unit` not set")
+
+    completed = _run_systemctl(declaration.unit, "restart")
+    if isinstance(completed, ActionResult):
+        return completed
+    if completed.returncode != 0:
+        return ActionResult(ok=False, detail=_systemctl_failure_detail(completed))
+
+    result = probe(detection)
+    if result.status == "up":
+        return ActionResult(ok=True, detail="restarted")
+    return ActionResult(
+        ok=False,
+        detail=(
+            "systemctl ok but server not responding after restart "
+            f"(check unit logs: journalctl --user -u {declaration.unit})"
+        ),
+    )

--- a/auntiepypi/cli/__init__.py
+++ b/auntiepypi/cli/__init__.py
@@ -17,9 +17,12 @@ import sys
 
 from auntiepypi import __version__
 from auntiepypi.cli._commands import doctor as _doctor_cmd
+from auntiepypi.cli._commands import down as _down_cmd
 from auntiepypi.cli._commands import explain as _explain_cmd
 from auntiepypi.cli._commands import learn as _learn_cmd
 from auntiepypi.cli._commands import overview as _overview_cmd
+from auntiepypi.cli._commands import restart as _restart_cmd
+from auntiepypi.cli._commands import up as _up_cmd
 from auntiepypi.cli._commands import whoami as _whoami_cmd
 from auntiepypi.cli._errors import EXIT_USER_ERROR, AfiError
 from auntiepypi.cli._output import emit_error
@@ -55,6 +58,9 @@ def _build_parser() -> argparse.ArgumentParser:
     _explain_cmd.register(sub)
     _overview_cmd.register(sub)
     _doctor_cmd.register(sub)
+    _up_cmd.register(sub)
+    _down_cmd.register(sub)
+    _restart_cmd.register(sub)
     _whoami_cmd.register(sub)
 
     return parser

--- a/auntiepypi/cli/_commands/_lifecycle.py
+++ b/auntiepypi/cli/_commands/_lifecycle.py
@@ -90,7 +90,8 @@ def _resolve_one_spec(target: str, specs: list[ServerSpec], decisions: Decisions
         raise AfiError(
             code=EXIT_USER_ERROR,
             message=(
-                f"target {target!r} is ambiguous " f"({len(matching)} declarations share the name)"
+                f"target {target!r} is ambiguous "
+                + f"({len(matching)} declarations share the name)"
             ),
             remediation=f"re-run with --decide=duplicate:{target}{options}",
         )
@@ -169,6 +170,44 @@ def _render_text(verb: str, results: list[tuple[str, ActionResult]]) -> str:
     return f"auntie {verb}:\n" + "\n".join(lines)
 
 
+def _bare_invocation_error(verb: str) -> AfiError:
+    return AfiError(
+        code=EXIT_USER_ERROR,
+        message=_bare_invocation_message(verb),
+        remediation=(
+            f"give a server name (`auntie {verb} <name>`) or use "
+            f"`auntie {verb} --all` to act on every supervised declaration"
+        ),
+    )
+
+
+def _collect_pairs(
+    target: str | None,
+    all_servers: bool,
+    cfg,
+    detections: list[Detection],
+    decisions: Decisions,
+    skipped: list[ServerSpec],
+) -> list[_Pair]:
+    """Build the (name, detection, spec) list for the lifecycle dispatch loop."""
+    if all_servers:
+        return [
+            _Pair(name=s.name, detection=_detection_for_spec(detections, s), spec=s)
+            for s in _supervised_specs(cfg.specs, skipped_out=skipped)
+        ]
+    spec = _resolve_one_spec(target or "", cfg.specs, decisions)
+    if (spec.managed_by or "manual") not in SUPERVISED_MODES:
+        _refuse_unsupervised(spec)
+    return [_Pair(name=spec.name, detection=_detection_for_spec(detections, spec), spec=spec)]
+
+
+def _emit_lifecycle_output(
+    verb: str, results: list[tuple[str, ActionResult]], *, json_mode: bool
+) -> None:
+    payload = _build_payload(verb, results) if json_mode else _render_text(verb, results)
+    emit_result(payload, json_mode=json_mode)
+
+
 def run_lifecycle(args: argparse.Namespace, *, verb: str, action: Action) -> int:
     """Shared entry point for the three lifecycle verbs."""
     target = getattr(args, "target", None)
@@ -177,40 +216,19 @@ def run_lifecycle(args: argparse.Namespace, *, verb: str, action: Action) -> int
     decisions = parse_decisions(getattr(args, "decide", None) or [])
 
     if target is None and not all_servers:
-        raise AfiError(
-            code=EXIT_USER_ERROR,
-            message=_bare_invocation_message(verb),
-            remediation=(
-                f"give a server name (`auntie {verb} <name>`) or use "
-                f"`auntie {verb} --all` to act on every supervised declaration"
-            ),
-        )
+        raise _bare_invocation_error(verb)
 
     cfg, _gaps = load_servers_lenient()
     detections = detect_all(cfg)
 
-    pairs: list[_Pair] = []
     skipped: list[ServerSpec] = []
-    if all_servers:
-        for spec in _supervised_specs(cfg.specs, skipped_out=skipped):
-            det = _detection_for_spec(detections, spec)
-            pairs.append(_Pair(name=spec.name, detection=det, spec=spec))
-    else:
-        spec = _resolve_one_spec(target or "", cfg.specs, decisions)
-        if (spec.managed_by or "manual") not in SUPERVISED_MODES:
-            _refuse_unsupervised(spec)
-        det = _detection_for_spec(detections, spec)
-        pairs.append(_Pair(name=spec.name, detection=det, spec=spec))
+    pairs = _collect_pairs(target, all_servers, cfg, detections, decisions, skipped)
 
-    results: list[tuple[str, ActionResult]] = []
-    for pair in pairs:
-        res = _actions.dispatch(action, pair.detection, pair.spec)
-        results.append((pair.name, res))
+    results: list[tuple[str, ActionResult]] = [
+        (pair.name, _actions.dispatch(action, pair.detection, pair.spec)) for pair in pairs
+    ]
 
-    if json_mode:
-        emit_result(_build_payload(verb, results), json_mode=True)
-    else:
-        emit_result(_render_text(verb, results), json_mode=False)
+    _emit_lifecycle_output(verb, results, json_mode=json_mode)
 
     if all_servers and skipped:
         from auntiepypi.cli._output import emit_diagnostic

--- a/auntiepypi/cli/_commands/_lifecycle.py
+++ b/auntiepypi/cli/_commands/_lifecycle.py
@@ -1,0 +1,246 @@
+"""Shared core for the v0.5.0 lifecycle verbs (`up`, `down`, `restart`).
+
+All three verbs share resolution logic, supervision filtering, exit-code
+derivation, and output shape. Each verb-specific module is a thin
+wrapper that supplies its action ("start", "stop", "restart") and a few
+strings for help text.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Literal
+
+from auntiepypi import _actions
+from auntiepypi._actions._action import ActionResult
+from auntiepypi._detect import detect_all
+from auntiepypi._detect._config import ServerSpec, load_servers_lenient
+from auntiepypi._detect._detection import Detection
+from auntiepypi.cli._commands._decide import Decisions, parse_decisions
+from auntiepypi.cli._errors import EXIT_ENV_ERROR, EXIT_SUCCESS, EXIT_USER_ERROR, AfiError
+from auntiepypi.cli._output import emit_result
+
+Action = Literal["start", "stop", "restart"]
+SUPERVISED_MODES: frozenset[str] = frozenset({"systemd-user", "command"})
+
+
+@dataclass(frozen=True)
+class _Pair:
+    """One target to act on."""
+
+    name: str
+    detection: Detection
+    spec: ServerSpec
+
+
+def _bare_invocation_message(verb: str) -> str:
+    """The forward-pointing error for `auntie up` / `auntie down` /
+    `auntie restart` invoked with no target and no --all.
+    """
+    return (
+        f"auntie {verb}: the first-party auntie server lands in v0.6.0; for now "
+        f"use `auntie {verb} <name>` or `auntie {verb} --all`"
+    )
+
+
+def _detection_for_spec(detections: list[Detection], spec: ServerSpec) -> Detection:
+    """Pair each spec with its matching detection; synthesize one if missing."""
+    for det in detections:
+        if det.name == spec.name and det.source == "declared":
+            return det
+    # Fallback: build a synthetic Detection from the spec. detect_all
+    # already covers this for known declarations, but if the user adds a
+    # declaration after `auntie overview` ran, this keeps the action path
+    # robust.
+    return Detection(
+        name=spec.name,
+        flavor=spec.flavor or "unknown",
+        host=spec.host or "127.0.0.1",
+        port=spec.port,
+        url=f"http://{spec.host or '127.0.0.1'}:{spec.port}/",
+        status="absent",
+        source="declared",
+    )
+
+
+def _resolve_one_spec(target: str, specs: list[ServerSpec], decisions: Decisions) -> ServerSpec:
+    """Resolve one ``<name>`` argument against `specs`, with duplicate handling."""
+    matching = [s for s in specs if s.name == target]
+    if not matching:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"unknown TARGET {target!r}",
+            remediation=(
+                "list declared servers with `auntie overview`; "
+                "names come from [[tool.auntiepypi.servers]].name"
+            ),
+        )
+    if len(matching) == 1:
+        return matching[0]
+    # Ambiguous: require --decide=duplicate:NAME=N
+    decided = decisions.for_key("duplicate", target)
+    if decided is None:
+        options = " or ".join(f"={i + 1}" for i in range(len(matching)))
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"target {target!r} is ambiguous " f"({len(matching)} declarations share the name)"
+            ),
+            remediation=f"re-run with --decide=duplicate:{target}{options}",
+        )
+    idx_1based = int(decided)
+    if idx_1based < 1 or idx_1based > len(matching):
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"--decide=duplicate:{target}={decided}: index out of range "
+                f"(expected 1..{len(matching)})"
+            ),
+            remediation="run `auntie overview` to count declarations",
+        )
+    return matching[idx_1based - 1]
+
+
+def _supervised_specs(
+    specs: list[ServerSpec],
+    *,
+    skipped_out: list[ServerSpec] | None = None,
+) -> list[ServerSpec]:
+    """Filter to supervised modes; record skipped specs in `skipped_out` if given."""
+    out: list[ServerSpec] = []
+    for s in specs:
+        if (s.managed_by or "manual") in SUPERVISED_MODES:
+            out.append(s)
+        elif skipped_out is not None:
+            skipped_out.append(s)
+    return out
+
+
+def _refuse_unsupervised(spec: ServerSpec) -> None:
+    """Raise AfiError(EXIT_USER_ERROR) when an explicit target isn't supervised."""
+    mode = spec.managed_by or "manual"
+    raise AfiError(
+        code=EXIT_USER_ERROR,
+        message=(
+            f"server {spec.name!r} has managed_by={mode!r} — auntie does not "
+            f"supervise this mode; lifecycle verbs are no-ops"
+        ),
+        remediation=(
+            "use a supervised mode (systemd-user or command) in "
+            "[[tool.auntiepypi.servers]] if you want auntie to act on this server"
+        ),
+    )
+
+
+def _build_payload(verb: str, results: list[tuple[str, ActionResult]]) -> dict:
+    """Uniform JSON envelope for up/down/restart."""
+    return {
+        "verb": verb,
+        "results": [
+            {
+                "name": name,
+                "ok": res.ok,
+                "detail": res.detail,
+                **({"pid": res.pid} if res.pid is not None else {}),
+                **({"log_path": res.log_path} if res.log_path else {}),
+            }
+            for name, res in results
+        ],
+    }
+
+
+def _render_text(verb: str, results: list[tuple[str, ActionResult]]) -> str:
+    """Plain-text rendering of the lifecycle payload."""
+    if not results:
+        return f"auntie {verb}: nothing to do"
+    lines: list[str] = []
+    for name, res in results:
+        marker = "ok" if res.ok else "FAIL"
+        line = f"  [{marker}] {name}: {res.detail}"
+        if res.pid is not None:
+            line += f"  (pid={res.pid})"
+        lines.append(line)
+    return f"auntie {verb}:\n" + "\n".join(lines)
+
+
+def run_lifecycle(args: argparse.Namespace, *, verb: str, action: Action) -> int:
+    """Shared entry point for the three lifecycle verbs."""
+    target = getattr(args, "target", None)
+    all_servers = bool(getattr(args, "all_servers", False))
+    json_mode = bool(getattr(args, "json", False))
+    decisions = parse_decisions(getattr(args, "decide", None) or [])
+
+    if target is None and not all_servers:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=_bare_invocation_message(verb),
+            remediation=(
+                f"give a server name (`auntie {verb} <name>`) or use "
+                f"`auntie {verb} --all` to act on every supervised declaration"
+            ),
+        )
+
+    cfg, _gaps = load_servers_lenient()
+    detections = detect_all(cfg)
+
+    pairs: list[_Pair] = []
+    skipped: list[ServerSpec] = []
+    if all_servers:
+        for spec in _supervised_specs(cfg.specs, skipped_out=skipped):
+            det = _detection_for_spec(detections, spec)
+            pairs.append(_Pair(name=spec.name, detection=det, spec=spec))
+    else:
+        spec = _resolve_one_spec(target or "", cfg.specs, decisions)
+        if (spec.managed_by or "manual") not in SUPERVISED_MODES:
+            _refuse_unsupervised(spec)
+        det = _detection_for_spec(detections, spec)
+        pairs.append(_Pair(name=spec.name, detection=det, spec=spec))
+
+    results: list[tuple[str, ActionResult]] = []
+    for pair in pairs:
+        res = _actions.dispatch(action, pair.detection, pair.spec)
+        results.append((pair.name, res))
+
+    if json_mode:
+        emit_result(_build_payload(verb, results), json_mode=True)
+    else:
+        emit_result(_render_text(verb, results), json_mode=False)
+
+    if all_servers and skipped:
+        from auntiepypi.cli._output import emit_diagnostic
+
+        names = ", ".join(f"{s.name} (managed_by={s.managed_by or 'manual'})" for s in skipped)
+        emit_diagnostic(f"auntie {verb}: skipped {len(skipped)} unsupervised: {names}")
+
+    if any(not r[1].ok for r in results):
+        # Don't raise — exit 2 cleanly. Output already emitted.
+        return EXIT_ENV_ERROR
+    return EXIT_SUCCESS
+
+
+def add_lifecycle_parser(
+    sub: argparse._SubParsersAction, *, verb: str, help_summary: str
+) -> argparse.ArgumentParser:
+    """Build a subparser shape that's identical across up/down/restart."""
+    p = sub.add_parser(verb, help=help_summary)
+    p.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        help="server name; omit and pass --all to act on every supervised declaration",
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_servers",
+        help="act on every supervised declaration (managed_by=systemd-user|command)",
+    )
+    p.add_argument(
+        "--decide",
+        action="append",
+        default=[],
+        help="resolve ambiguity, e.g. duplicate:NAME=N",
+    )
+    p.add_argument("--json", action="store_true", help="emit structured JSON")
+    return p

--- a/auntiepypi/cli/_commands/_lifecycle.py
+++ b/auntiepypi/cli/_commands/_lifecycle.py
@@ -53,12 +53,17 @@ def _detection_for_spec(detections: list[Detection], spec: ServerSpec) -> Detect
     # already covers this for known declarations, but if the user adds a
     # declaration after `auntie overview` ran, this keeps the action path
     # robust.
+    host = spec.host or "127.0.0.1"
+    # HTTP is by design here (matches _detect/_proc.py:169 and the rest
+    # of the detection layer). HTTPS is deferred to v0.6.0+; see
+    # docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-...md.
+    url = f"http://{host}:{spec.port}/"  # NOSONAR python:S5332
     return Detection(
         name=spec.name,
         flavor=spec.flavor or "unknown",
-        host=spec.host or "127.0.0.1",
+        host=host,
         port=spec.port,
-        url=f"http://{spec.host or '127.0.0.1'}:{spec.port}/",
+        url=url,
         status="absent",
         source="declared",
     )
@@ -124,7 +129,7 @@ def _refuse_unsupervised(spec: ServerSpec) -> None:
         code=EXIT_USER_ERROR,
         message=(
             f"server {spec.name!r} has managed_by={mode!r} — auntie does not "
-            f"supervise this mode; lifecycle verbs are no-ops"
+            f"supervise this mode; refusing lifecycle operation"
         ),
         remediation=(
             "use a supervised mode (systemd-user or command) in "

--- a/auntiepypi/cli/_commands/doctor.py
+++ b/auntiepypi/cli/_commands/doctor.py
@@ -206,7 +206,7 @@ def _dispatch_actionable(items: list[_Item]) -> dict[str, ActionResult]:
     for it in items:
         if it.action_class != "actionable" or it.spec is None:
             continue
-        result = _actions.dispatch(it.detection, it.spec)
+        result = _actions.dispatch("start", it.detection, it.spec)
         results[it.detection.name] = result
         if result.ok:
             # Strategy's re-probe confirmed the server is now up. Reflect

--- a/auntiepypi/cli/_commands/down.py
+++ b/auntiepypi/cli/_commands/down.py
@@ -1,0 +1,20 @@
+"""``auntie down`` — stop a declared server (or all supervised, with --all)."""
+
+from __future__ import annotations
+
+import argparse
+
+from auntiepypi.cli._commands._lifecycle import add_lifecycle_parser, run_lifecycle
+
+
+def cmd_down(args: argparse.Namespace) -> int:
+    return run_lifecycle(args, verb="down", action="stop")
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = add_lifecycle_parser(
+        sub,
+        verb="down",
+        help_summary="Stop a declared server (or all supervised with --all).",
+    )
+    p.set_defaults(func=cmd_down)

--- a/auntiepypi/cli/_commands/learn.py
+++ b/auntiepypi/cli/_commands/learn.py
@@ -41,6 +41,15 @@ Commands
     [--decide KEY=VALUE]       supervised entries. --decide resolves
                                ambiguous cases (duplicate names). Default
                                is dry-run. Supports --json.
+  auntie up <name>|--all       Start a declared server (or every supervised
+                               one). Bare `auntie up` is reserved for
+                               v0.6.0's first-party server. Supports --json.
+  auntie down <name>|--all     Stop a declared server (or every supervised
+                               one). Same bare-form reservation as `up`.
+                               Supports --json.
+  auntie restart <name>|--all  Restart a declared server (atomic for
+                               systemd-user; stop+start for command).
+                               Same bare-form reservation. Supports --json.
   auntie whoami                Auth/env probe — which PyPI / TestPyPI /
                                local index is the active environment
                                pointing at? Supports --json.
@@ -74,7 +83,8 @@ Exit-code policy
   0 success / dry-run / ambiguous --decide deferred / unknown TARGET
   1 configuration or usage error (cross-field validation, unknown --decide key,
     unparseable block, .bak slot exhaustion)
-  2 --apply ran but at least one actionable server is still not up
+  2 --apply ran but at least one actionable server is still not up;
+    or `up` / `down` / `restart` failed for at least one targeted server
 
 More detail
 -----------
@@ -107,6 +117,28 @@ def _as_json_payload() -> dict[str, object]:
                 "summary": (
                     "Diagnose declared inventory; --apply to act (start servers, "
                     "delete half-supervised). Use --decide for ambiguous duplicates."
+                ),
+            },
+            {
+                "path": ["up"],
+                "summary": (
+                    "Start a declared server (one by name; --all for every "
+                    "supervised). Bare `auntie up` reserved for v0.6.0's "
+                    "first-party server."
+                ),
+            },
+            {
+                "path": ["down"],
+                "summary": (
+                    "Stop a declared server (one by name; --all for every "
+                    "supervised). PID-tracked for managed_by=command."
+                ),
+            },
+            {
+                "path": ["restart"],
+                "summary": (
+                    "Restart a declared server. Atomic for systemd-user; "
+                    "stop+start for command (re-spawn from current pyproject argv)."
                 ),
             },
             {

--- a/auntiepypi/cli/_commands/restart.py
+++ b/auntiepypi/cli/_commands/restart.py
@@ -1,0 +1,20 @@
+"""``auntie restart`` — restart a declared server (or all supervised, with --all)."""
+
+from __future__ import annotations
+
+import argparse
+
+from auntiepypi.cli._commands._lifecycle import add_lifecycle_parser, run_lifecycle
+
+
+def cmd_restart(args: argparse.Namespace) -> int:
+    return run_lifecycle(args, verb="restart", action="restart")
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = add_lifecycle_parser(
+        sub,
+        verb="restart",
+        help_summary="Restart a declared server (or all supervised with --all).",
+    )
+    p.set_defaults(func=cmd_restart)

--- a/auntiepypi/cli/_commands/up.py
+++ b/auntiepypi/cli/_commands/up.py
@@ -1,0 +1,20 @@
+"""``auntie up`` — start a declared server (or all supervised, with --all)."""
+
+from __future__ import annotations
+
+import argparse
+
+from auntiepypi.cli._commands._lifecycle import add_lifecycle_parser, run_lifecycle
+
+
+def cmd_up(args: argparse.Namespace) -> int:
+    return run_lifecycle(args, verb="up", action="start")
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = add_lifecycle_parser(
+        sub,
+        verb="up",
+        help_summary="Start a declared server (or all supervised with --all).",
+    )
+    p.set_defaults(func=cmd_up)

--- a/auntiepypi/explain/catalog.py
+++ b/auntiepypi/explain/catalog.py
@@ -29,6 +29,15 @@ locally. Informational, not gating.
 - `auntie doctor [TARGET] [--apply] [--decide KEY=VALUE] [--json]` —
   probe + diagnose declared inventory; `--apply` starts servers and
   deletes half-supervised entries; `--decide` resolves ambiguous cases.
+- `auntie up <name> | --all` — start a declared server (or every
+  supervised one). Bare `auntie up` is reserved for v0.6.0's
+  first-party server.
+- `auntie down <name> | --all` — stop a declared server (or every
+  supervised one). For `command` strategy: SIGTERM with 5 s grace,
+  SIGKILL fallback.
+- `auntie restart <name> | --all` — atomic restart for `systemd-user`,
+  stop+start for `command`. Always re-spawns from the current
+  `pyproject.toml` argv.
 - `auntie whoami` — auth/env probe; reports configured indexes.
 
 ## Console scripts
@@ -51,6 +60,9 @@ The package installs two scripts that point at the same entry point:
 - `auntie explain explain`
 - `auntie explain overview`
 - `auntie explain doctor`
+- `auntie explain up`
+- `auntie explain down`
+- `auntie explain restart`
 - `auntie explain whoami`
 """
 
@@ -216,6 +228,108 @@ a remediation hint to clean up old `.bak` files.
   `up` after the strategy + re-probe.
 """
 
+_LIFECYCLE_PREAMBLE = """\
+The lifecycle verbs (`up`, `down`, `restart`) operate on declared servers
+in `[[tool.auntiepypi.servers]]` whose `managed_by` is `systemd-user` or
+`command`. Other modes (`manual`, `docker`, `compose`, unset) are
+out-of-scope for v0.5.0 and refused with a clear error.
+
+## Bare invocation reserved
+
+`auntie up` (and `down` / `restart`) with no target and no `--all` is
+reserved for v0.6.0, where it will start auntie's own first-party
+PEP 503 simple-index server. v0.5.0 only accepts the `<name>` and
+`--all` forms.
+
+## Common shape
+
+    auntie <verb>                       # exit 1, "lands in v0.6.0"
+    auntie <verb> <name>                # one declared server
+    auntie <verb> --all                 # every supervised declaration
+    auntie <verb> --json                # JSON envelope
+    auntie <verb> --decide=duplicate:NAME=N <name>
+
+## Exit codes
+
+- `0` — every targeted server reached the desired state
+- `1` — user / config error before any action attempted
+- `2` — at least one targeted server did not reach the desired state
+"""
+
+_UP = """\
+# auntie up
+
+Start a declared server.
+
+%s
+
+## What it does
+
+- `managed_by = "systemd-user"` → `systemctl --user start <unit>` +
+  re-probe (5 s budget; "up" wins).
+- `managed_by = "command"` → detached `Popen` with
+  `start_new_session=True`; logs to
+  `$XDG_STATE_HOME/auntiepypi/<slug>.log`; on success writes
+  `<slug>.pid` + `<slug>.json` sidecar so future `auntie down` /
+  `restart` can find the process.
+- Idempotent: an already-up server is a successful no-op.
+
+## Drift handling
+
+A stale PID file (PID dead) on `up` is silently cleared before the
+fresh spawn.
+""" % _LIFECYCLE_PREAMBLE
+
+_DOWN = """\
+# auntie down
+
+Stop a declared server.
+
+%s
+
+## What it does
+
+- `managed_by = "systemd-user"` → `systemctl --user stop <unit>` +
+  re-probe with `desired="down"`.
+- `managed_by = "command"` → read `<slug>.pid`; SIGTERM; poll the port
+  for up to 5 s; if still bound, SIGKILL with another 2 s grace.
+- Fallback: when no PID file exists (Linux only), walks
+  `/proc/net/tcp` + `/proc/<pid>/fd/*` to find the listener on the
+  declared port. Refuses to kill unless the discovered process's argv
+  matches the declared `command` (footgun guard against killing an
+  unrelated process bound to the same port).
+- Idempotent: nothing-to-stop is `ok=True, detail="already stopped"`.
+
+## When refused
+
+If the port is up but the discovered argv doesn't match, exit `2`
+with `port <N> listener argv does not match declaration; refusing to
+kill`. Inspect with `auntie overview --proc`.
+""" % _LIFECYCLE_PREAMBLE
+
+_RESTART = """\
+# auntie restart
+
+Restart a declared server.
+
+%s
+
+## What it does
+
+- `managed_by = "systemd-user"` → `systemctl --user restart <unit>`
+  (atomic; faster and safer than stop+start).
+- `managed_by = "command"` → `down` then `up`. The new spawn re-uses
+  the **current** `[[tool.auntiepypi.servers]].command`, never the
+  sidecar argv. If the sidecar argv differs from the current spec,
+  a single `argv changed since last start` line is appended to the
+  log (advisory; no failure).
+
+## Drift policy
+
+Source of truth is always current `pyproject.toml`. Edit your
+`command` array, then `auntie restart <name>`.
+""" % _LIFECYCLE_PREAMBLE
+
 _WHOAMI = """\
 # auntie whoami
 
@@ -248,5 +362,8 @@ ENTRIES: dict[tuple[str, ...], str] = {
     ("explain",): _EXPLAIN,
     ("overview",): _OVERVIEW,
     ("doctor",): _DOCTOR,
+    ("up",): _UP,
+    ("down",): _DOWN,
+    ("restart",): _RESTART,
     ("whoami",): _WHOAMI,
 }

--- a/docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md
+++ b/docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md
@@ -1,7 +1,7 @@
 # auntiepypi v0.5.0 — lifecycle verbs (`up` / `down` / `restart`)
 
 **Status:** approved (brainstorm 2026-04-30; plan
-`/home/spark/.claude/plans/dazzling-snacking-kay.md`).
+`$CLAUDE_HOME/plans/dazzling-snacking-kay.md`).
 
 **Predecessor:** `2026-04-30-auntiepypi-v0.4.0-doctor-lifecycle-design.md`.
 
@@ -128,7 +128,7 @@ internal; no public API is affected.
 ### D4. Bare verb reserved for v0.6.0
 
 ```text
-auntie up                  → exit 2; "first-party auntie server lands in
+auntie up                  → exit 1; "first-party auntie server lands in
                                        v0.6.0; for now use `auntie up <name>`
                                        or `auntie up --all`"
 auntie up <name>           → resolve and dispatch("start", ...)
@@ -371,9 +371,9 @@ Inherits the v0.4.0 patterns:
   `command.restart` clean path; argv drift logged; restart-when-down.
 - `tests/test_actions_systemd_user_lifecycle.py` — `stop`, `restart`
   via `RUN` indirection (already used by `start`).
-- `tests/test_cli_{up,down,restart}.py` — bare exit 2;
-  `<name>` happy path; refused `managed_by=manual`; `--all` aggregate
-  exit codes; `--decide` resolution; `--json` shape.
+- `tests/test_cli_{up,down,restart}.py` — bare exit 1
+  (`EXIT_USER_ERROR`); `<name>` happy path; refused `managed_by=manual`;
+  `--all` aggregate exit codes; `--decide` resolution; `--json` shape.
 - Existing v0.4.0 tests must continue passing with the renamed
   `apply` → `start` and the widened `dispatch(action, ...)`.
 
@@ -410,5 +410,5 @@ actually lands.
 
 ## Tasks
 
-See plan: `/home/spark/.claude/plans/dazzling-snacking-kay.md`. Fourteen
+See plan: `$CLAUDE_HOME/plans/dazzling-snacking-kay.md`. Fourteen
 tasks; task 1 is this spec, tasks 2–14 deliver the implementation.

--- a/docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md
+++ b/docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md
@@ -1,0 +1,414 @@
+# auntiepypi v0.5.0 — lifecycle verbs (`up` / `down` / `restart`)
+
+**Status:** approved (brainstorm 2026-04-30; plan
+`/home/spark/.claude/plans/dazzling-snacking-kay.md`).
+
+**Predecessor:** `2026-04-30-auntiepypi-v0.4.0-doctor-lifecycle-design.md`.
+
+## Why this milestone
+
+v0.4.0 shipped `auntie doctor --apply` as a *starter*: it can dispatch
+`_actions/<strategy>.apply()` to start a half-supervised server and
+mutate `pyproject.toml` to delete broken declarations. It cannot
+**stop** anything. The asymmetry is structural:
+
+- `command`-managed servers are detached `Popen(start_new_session=True)`
+  children whose PIDs `command.apply()` returns and forgets. Auntie
+  has no way to terminate them later.
+- `systemd-user` strategy starts units but never invokes
+  `systemctl --user stop`.
+- `doctor --apply` cannot offer a "stop and reconfigure" workflow
+  because there is no stop primitive to call.
+
+`auntiepypi/_actions/command.py` already announces the gap:
+
+```python
+# Doctor does NOT track the child past spawn. ``auntie down`` (v0.5.0)
+# will own process-tracking.
+```
+
+v0.5.0 closes the gap with three lifecycle verbs and a widened
+strategy contract. Crucially, **the bare invocation `auntie up` is
+reserved for v0.6.0**, where it will start auntie's own first-party
+PEP 503 simple-index server. v0.5.0 only delivers the
+`<name>` / `--all` paths so that the bare form remains free.
+
+## Decisions (locked)
+
+### D1. Immediate-action verbs (no `--apply` gate)
+
+`auntie up <name>` starts the server now. `auntie down <name>` stops
+it now. `auntie restart <name>` does both now. There is no dry-run
+gate.
+
+**Rationale.** The dry-run-first rule in this repo exists to protect
+*persistent state* — `pyproject.toml`, mainly. Lifecycle verbs operate
+on *volatile* process state, which is recoverable by re-running the
+verb. The mental model is `systemctl start`, which has no `--really`
+flag for the same reason. Idempotency (D5) makes accidents harmless.
+
+**Cost.** One verb in this repo doesn't follow the dry-run-first
+convention. Documented in CLAUDE.md and in the verbs' `--help` text.
+
+### D2. Eager PID file + argv-matched port-walk fallback
+
+`command.start()` writes a PID record on success.
+`command.stop()` reads the PID and signals it. Two-tier discovery:
+
+1. **Primary: PID file.** `$XDG_STATE_HOME/auntiepypi/<slug>.pid`
+   (raw integer) plus `<slug>.json` sidecar (pid, argv, started_at,
+   port). Written atomically by `command.start()` after a successful
+   re-probe.
+2. **Fallback: port-walk + argv match.** If no PID file exists,
+   `command.stop()` walks `/proc/net/tcp` + `/proc/<pid>/fd/*` to find
+   the listener bound to `declaration.port`. If found, compare the
+   discovered process's argv against the declared `command`. If they
+   agree (basename-of-argv0 + presence of declared tokens), kill.
+   If they disagree, refuse with a footgun-guard error.
+
+Liveness is checked at read time: `os.kill(pid, 0)` against the file's
+PID; ESRCH means the process is gone, so the file is stale and gets
+cleaned up silently.
+
+`systemd-user` is unaffected. systemd owns the unit's process state;
+auntie shells out to `systemctl --user {start,stop,restart} <unit>`
+and doesn't track PIDs.
+
+**Rationale.** The PID file is portable, simple, race-free at the
+auntie boundary. The port-walk fallback covers the case where someone
+started the server outside `auntie up` (a previous shell, a manual
+test) and now wants `auntie down` to clean it up. The argv match
+prevents accidentally killing an unrelated process bound to the same
+port.
+
+**Cost.** Linux-only fallback. Non-Linux platforms get
+`find_by_port → None` and a graceful "already stopped" no-op when
+no PID file exists. The argv-match heuristic may reject legitimate
+processes spawned with subtly different argv; a `--force` opt-out
+will land in v0.5.x if it bites.
+
+### D3. Three sibling strategy functions
+
+Today each strategy module exposes a single `apply(detection,
+declaration) -> ActionResult`. v0.5.0 widens this to:
+
+```python
+# auntiepypi/_actions/<strategy>.py
+def start(detection, declaration) -> ActionResult: ...
+def stop(detection, declaration) -> ActionResult: ...
+def restart(detection, declaration) -> ActionResult: ...
+```
+
+`_actions/__init__.py:ACTIONS` becomes `dict[str, dict[str, Strategy]]`:
+
+```python
+ACTIONS = {
+    "systemd-user": {"start": ..., "stop": ..., "restart": ...},
+    "command":      {"start": ..., "stop": ..., "restart": ...},
+}
+
+def dispatch(
+    action: Literal["start", "stop", "restart"],
+    detection: Detection,
+    declaration: ServerSpec,
+) -> ActionResult: ...
+```
+
+The internal rename `apply` → `start` honestly reflects what doctor
+has been calling all along.
+
+**Rationale.** Strategy boundary matches lifecycle boundary. Each
+function gets type-safe inputs/outputs without internal switch
+statements. `restart` is free to be smarter than naive stop+start
+(D5). Doctor's `--apply` rewires to `dispatch("start", ...)`.
+
+**Cost.** One mechanical rename + interface widening. The change is
+internal; no public API is affected.
+
+### D4. Bare verb reserved for v0.6.0
+
+```text
+auntie up                  → exit 2; "first-party auntie server lands in
+                                       v0.6.0; for now use `auntie up <name>`
+                                       or `auntie up --all`"
+auntie up <name>           → resolve and dispatch("start", ...)
+auntie up --all            → bulk-act on every supervised declaration
+auntie up --all --json     → JSON envelope
+auntie up --decide=duplicate:NAME=N <name>   → ambiguity resolution
+```
+
+Symmetric for `down` and `restart`. `--all` skips
+`managed_by ∈ {manual, docker, compose, unset}` with a per-line note;
+the explicit single-name form refuses with exit 1 for those modes.
+
+Resolution priority for `<name>`: detection name first, configured
+server name second (mirrors `auntie overview <TARGET>` and `auntie
+doctor [TARGET]`).
+
+**Exit codes.** Same contract as doctor:
+
+- `0` — every targeted server reached the desired state
+- `1` — user error or config error before any action attempted
+- `2` — at least one targeted server did not reach the desired state
+
+**Rationale.** Reserving the bare form lets v0.6.0 introduce
+`auntie up` as "start the first-party simple-index server" without
+breaking v0.5.0's `auntie up <name>` ergonomics. Explicit `--all` is
+a footgun guard ("did I really mean every dev server?"). Reusing
+`--decide=duplicate:NAME=N` keeps the ambiguity-resolution UX uniform
+across doctor and the lifecycle verbs.
+
+### D5. Strategy-native restart; sidecar advisory; idempotency
+
+**`systemd-user.restart`** uses `systemctl --user restart <unit>`
+directly. It's atomic, faster than stop+start, and lets systemd
+preserve invariants the unit file declares.
+
+**`command.restart`** does `stop()` then `start()`. The new spawn
+re-uses the **current** `[[tool.auntiepypi.servers]].command` from
+`pyproject.toml` — never the sidecar argv. If the sidecar argv
+disagrees with the current spec, a single drift line is written to
+the existing log file (no failure):
+
+```text
+=== 2026-04-30T18:42:00Z: argv changed since last start ===
+prev: ['pypi-server', 'run', '-p', '18080', '.']
+cur:  ['pypi-server', 'run', '-p', '18081', '.']
+```
+
+**Idempotency.**
+
+- `up` already-up → `ok=True, detail="already running"` (re-probe
+  confirms; no re-spawn).
+- `down` already-down → `ok=True, detail="already stopped"` (no PID
+  to kill; any stale PID file is cleaned up).
+- `restart` always tears down and brings up (even if already up;
+  user intent is "make it match current config now").
+
+**Stale state.**
+
+- `up` with stale PID file: log `"stale PID for <name>; cleaning up"`,
+  delete file, fresh spawn.
+- `down` with stale PID: success no-op + cleanup.
+
+**Rationale.** Source of truth is always current `pyproject.toml`.
+Users edit config to change behavior; if `restart` ignored the edit
+they'd be debugging "why didn't it pick up my change." The sidecar
+exists only to remember "what was last spawned" so `down` knows what
+argv to verify.
+
+## Architecture
+
+### File layout (after v0.5.0)
+
+```text
+auntiepypi/_actions/
+├── __init__.py          # ACTIONS dict-of-dicts; dispatch(action, ...)
+├── _action.py           # ActionResult (unchanged)
+├── _logs.py             # slugify, state_root, path_for (unchanged)
+├── _pid.py              # NEW: PidRecord, write/read/clear/find_by_port
+├── _reprobe.py          # widened: probe(detection, *, desired="up")
+├── _config_edit.py      # unchanged
+├── command.py           # start (writes PID), stop, restart
+└── systemd_user.py      # start, stop, restart
+
+auntiepypi/cli/_commands/
+├── up.py                # NEW
+├── down.py              # NEW
+├── restart.py           # NEW
+├── doctor.py            # one call site: dispatch("start", ...)
+└── ...
+```
+
+### Strategy contract (post-task-2)
+
+```python
+# auntiepypi/_actions/__init__.py
+from typing import Callable, Literal
+
+Strategy = Callable[[Detection, ServerSpec], ActionResult]
+StrategyMap = dict[str, Strategy]
+
+ACTIONS: dict[str, StrategyMap] = {
+    "systemd-user": {
+        "start":   _systemd_user.start,
+        "stop":    _systemd_user.stop,
+        "restart": _systemd_user.restart,
+    },
+    "command": {
+        "start":   _command.start,
+        "stop":    _command.stop,
+        "restart": _command.restart,
+    },
+}
+
+_NOT_IMPLEMENTED: frozenset[str] = frozenset({"docker", "compose"})
+
+def dispatch(
+    action: Literal["start", "stop", "restart"],
+    detection: Detection,
+    declaration: ServerSpec,
+) -> ActionResult:
+    """Route to the strategy/action; never raises."""
+```
+
+`dispatch()` returns a uniform `ActionResult(ok=False, detail=...)`
+for `managed_by ∈ {manual, docker, compose, unset}`, mirroring the
+v0.4.0 behavior.
+
+### PID + sidecar contract
+
+```python
+# auntiepypi/_actions/_pid.py
+@dataclass(frozen=True)
+class PidRecord:
+    pid: int
+    argv: tuple[str, ...]
+    started_at: str   # ISO 8601 UTC
+    port: int
+
+def write(name: str, *, pid: int, argv: Sequence[str], port: int) -> None:
+    """Write <name>.pid (text int) and <name>.json (sidecar) atomically."""
+
+def read(name: str) -> PidRecord | None:
+    """Return parsed record, or None if absent / stale (with cleanup).
+
+    Liveness check: os.kill(record.pid, 0). ESRCH → stale → clear and
+    return None. EPERM → live but not ours → return record (the caller
+    will likely fail the kill, but that's their concern)."""
+
+def clear(name: str) -> None:
+    """Delete <name>.pid and <name>.json. Idempotent."""
+
+def find_by_port(port: int, *, expected_argv: Sequence[str]) -> int | None:
+    """Linux-only: walk /proc/net/tcp + /proc/<pid>/fd/* for the listener
+    on `port`. Return its PID iff its argv matches `expected_argv`
+    (basename-of-argv0 equality + every non-flag token in expected_argv
+    appears in discovered argv). Return None on non-Linux or no match."""
+```
+
+Files cluster with the v0.4.0 log file:
+`$XDG_STATE_HOME/auntiepypi/<slug>.{log,pid,json}`. Slug derivation
+reuses `auntiepypi._actions._logs.slugify`.
+
+**Atomic write.** `<slug>.pid.tmp` is created via
+`tempfile.mkstemp(dir=state_root, prefix=f"{slug}.pid.", suffix=".tmp")`,
+written, fsynced, then `os.replace`d onto `<slug>.pid`. Same pattern
+for the sidecar. This mirrors the v0.4.0 `_config_edit._atomic_write_pyproject`
+pattern that cleared the SonarCloud S2083 BLOCKER.
+
+### Re-probe widening
+
+```python
+# auntiepypi/_actions/_reprobe.py
+def probe(
+    detection: Detection,
+    *,
+    budget_seconds: float = 5.0,
+    desired: Literal["up", "down"] = "up",
+    _sleep=time.sleep, _now=time.monotonic,
+) -> ReprobeResult:
+    """Poll until status matches `desired` or budget exhausted.
+
+    `desired="up"` (default): existing v0.4.0 behavior, exit early on
+    "up". `desired="down"` (new in v0.5.0): exit early on "down" or
+    "absent", continue while status is "up"."""
+```
+
+All v0.4.0 callers pass `desired="up"` implicitly via the default.
+
+### CLI verb shape
+
+```python
+# auntiepypi/cli/_commands/up.py (down.py, restart.py mirror this)
+
+def add_parser(subparsers):
+    p = subparsers.add_parser("up", help="start a declared server")
+    p.add_argument("target", nargs="?", default=None,
+                   help="server name; omit to require --all")
+    p.add_argument("--all", action="store_true", dest="all_servers",
+                   help="act on every supervised declaration")
+    p.add_argument("--decide", action="append", default=[],
+                   help="resolve ambiguity, e.g. duplicate:NAME=N")
+    p.add_argument("--json", action="store_true",
+                   help="JSON envelope instead of text")
+    p.set_defaults(func=cmd_up)
+
+
+def cmd_up(args) -> int:
+    if args.target is None and not args.all_servers:
+        # Bare form is reserved for v0.6.0
+        sys.stderr.write(_BARE_UP_RESERVED + "\n")
+        return EXIT_USER_ERROR
+    ...
+```
+
+JSON envelope (uniform across the three verbs):
+
+```json
+{
+  "verb": "up",
+  "results": [
+    {"name": "main",       "ok": true,  "detail": "started", "pid": 12345},
+    {"name": "secondary",  "ok": true,  "detail": "already running"},
+    {"name": "broken-one", "ok": false, "detail": "command not found: ..."}
+  ]
+}
+```
+
+Exit code derived from results: `0` iff all `ok=true`; `2` otherwise.
+
+## Testing strategy
+
+Inherits the v0.4.0 patterns:
+
+- `tests/test_actions_pid.py` — round-trip; stale detection;
+  `find_by_port` argv match (positive + negative); non-Linux platform
+  shim returning None.
+- `tests/test_actions_command_lifecycle.py` — `command.stop` clean
+  path; SIGKILL escalation; stale PID cleanup; missing PID +
+  port-walk match; missing PID + port-walk argv-mismatch refusal.
+  `command.restart` clean path; argv drift logged; restart-when-down.
+- `tests/test_actions_systemd_user_lifecycle.py` — `stop`, `restart`
+  via `RUN` indirection (already used by `start`).
+- `tests/test_cli_{up,down,restart}.py` — bare exit 2;
+  `<name>` happy path; refused `managed_by=manual`; `--all` aggregate
+  exit codes; `--decide` resolution; `--json` shape.
+- Existing v0.4.0 tests must continue passing with the renamed
+  `apply` → `start` and the widened `dispatch(action, ...)`.
+
+Coverage floor stays at 94% (v0.4.0 baseline). Lifecycle stop/restart
+paths are heavily mockable, so 95% is plausible — defer to what
+actually lands.
+
+## Out of scope (deferred to v0.6.0)
+
+- First-party PEP 503 simple-index server (`auntie up` bare form).
+- `[tool.auntiepypi.local]` config block for the first-party server
+  (port, wheelhouse path, auth model).
+- HTTPS termination.
+- `auntie publish` upload path.
+- Cross-machine state sharing for the PID file (state stays per-host
+  under XDG; mesh-aware service registry is also v0.6.0+).
+
+## Risks / open issues
+
+- **argv-match heuristic.** Basename(argv[0]) + every non-flag token
+  from declared command must appear in discovered argv. False
+  negatives possible (e.g. user ran `pypi-server -p 18080` but
+  declared `["pypi-server", "run", "-p", "18080", "."]`). v0.5.x
+  may add `--force` to bypass.
+- **Sidecar drift detection.** `command.restart` only logs; doesn't
+  surface drift to the CLI summary. Consider promoting to a JSON
+  field (`drift_detected: bool`) if it becomes useful.
+- **PID file race on shared state dir.** Two `auntie up <name>`
+  invocations against the same name in parallel could clobber.
+  Auntie is single-user per host; this is acceptable for v0.5.0.
+- **`find_by_port` on macOS / BSD.** Returns None; the documented
+  behavior is "no fallback, declare your servers." Future work could
+  add a `lsof`-based shim.
+
+## Tasks
+
+See plan: `/home/spark/.claude/plans/dazzling-snacking-kay.md`. Fourteen
+tasks; task 1 is this spec, tasks 2–14 deliver the implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auntiepypi"
-version = "0.4.0"
+version = "0.5.0"
 description = "auntiepypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_actions_command.py
+++ b/tests/test_actions_command.py
@@ -8,7 +8,7 @@ import socket
 import sys
 from pathlib import Path
 
-from auntiepypi._actions.command import apply
+from auntiepypi._actions.command import start
 from auntiepypi._detect._config import ServerSpec
 from auntiepypi._detect._detection import Detection
 
@@ -52,7 +52,7 @@ def test_command_happy_path(tmp_path, monkeypatch):
     spec = _spec("test", port, cmd)
     result = None
     try:
-        result = apply(detection, spec)
+        result = start(detection, spec)
         assert result.ok, f"expected ok=True, got {result}"
         assert result.detail == "started"
         assert result.log_path is not None
@@ -72,7 +72,7 @@ def test_command_not_found(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     port = _free_port()
     spec = _spec("missing", port, ("definitely_not_a_real_binary_42",))
-    result = apply(_detection(port), spec)
+    result = start(_detection(port), spec)
     assert result.ok is False
     assert "not found" in result.detail
 
@@ -81,7 +81,7 @@ def test_command_exits_immediately(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     port = _free_port()
     spec = _spec("badexit", port, (sys.executable, "-c", "import sys; sys.exit(1)"))
-    result = apply(_detection(port), spec)
+    result = start(_detection(port), spec)
     assert result.ok is False
     assert "exited immediately" in result.detail
     assert result.log_path is not None  # log was written before child exited
@@ -94,7 +94,7 @@ def test_command_spawns_but_never_binds(tmp_path, monkeypatch):
     spec = _spec("idle", port, (sys.executable, "-c", "import time; time.sleep(30)"))
     result = None
     try:
-        result = apply(_detection(port), spec)
+        result = start(_detection(port), spec)
         assert result.ok is False
         assert "not responding" in result.detail
         assert result.pid is not None  # pid was captured
@@ -112,17 +112,17 @@ def test_command_log_path_uses_xdg(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     port = _free_port()
     spec = _spec("logtest", port, (sys.executable, "-c", "import sys; sys.exit(0)"))
-    result = apply(_detection(port), spec)
+    result = start(_detection(port), spec)
     assert result.log_path is not None
     assert str(tmp_path) in result.log_path
     assert Path(result.log_path).read_bytes()  # non-empty
 
 
 def test_command_not_configured_returns_error(tmp_path, monkeypatch):
-    """`apply` returns ok=False when declaration.command is None/empty (defensive guard).
+    """`start` returns ok=False when declaration.command is None/empty (defensive guard).
 
     Upstream config validation (`_detect/_config.py`, T9) prevents this in
-    practice, but `apply()` is a public function with its own contract.
+    practice, but `start()` is a public function with its own contract.
     """
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     spec = ServerSpec(
@@ -133,7 +133,7 @@ def test_command_not_configured_returns_error(tmp_path, monkeypatch):
         managed_by="command",
         command=None,
     )
-    result = apply(_detection(spec.port), spec)
+    result = start(_detection(spec.port), spec)
     assert result.ok is False
     assert "command" in result.detail and "not set" in result.detail
 
@@ -147,6 +147,6 @@ def test_command_permission_denied(tmp_path, monkeypatch):
     fake_bin.chmod(0o644)  # readable but not executable
     port = _free_port()
     spec = _spec("noperm", port, (str(fake_bin),))
-    result = apply(_detection(port), spec)
+    result = start(_detection(port), spec)
     assert result.ok is False
     assert "permission denied" in result.detail.lower()

--- a/tests/test_actions_command.py
+++ b/tests/test_actions_command.py
@@ -58,6 +58,14 @@ def test_command_happy_path(tmp_path, monkeypatch):
         assert result.log_path is not None
         assert result.pid is not None
         assert Path(result.log_path).exists()
+        # PID file + sidecar were written on success
+        from auntiepypi._actions import _pid
+
+        record = _pid.read("test")
+        assert record is not None
+        assert record.pid == result.pid
+        assert record.port == port
+        assert tuple(record.argv) == cmd
     finally:
         if result and result.pid:
             try:
@@ -66,6 +74,18 @@ def test_command_happy_path(tmp_path, monkeypatch):
                 os.killpg(os.getpgid(result.pid), signal.SIGTERM)  # NOSONAR python:S4828
             except ProcessLookupError:
                 pass
+
+
+def test_command_failed_start_does_not_write_pid_file(tmp_path, monkeypatch):
+    """A failing start (command not found) leaves no PID file behind."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    port = _free_port()
+    spec = _spec("missing-binary", port, ("definitely_not_a_real_binary_42",))
+    result = start(_detection(port), spec)
+    assert result.ok is False
+    from auntiepypi._actions import _pid
+
+    assert _pid.read("missing-binary") is None
 
 
 def test_command_not_found(tmp_path, monkeypatch):

--- a/tests/test_actions_command.py
+++ b/tests/test_actions_command.py
@@ -61,7 +61,7 @@ def test_command_happy_path(tmp_path, monkeypatch):
         # PID file + sidecar were written on success
         from auntiepypi._actions import _pid
 
-        record = _pid.read("test")
+        record = _pid.read("test", port)
         assert record is not None
         assert record.pid == result.pid
         assert record.port == port
@@ -85,7 +85,7 @@ def test_command_failed_start_does_not_write_pid_file(tmp_path, monkeypatch):
     assert result.ok is False
     from auntiepypi._actions import _pid
 
-    assert _pid.read("missing-binary") is None
+    assert _pid.read("missing-binary", port) is None
 
 
 def test_command_not_found(tmp_path, monkeypatch):

--- a/tests/test_actions_command_lifecycle.py
+++ b/tests/test_actions_command_lifecycle.py
@@ -1,0 +1,277 @@
+"""Tests for `command.stop` and `command.restart`.
+
+These tests don't actually spawn processes — they monkey-patch
+``command.KILL`` (the os.kill indirection) and the reprobe loop to
+simulate the success / timeout / argv-mismatch paths.
+"""
+
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+from auntiepypi._actions import _pid, command
+from auntiepypi._actions._action import ActionResult
+from auntiepypi._actions._reprobe import ReprobeResult
+from auntiepypi._detect._config import ServerSpec
+from auntiepypi._detect._detection import Detection
+
+
+def _detection(port: int) -> Detection:
+    return Detection(
+        name="lc",
+        flavor="pypiserver",
+        host="127.0.0.1",
+        port=port,
+        url=f"http://127.0.0.1:{port}/",
+        status="up",
+        source="declared",
+    )
+
+
+def _spec(port: int, command_argv: tuple[str, ...] = ("pypi-server", "run")) -> ServerSpec:
+    return ServerSpec(
+        name="lc",
+        flavor="pypiserver",
+        host="127.0.0.1",
+        port=port,
+        managed_by="command",
+        command=command_argv,
+    )
+
+
+@pytest.fixture
+def fake_kill(monkeypatch):
+    """Capture (pid, signal) tuples instead of really signalling."""
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(command, "KILL", lambda pid, sig: calls.append((pid, sig)))
+    return calls
+
+
+def _patch_probe(monkeypatch, statuses):
+    """Make `command.probe` return successive statuses from `statuses`."""
+    it = iter(statuses)
+
+    def fake_probe(detection, *, desired="up", budget_seconds=5.0, **_kw):
+        try:
+            return ReprobeResult(status=next(it))
+        except StopIteration:
+            # Repeat the last status forever
+            return ReprobeResult(status=statuses[-1])
+
+    monkeypatch.setattr(command, "probe", fake_probe)
+
+
+# --------- happy paths ---------
+
+
+def test_stop_clean_path_sigterm(tmp_path, monkeypatch, fake_kill):
+    """PID file present, SIGTERM lands, port goes down on first reprobe."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
+    # _pid.read calls os.kill(pid, 0) for liveness; pretend it's alive
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+    _patch_probe(monkeypatch, ["down"])
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert "stopped (SIGTERM)" in result.detail
+    assert fake_kill == [(12345, signal.SIGTERM)]
+    assert _pid.read("lc") is None  # PID file cleared
+
+
+def test_stop_sigkill_escalation(tmp_path, monkeypatch, fake_kill):
+    """SIGTERM lands but port is still bound; SIGKILL escalation; eventually down."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+    # First probe (SIGTERM grace): still up. Second probe (post-SIGKILL): down.
+    _patch_probe(monkeypatch, ["up", "down"])
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert "SIGKILL" in result.detail
+    assert fake_kill == [(12345, signal.SIGTERM), (12345, signal.SIGKILL)]
+
+
+def test_stop_already_stopped_no_pid_no_listener(tmp_path, monkeypatch, fake_kill):
+    """No PID file, port-walk returns nothing, port is down → idempotent success."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
+    _patch_probe(monkeypatch, ["down"])  # port already down
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert result.detail == "already stopped"
+    assert fake_kill == []  # no signal sent
+
+
+def test_stop_argv_mismatch_refuses(tmp_path, monkeypatch, fake_kill):
+    """No PID file but the port is up — refuse to kill (some other process)."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
+    # Port-walk finds nothing whose argv matches; reprobe says still up.
+    _patch_probe(monkeypatch, ["up"])
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is False
+    assert "does not match declaration" in result.detail
+    assert "refusing to kill" in result.detail
+    assert fake_kill == []
+
+
+def test_stop_port_walk_finds_pid_when_no_pid_file(tmp_path, monkeypatch, fake_kill):
+    """No PID file, port-walk returns a PID → kill it."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: 9876)
+    _patch_probe(monkeypatch, ["down"])
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert "stopped (SIGTERM) (found via port-walk)" in result.detail
+    assert fake_kill == [(9876, signal.SIGTERM)]
+
+
+def test_stop_stale_pid_then_no_listener_is_already_stopped(tmp_path, monkeypatch, fake_kill):
+    """PID file references a dead PID; no port-walk match; port down → already stopped."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    # Write a stale PID file. _pid.read with _is_alive=False clears it.
+    _pid.write("lc", pid=2_000_000_000, argv=["x"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: False)
+    monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
+    _patch_probe(monkeypatch, ["down"])
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert result.detail == "already stopped"
+    assert fake_kill == []
+
+
+def test_stop_sigterm_race_lookuperror(tmp_path, monkeypatch):
+    """Process dies between read() and kill() — ProcessLookupError → success."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+
+    def kill_raises_lookup(pid, sig):
+        raise ProcessLookupError()
+
+    monkeypatch.setattr(command, "KILL", kill_raises_lookup)
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert "race" in result.detail
+
+
+def test_stop_sigterm_oserror_returns_failure(tmp_path, monkeypatch):
+    """An unexpected OSError from kill() (e.g. EPERM) is reported as failure."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+
+    def kill_raises_perm(pid, sig):
+        raise PermissionError("not your process")
+
+    monkeypatch.setattr(command, "KILL", kill_raises_perm)
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is False
+    assert "SIGTERM failed" in result.detail
+
+
+def test_stop_sigkill_still_bound_returns_failure(tmp_path, monkeypatch, fake_kill):
+    """SIGKILL sent but port still bound after grace → failure."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+    # Both reprobe windows return "up" — port never unbinds.
+    _patch_probe(monkeypatch, ["up", "up"])
+
+    result = command.stop(_detection(8080), _spec(8080))
+    assert result.ok is False
+    assert "SIGKILL sent but port still bound" in result.detail
+
+
+# --------- restart ---------
+
+
+def test_restart_clean(tmp_path, monkeypatch, fake_kill):
+    """restart: stop succeeds, start succeeds."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+    _patch_probe(monkeypatch, ["down"])  # stop's reprobe sees down
+
+    # Stub command.start so restart doesn't actually spawn anything.
+    monkeypatch.setattr(
+        command,
+        "start",
+        lambda det, decl: ActionResult(ok=True, detail="started", pid=99999),
+    )
+
+    result = command.restart(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert result.detail == "started"
+    assert fake_kill == [(12345, signal.SIGTERM)]
+
+
+def test_restart_when_not_running_acts_like_start(tmp_path, monkeypatch, fake_kill):
+    """restart with no PID file + no listener: stop is a no-op; start runs."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
+    _patch_probe(monkeypatch, ["down", "down"])
+
+    started = {}
+
+    def fake_start(det, decl):
+        started["called"] = True
+        return ActionResult(ok=True, detail="started", pid=999)
+
+    monkeypatch.setattr(command, "start", fake_start)
+
+    result = command.restart(_detection(8080), _spec(8080))
+    assert result.ok is True
+    assert started.get("called") is True
+
+
+def test_restart_logs_argv_drift(tmp_path, monkeypatch, fake_kill):
+    """When sidecar argv differs from current, restart writes a drift line to the log."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("lc", pid=12345, argv=["pypi-server", "run", "-p", "8080"], port=8080)
+    monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
+    _patch_probe(monkeypatch, ["down"])
+    monkeypatch.setattr(
+        command,
+        "start",
+        lambda det, decl: ActionResult(ok=True, detail="started", pid=99999),
+    )
+
+    # Spec's command differs from sidecar.
+    new_spec = _spec(8080, command_argv=("pypi-server", "run", "-p", "9090"))
+    result = command.restart(_detection(8080), new_spec)
+    assert result.ok is True
+
+    log = (tmp_path / "auntiepypi" / "lc.log").read_text()
+    assert "argv changed since last start" in log
+    assert "9090" in log
+
+
+def test_restart_aborts_when_stop_fails(tmp_path, monkeypatch):
+    """If stop returns ok=False (e.g. argv mismatch), restart bails without starting."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
+    _patch_probe(monkeypatch, ["up"])  # port up but no PID/argv match → refuse
+
+    started = {"called": False}
+
+    def fake_start(det, decl):
+        started["called"] = True
+        return ActionResult(ok=True, detail="started")
+
+    monkeypatch.setattr(command, "start", fake_start)
+
+    result = command.restart(_detection(8080), _spec(8080))
+    assert result.ok is False
+    assert "refusing to kill" in result.detail
+    assert started["called"] is False

--- a/tests/test_actions_command_lifecycle.py
+++ b/tests/test_actions_command_lifecycle.py
@@ -72,13 +72,13 @@ def test_stop_clean_path_sigterm(tmp_path, monkeypatch, fake_kill):
     _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
     # _pid.read calls os.kill(pid, 0) for liveness; pretend it's alive
     monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
-    _patch_probe(monkeypatch, ["down"])
+    _patch_probe(monkeypatch, ["absent"])
 
     result = command.stop(_detection(8080), _spec(8080))
     assert result.ok is True
     assert "stopped (SIGTERM)" in result.detail
     assert fake_kill == [(12345, signal.SIGTERM)]
-    assert _pid.read("lc") is None  # PID file cleared
+    assert _pid.read("lc", 8080) is None  # PID file cleared
 
 
 def test_stop_sigkill_escalation(tmp_path, monkeypatch, fake_kill):
@@ -87,7 +87,7 @@ def test_stop_sigkill_escalation(tmp_path, monkeypatch, fake_kill):
     _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
     monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
     # First probe (SIGTERM grace): still up. Second probe (post-SIGKILL): down.
-    _patch_probe(monkeypatch, ["up", "down"])
+    _patch_probe(monkeypatch, ["up", "absent"])
 
     result = command.stop(_detection(8080), _spec(8080))
     assert result.ok is True
@@ -99,7 +99,7 @@ def test_stop_already_stopped_no_pid_no_listener(tmp_path, monkeypatch, fake_kil
     """No PID file, port-walk returns nothing, port is down → idempotent success."""
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
-    _patch_probe(monkeypatch, ["down"])  # port already down
+    _patch_probe(monkeypatch, ["absent"])  # port already down
 
     result = command.stop(_detection(8080), _spec(8080))
     assert result.ok is True
@@ -125,7 +125,7 @@ def test_stop_port_walk_finds_pid_when_no_pid_file(tmp_path, monkeypatch, fake_k
     """No PID file, port-walk returns a PID → kill it."""
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: 9876)
-    _patch_probe(monkeypatch, ["down"])
+    _patch_probe(monkeypatch, ["absent"])
 
     result = command.stop(_detection(8080), _spec(8080))
     assert result.ok is True
@@ -140,7 +140,7 @@ def test_stop_stale_pid_then_no_listener_is_already_stopped(tmp_path, monkeypatc
     _pid.write("lc", pid=2_000_000_000, argv=["x"], port=8080)
     monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: False)
     monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
-    _patch_probe(monkeypatch, ["down"])
+    _patch_probe(monkeypatch, ["absent"])
 
     result = command.stop(_detection(8080), _spec(8080))
     assert result.ok is True
@@ -201,7 +201,7 @@ def test_restart_clean(tmp_path, monkeypatch, fake_kill):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     _pid.write("lc", pid=12345, argv=["pypi-server", "run"], port=8080)
     monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
-    _patch_probe(monkeypatch, ["down"])  # stop's reprobe sees down
+    _patch_probe(monkeypatch, ["absent"])  # stop's reprobe sees down
 
     # Stub command.start so restart doesn't actually spawn anything.
     monkeypatch.setattr(
@@ -220,7 +220,7 @@ def test_restart_when_not_running_acts_like_start(tmp_path, monkeypatch, fake_ki
     """restart with no PID file + no listener: stop is a no-op; start runs."""
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     monkeypatch.setattr(_pid, "find_by_port", lambda *a, **kw: None)
-    _patch_probe(monkeypatch, ["down", "down"])
+    _patch_probe(monkeypatch, ["absent", "absent"])
 
     started = {}
 
@@ -240,7 +240,7 @@ def test_restart_logs_argv_drift(tmp_path, monkeypatch, fake_kill):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     _pid.write("lc", pid=12345, argv=["pypi-server", "run", "-p", "8080"], port=8080)
     monkeypatch.setattr("auntiepypi._actions._pid._is_alive", lambda pid: True)
-    _patch_probe(monkeypatch, ["down"])
+    _patch_probe(monkeypatch, ["absent"])
     monkeypatch.setattr(
         command,
         "start",

--- a/tests/test_actions_dispatch.py
+++ b/tests/test_actions_dispatch.py
@@ -19,11 +19,11 @@ def _det() -> Detection:
     )
 
 
-def test_dispatch_routes_systemd_user(monkeypatch):
+def test_dispatch_routes_systemd_user_start(monkeypatch):
     called = []
     monkeypatch.setitem(
-        _actions.ACTIONS,
-        "systemd-user",
+        _actions.ACTIONS["systemd-user"],
+        "start",
         lambda d, s: (
             called.append(("systemd-user", d, s)) or _actions.ActionResult(ok=True, detail="ok")
         ),
@@ -36,17 +36,17 @@ def test_dispatch_routes_systemd_user(monkeypatch):
         managed_by="systemd-user",
         unit="x.service",
     )
-    result = _actions.dispatch(_det(), spec)
+    result = _actions.dispatch("start", _det(), spec)
     assert result.ok is True
     assert len(called) == 1, f"expected exactly one call, got {called!r}"
     assert called[0][0] == "systemd-user"
 
 
-def test_dispatch_routes_command(monkeypatch):
+def test_dispatch_routes_command_start(monkeypatch):
     called = []
     monkeypatch.setitem(
-        _actions.ACTIONS,
-        "command",
+        _actions.ACTIONS["command"],
+        "start",
         lambda d, s: (called.append("command") or _actions.ActionResult(ok=True, detail="ok")),
     )
     spec = ServerSpec(
@@ -57,10 +57,56 @@ def test_dispatch_routes_command(monkeypatch):
         managed_by="command",
         command=("echo",),
     )
-    result = _actions.dispatch(_det(), spec)
+    result = _actions.dispatch("start", _det(), spec)
     assert result.ok is True
     assert len(called) == 1, f"expected exactly one call, got {called!r}"
     assert called == ["command"]
+
+
+def test_dispatch_routes_systemd_user_stop(monkeypatch):
+    called = []
+    monkeypatch.setitem(
+        _actions.ACTIONS["systemd-user"],
+        "stop",
+        lambda d, s: (
+            called.append(("systemd-user-stop",))
+            or _actions.ActionResult(ok=True, detail="stopped")
+        ),
+    )
+    spec = ServerSpec(
+        name="t",
+        flavor="pypiserver",
+        host="127.0.0.1",
+        port=8080,
+        managed_by="systemd-user",
+        unit="x.service",
+    )
+    result = _actions.dispatch("stop", _det(), spec)
+    assert result.ok is True
+    assert len(called) == 1
+
+
+def test_dispatch_routes_command_restart(monkeypatch):
+    called = []
+    monkeypatch.setitem(
+        _actions.ACTIONS["command"],
+        "restart",
+        lambda d, s: (
+            called.append(("command-restart",))
+            or _actions.ActionResult(ok=True, detail="restarted")
+        ),
+    )
+    spec = ServerSpec(
+        name="t",
+        flavor="pypiserver",
+        host="127.0.0.1",
+        port=8080,
+        managed_by="command",
+        command=("echo",),
+    )
+    result = _actions.dispatch("restart", _det(), spec)
+    assert result.ok is True
+    assert len(called) == 1
 
 
 def test_dispatch_docker_returns_not_implemented():
@@ -72,9 +118,9 @@ def test_dispatch_docker_returns_not_implemented():
         managed_by="docker",
         dockerfile="./Dockerfile",
     )
-    result = _actions.dispatch(_det(), spec)
+    result = _actions.dispatch("start", _det(), spec)
     assert result.ok is False
-    assert "not implemented in v0.4.0" in result.detail
+    assert "not implemented" in result.detail
 
 
 def test_dispatch_compose_returns_not_implemented():
@@ -86,7 +132,7 @@ def test_dispatch_compose_returns_not_implemented():
         managed_by="compose",
         compose="./docker-compose.yml",
     )
-    result = _actions.dispatch(_det(), spec)
+    result = _actions.dispatch("start", _det(), spec)
     assert result.ok is False
     assert "not implemented" in result.detail
 
@@ -95,13 +141,13 @@ def test_dispatch_manual_is_noop():
     spec = ServerSpec(
         name="t", flavor="pypiserver", host="127.0.0.1", port=8080, managed_by="manual"
     )
-    result = _actions.dispatch(_det(), spec)
+    result = _actions.dispatch("start", _det(), spec)
     assert result.ok is False  # observed-only is not "fixed"
     assert "manual" in result.detail.lower() or "not supervised" in result.detail.lower()
 
 
 def test_dispatch_unset_managed_by_treated_as_manual():
     spec = ServerSpec(name="t", flavor="pypiserver", host="127.0.0.1", port=8080, managed_by=None)
-    result = _actions.dispatch(_det(), spec)
+    result = _actions.dispatch("start", _det(), spec)
     assert result.ok is False
     assert "manual" in result.detail.lower() or "not supervised" in result.detail.lower()

--- a/tests/test_actions_pid.py
+++ b/tests/test_actions_pid.py
@@ -20,7 +20,7 @@ def test_write_and_read_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     _pid.write("main", pid=os.getpid(), argv=["pypi-server", "-p", "8080"], port=8080)
 
-    record = _pid.read("main")
+    record = _pid.read("main", 8080)
     assert record is not None
     assert record.pid == os.getpid()
     assert record.argv == ("pypi-server", "-p", "8080")
@@ -30,22 +30,20 @@ def test_write_and_read_roundtrip(tmp_path, monkeypatch):
 
 def test_read_returns_none_when_absent(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    assert _pid.read("nonexistent") is None
+    assert _pid.read("nonexistent", 1) is None
 
 
 def test_read_detects_stale_pid_and_clears(tmp_path, monkeypatch):
     """When the PID is dead, read() returns None AND removes the files."""
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    # 0 is a special PID that os.kill(0, 0) won't ESRCH on, but 2^31-1
-    # is essentially guaranteed not to exist.
-    fake_pid = 2_000_000_000
+    fake_pid = 2_000_000_000  # essentially guaranteed not to exist
     _pid.write("ghost", pid=fake_pid, argv=["x"], port=1)
 
-    pid_file = tmp_path / "auntiepypi" / "ghost.pid"
-    sidecar = tmp_path / "auntiepypi" / "ghost.json"
+    pid_file = tmp_path / "auntiepypi" / "ghost_1.pid"
+    sidecar = tmp_path / "auntiepypi" / "ghost_1.json"
     assert pid_file.exists() and sidecar.exists()
 
-    assert _pid.read("ghost") is None
+    assert _pid.read("ghost", 1) is None
     assert not pid_file.exists()
     assert not sidecar.exists()
 
@@ -54,46 +52,89 @@ def test_read_with_garbage_pid_file_returns_none_and_clears(tmp_path, monkeypatc
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     state_dir = tmp_path / "auntiepypi"
     state_dir.mkdir()
-    (state_dir / "junk.pid").write_text("not-a-number\n")
-    (state_dir / "junk.json").write_text("{}")
+    (state_dir / "junk_1.pid").write_text("not-a-number\n")
+    (state_dir / "junk_1.json").write_text("{}")
 
-    assert _pid.read("junk") is None
-    assert not (state_dir / "junk.pid").exists()
+    assert _pid.read("junk", 1) is None
+    assert not (state_dir / "junk_1.pid").exists()
 
 
 def test_read_tolerates_missing_sidecar(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     state_dir = tmp_path / "auntiepypi"
     state_dir.mkdir()
-    (state_dir / "lone.pid").write_text(f"{os.getpid()}\n")
+    (state_dir / "lone_1.pid").write_text(f"{os.getpid()}\n")
     # No sidecar.
 
-    record = _pid.read("lone")
+    record = _pid.read("lone", 1)
     assert record is not None
     assert record.pid == os.getpid()
     assert record.argv == ()
     assert record.port == 0
 
 
+def test_read_corrupt_sidecar_port_returns_none(tmp_path, monkeypatch):
+    """A non-integer port in the sidecar JSON → invalid record, cleaned up."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    state_dir = tmp_path / "auntiepypi"
+    state_dir.mkdir()
+    (state_dir / "bad_1.pid").write_text(f"{os.getpid()}\n")
+    (state_dir / "bad_1.json").write_text('{"port": "not-an-int", "argv": ["x"]}')
+
+    assert _pid.read("bad", 1) is None
+    assert not (state_dir / "bad_1.pid").exists()
+
+
+def test_read_sidecar_port_mismatch_returns_none(tmp_path, monkeypatch):
+    """Sidecar's port disagrees with the requested port → invalid (treats as stale)."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    state_dir = tmp_path / "auntiepypi"
+    state_dir.mkdir()
+    (state_dir / "main_8080.pid").write_text(f"{os.getpid()}\n")
+    # Sidecar says port=9999 but file is keyed on 8080
+    import json as _json
+
+    (state_dir / "main_8080.json").write_text(
+        _json.dumps({"pid": os.getpid(), "argv": ["x"], "port": 9999, "started_at": "x"})
+    )
+
+    assert _pid.read("main", 8080) is None
+
+
+def test_duplicate_names_with_different_ports_dont_collide(tmp_path, monkeypatch):
+    """Two declarations sharing `name` but on different ports keep separate state."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    pid_a = os.getpid()
+    pid_b = os.getpid()  # not real distinct processes; we just want distinct records
+    _pid.write("main", pid=pid_a, argv=["server-a"], port=8080)
+    _pid.write("main", pid=pid_b, argv=["server-b"], port=9090)
+
+    rec_a = _pid.read("main", 8080)
+    rec_b = _pid.read("main", 9090)
+    assert rec_a is not None and tuple(rec_a.argv) == ("server-a",)
+    assert rec_b is not None and tuple(rec_b.argv) == ("server-b",)
+
+
 def test_clear_is_idempotent(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    _pid.clear("never-written")  # no exception
+    _pid.clear("never-written", 1)  # no exception
     _pid.write("real", pid=os.getpid(), argv=["x"], port=1)
-    _pid.clear("real")
-    _pid.clear("real")  # idempotent
-    assert _pid.read("real") is None
+    _pid.clear("real", 1)
+    _pid.clear("real", 1)  # idempotent
+    assert _pid.read("real", 1) is None
 
 
 def test_write_uses_slugified_name(tmp_path, monkeypatch):
     """Names with unsafe chars are slugified before becoming filenames."""
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    _pid.write("Main/Pypi:1", pid=os.getpid(), argv=["x"], port=1)
+    _pid.write("Main/Pypi:1", pid=os.getpid(), argv=["x"], port=8080)
 
     state_dir = tmp_path / "auntiepypi"
     files = sorted(p.name for p in state_dir.iterdir())
     # _logs.slugify lowercases + replaces non-[a-z0-9._-] with '_'.
-    assert "main_pypi_1.pid" in files
-    assert "main_pypi_1.json" in files
+    # Filename also includes the port for duplicate-name disambiguation.
+    assert "main_pypi_1_8080.pid" in files
+    assert "main_pypi_1_8080.json" in files
 
 
 # --------- _argv_matches helper ---------

--- a/tests/test_actions_pid.py
+++ b/tests/test_actions_pid.py
@@ -274,7 +274,7 @@ def test_find_by_port_wrong_port_returns_none(tmp_path):
     (fd_dir / "3").symlink_to("socket:[9999]")
     net_dir = proc / "net"
     net_dir.mkdir()
-    # 0050 = 80, not 8080
+    # The hex literal "0050" in the line below decodes to port 80 (not 8080).
     (net_dir / "tcp").write_text(
         "  sl local rem st\n"
         "   0: 0100007F:0050 00000000:0000 0A 00000000:00000000 00:00000000 "

--- a/tests/test_actions_pid.py
+++ b/tests/test_actions_pid.py
@@ -1,0 +1,252 @@
+"""Tests for `auntiepypi._actions._pid` — PID file + sidecar + port-walk fallback."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from auntiepypi._actions import _pid
+from auntiepypi._actions._pid import PidRecord, _argv_matches
+
+linux_only = pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+
+
+# --------- write / read / clear roundtrip ---------
+
+
+def test_write_and_read_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("main", pid=os.getpid(), argv=["pypi-server", "-p", "8080"], port=8080)
+
+    record = _pid.read("main")
+    assert record is not None
+    assert record.pid == os.getpid()
+    assert record.argv == ("pypi-server", "-p", "8080")
+    assert record.port == 8080
+    assert record.started_at  # ISO 8601 string, non-empty
+
+
+def test_read_returns_none_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    assert _pid.read("nonexistent") is None
+
+
+def test_read_detects_stale_pid_and_clears(tmp_path, monkeypatch):
+    """When the PID is dead, read() returns None AND removes the files."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    # 0 is a special PID that os.kill(0, 0) won't ESRCH on, but 2^31-1
+    # is essentially guaranteed not to exist.
+    fake_pid = 2_000_000_000
+    _pid.write("ghost", pid=fake_pid, argv=["x"], port=1)
+
+    pid_file = tmp_path / "auntiepypi" / "ghost.pid"
+    sidecar = tmp_path / "auntiepypi" / "ghost.json"
+    assert pid_file.exists() and sidecar.exists()
+
+    assert _pid.read("ghost") is None
+    assert not pid_file.exists()
+    assert not sidecar.exists()
+
+
+def test_read_with_garbage_pid_file_returns_none_and_clears(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    state_dir = tmp_path / "auntiepypi"
+    state_dir.mkdir()
+    (state_dir / "junk.pid").write_text("not-a-number\n")
+    (state_dir / "junk.json").write_text("{}")
+
+    assert _pid.read("junk") is None
+    assert not (state_dir / "junk.pid").exists()
+
+
+def test_read_tolerates_missing_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    state_dir = tmp_path / "auntiepypi"
+    state_dir.mkdir()
+    (state_dir / "lone.pid").write_text(f"{os.getpid()}\n")
+    # No sidecar.
+
+    record = _pid.read("lone")
+    assert record is not None
+    assert record.pid == os.getpid()
+    assert record.argv == ()
+    assert record.port == 0
+
+
+def test_clear_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.clear("never-written")  # no exception
+    _pid.write("real", pid=os.getpid(), argv=["x"], port=1)
+    _pid.clear("real")
+    _pid.clear("real")  # idempotent
+    assert _pid.read("real") is None
+
+
+def test_write_uses_slugified_name(tmp_path, monkeypatch):
+    """Names with unsafe chars are slugified before becoming filenames."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _pid.write("Main/Pypi:1", pid=os.getpid(), argv=["x"], port=1)
+
+    state_dir = tmp_path / "auntiepypi"
+    files = sorted(p.name for p in state_dir.iterdir())
+    # _logs.slugify lowercases + replaces non-[a-z0-9._-] with '_'.
+    assert "main_pypi_1.pid" in files
+    assert "main_pypi_1.json" in files
+
+
+# --------- _argv_matches helper ---------
+
+
+def test_argv_matches_exact():
+    assert _argv_matches(
+        ["pypi-server", "run", "-p", "8080", "."],
+        ["pypi-server", "run", "-p", "8080", "."],
+    )
+
+
+def test_argv_matches_basename_equality():
+    """argv[0] basename, not full path, is what matters."""
+    assert _argv_matches(
+        ["/usr/local/bin/pypi-server", "run"],
+        ["pypi-server", "run"],
+    )
+
+
+def test_argv_matches_skips_flag_tokens_in_expected():
+    """A flag-style token in expected ('-p') is skipped in the membership check."""
+    assert _argv_matches(
+        ["pypi-server", "run", "8080"],  # discovered, no -p
+        ["pypi-server", "run", "-p", "8080"],  # expected has -p (skipped)
+    )
+
+
+def test_argv_matches_rejects_different_executable():
+    assert not _argv_matches(["nginx", "-c", "/etc/nginx.conf"], ["pypi-server"])
+
+
+def test_argv_matches_rejects_missing_token():
+    assert not _argv_matches(
+        ["pypi-server", "run"],
+        ["pypi-server", "run", ".", "-p", "8080"],
+    )
+
+
+def test_argv_matches_rejects_empty():
+    assert not _argv_matches([], ["pypi-server"])
+    assert not _argv_matches(["pypi-server"], [])
+
+
+# --------- find_by_port ---------
+
+
+def test_find_by_port_returns_none_on_non_linux(monkeypatch):
+    """Non-Linux platforms get None without hitting /proc."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert _pid.find_by_port(8080, expected_argv=["pypi-server"]) is None
+
+
+def test_find_by_port_returns_none_when_no_listener(tmp_path):
+    proc = tmp_path / "proc"
+    (proc / "net").mkdir(parents=True)
+    (proc / "net" / "tcp").write_text("\n")
+    assert _pid.find_by_port(8080, expected_argv=["pypi-server"], proc_root=proc) is None
+
+
+def test_find_by_port_returns_none_when_proc_root_missing(tmp_path):
+    assert (
+        _pid.find_by_port(
+            8080,
+            expected_argv=["pypi-server"],
+            proc_root=tmp_path / "does-not-exist",
+        )
+        is None
+    )
+
+
+@linux_only
+def test_find_by_port_happy_path(tmp_path):
+    """argv match → returns PID."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    pid_dir = proc / "1234"
+    pid_dir.mkdir()
+    (pid_dir / "cmdline").write_bytes(b"pypi-server\x00run\x00-p\x008080\x00.\x00")
+    fd_dir = pid_dir / "fd"
+    fd_dir.mkdir()
+    (fd_dir / "3").symlink_to("socket:[9999]")
+    net_dir = proc / "net"
+    net_dir.mkdir()
+    # 1F90 = 8080 in hex
+    (net_dir / "tcp").write_text(
+        "  sl local rem st\n"
+        "   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 "
+        "00000000  1000        0 9999 1 ffff 100 0 0 10 0\n"
+    )
+
+    pid = _pid.find_by_port(
+        8080,
+        expected_argv=["pypi-server", "run", "-p", "8080", "."],
+        proc_root=proc,
+    )
+    assert pid == 1234
+
+
+@linux_only
+def test_find_by_port_argv_mismatch_returns_none(tmp_path):
+    """Listener exists on port but its argv doesn't match expected → None (footgun guard)."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    pid_dir = proc / "1234"
+    pid_dir.mkdir()
+    (pid_dir / "cmdline").write_bytes(b"nginx\x00-c\x00/etc/nginx.conf\x00")
+    fd_dir = pid_dir / "fd"
+    fd_dir.mkdir()
+    (fd_dir / "3").symlink_to("socket:[9999]")
+    net_dir = proc / "net"
+    net_dir.mkdir()
+    (net_dir / "tcp").write_text(
+        "  sl local rem st\n"
+        "   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 "
+        "00000000  1000        0 9999 1 ffff 100 0 0 10 0\n"
+    )
+
+    pid = _pid.find_by_port(
+        8080,
+        expected_argv=["pypi-server", "run", "-p", "8080"],
+        proc_root=proc,
+    )
+    assert pid is None
+
+
+@linux_only
+def test_find_by_port_wrong_port_returns_none(tmp_path):
+    """Listener bound to port other than asked → no match."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    pid_dir = proc / "1234"
+    pid_dir.mkdir()
+    (pid_dir / "cmdline").write_bytes(b"pypi-server\x00run\x00-p\x008080\x00")
+    fd_dir = pid_dir / "fd"
+    fd_dir.mkdir()
+    (fd_dir / "3").symlink_to("socket:[9999]")
+    net_dir = proc / "net"
+    net_dir.mkdir()
+    # 0050 = 80, not 8080
+    (net_dir / "tcp").write_text(
+        "  sl local rem st\n"
+        "   0: 0100007F:0050 00000000:0000 0A 00000000:00000000 00:00000000 "
+        "00000000  1000        0 9999 1 ffff 100 0 0 10 0\n"
+    )
+
+    assert _pid.find_by_port(8080, expected_argv=["pypi-server", "run"], proc_root=proc) is None
+
+
+def test_pidrecord_is_frozen():
+    """Frozen dataclass: assignment raises FrozenInstanceError."""
+    from dataclasses import FrozenInstanceError
+
+    rec = PidRecord(pid=1, argv=("x",), started_at="2026-04-30T00:00:00+00:00", port=8080)
+    with pytest.raises(FrozenInstanceError):
+        rec.pid = 2  # type: ignore[misc]

--- a/tests/test_actions_reprobe.py
+++ b/tests/test_actions_reprobe.py
@@ -123,3 +123,91 @@ def test_reprobe_early_exit_on_first_success(monkeypatch):
     assert result.status == "up"
     assert len(attempts) == 2  # first attempt at offset 0.5, success at offset 1.0
     assert len(sleep_calls) == 2  # sleeps before each of the two attempts
+
+
+def test_reprobe_desired_down_exits_on_absent(monkeypatch):
+    """desired='down' wins as soon as we observe absent (no listener)."""
+    from auntiepypi._actions import _reprobe
+
+    attempts = []
+
+    def fake_attempt(d):
+        attempts.append(d)
+        return _reprobe.ReprobeResult(status="absent")
+
+    monkeypatch.setattr(_reprobe, "_attempt", fake_attempt)
+    elapsed = [0.0]
+
+    def fake_now():
+        return elapsed[0]
+
+    def fake_sleep(s):
+        elapsed[0] += s
+
+    result = probe(
+        _detection(1),
+        budget_seconds=5.0,
+        desired="down",
+        _sleep=fake_sleep,
+        _now=fake_now,
+    )
+    assert result.status == "absent"
+    assert len(attempts) == 1  # first attempt observed absent → exit
+
+
+def test_reprobe_desired_down_keeps_polling_while_up(monkeypatch):
+    """desired='down' continues across attempts while status remains 'up'."""
+    from auntiepypi._actions import _reprobe
+
+    attempts = []
+
+    def fake_attempt(d):
+        attempts.append(d)
+        # Stay 'up' for first 3 attempts, then 'down'
+        return _reprobe.ReprobeResult(status="up" if len(attempts) <= 3 else "down")
+
+    monkeypatch.setattr(_reprobe, "_attempt", fake_attempt)
+    elapsed = [0.0]
+
+    def fake_now():
+        return elapsed[0]
+
+    def fake_sleep(s):
+        elapsed[0] += s
+
+    result = probe(
+        _detection(1),
+        budget_seconds=5.0,
+        desired="down",
+        _sleep=fake_sleep,
+        _now=fake_now,
+    )
+    assert result.status == "down"
+    assert len(attempts) == 4
+
+
+def test_reprobe_desired_down_exhausts_when_still_up(monkeypatch):
+    """desired='down' but server stays up for the full budget → returns final 'up'."""
+    from auntiepypi._actions import _reprobe
+
+    monkeypatch.setattr(
+        _reprobe,
+        "_attempt",
+        lambda d: _reprobe.ReprobeResult(status="up"),
+    )
+    elapsed = [0.0]
+
+    def fake_now():
+        return elapsed[0]
+
+    def fake_sleep(s):
+        elapsed[0] += s
+
+    result = probe(
+        _detection(1),
+        budget_seconds=5.0,
+        desired="down",
+        _sleep=fake_sleep,
+        _now=fake_now,
+    )
+    assert result.status == "up"  # ran the whole budget, never matched desired

--- a/tests/test_actions_reprobe.py
+++ b/tests/test_actions_reprobe.py
@@ -156,15 +156,19 @@ def test_reprobe_desired_down_exits_on_absent(monkeypatch):
 
 
 def test_reprobe_desired_down_keeps_polling_while_up(monkeypatch):
-    """desired='down' continues across attempts while status remains 'up'."""
+    """desired='down' continues across attempts while status remains 'up'.
+
+    desired='down' matches only 'absent' (port unbound) — 'down' (TCP open
+    but HTTP error) is treated as "still up" for stop's purposes.
+    """
     from auntiepypi._actions import _reprobe
 
     attempts = []
 
     def fake_attempt(d):
         attempts.append(d)
-        # Stay 'up' for first 3 attempts, then 'down'
-        return _reprobe.ReprobeResult(status="up" if len(attempts) <= 3 else "down")
+        # Stay 'up' for first 3 attempts, then 'absent'
+        return _reprobe.ReprobeResult(status="up" if len(attempts) <= 3 else "absent")
 
     monkeypatch.setattr(_reprobe, "_attempt", fake_attempt)
     elapsed = [0.0]
@@ -182,7 +186,7 @@ def test_reprobe_desired_down_keeps_polling_while_up(monkeypatch):
         _sleep=fake_sleep,
         _now=fake_now,
     )
-    assert result.status == "down"
+    assert result.status == "absent"
     assert len(attempts) == 4
 
 

--- a/tests/test_actions_systemd_user.py
+++ b/tests/test_actions_systemd_user.py
@@ -66,7 +66,7 @@ def test_systemd_user_happy_path(monkeypatch):
         systemd_user, "probe", lambda *a, **kw: type("R", (), {"status": "up", "detail": None})()
     )
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is True
     assert result.detail == "started"
     assert runner.last_call[0][0] == ["systemctl", "--user", "start", "x.service"]
@@ -79,7 +79,7 @@ def test_systemd_user_systemctl_nonzero(monkeypatch):
         systemd_user, "probe", lambda *a, **kw: type("R", (), {"status": "down", "detail": None})()
     )
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is False
     assert "exit 5" in result.detail
     assert "Failed to start" in result.detail
@@ -92,7 +92,7 @@ def test_systemd_user_systemctl_ok_but_reprobe_fails(monkeypatch):
         systemd_user, "probe", lambda *a, **kw: type("R", (), {"status": "down", "detail": None})()
     )
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is False
     assert "systemctl ok but server not responding" in result.detail
 
@@ -101,7 +101,7 @@ def test_systemd_user_not_on_path(monkeypatch):
     runner = _FakeRunner(raise_=FileNotFoundError("systemctl"))
     monkeypatch.setattr(systemd_user, "RUN", runner)
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is False
     assert "systemctl not found" in result.detail
 
@@ -110,13 +110,13 @@ def test_systemd_user_timeout(monkeypatch):
     runner = _FakeRunner(raise_=subprocess.TimeoutExpired(cmd="systemctl", timeout=15))
     monkeypatch.setattr(systemd_user, "RUN", runner)
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is False
     assert "timed out" in result.detail
 
 
 def test_systemd_user_missing_unit(monkeypatch):
-    result = systemd_user.apply(_det(), _spec(unit=None))
+    result = systemd_user.start(_det(), _spec(unit=None))
     assert result.ok is False
     assert "unit" in result.detail
 
@@ -126,7 +126,7 @@ def test_systemd_user_oserror_catch_all(monkeypatch):
     runner = _FakeRunner(raise_=PermissionError("systemctl"))
     monkeypatch.setattr(systemd_user, "RUN", runner)
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is False
     assert "PermissionError" in result.detail
 
@@ -136,7 +136,7 @@ def test_systemd_user_nonzero_with_empty_stderr(monkeypatch):
     runner = _FakeRunner(returncode=3, stderr="", stdout="")
     monkeypatch.setattr(systemd_user, "RUN", runner)
 
-    result = systemd_user.apply(_det(), _spec())
+    result = systemd_user.start(_det(), _spec())
     assert result.ok is False
     assert result.detail == "systemctl exit 3"  # no trailing colon, no trailing space
     assert not result.detail.endswith(":")

--- a/tests/test_actions_systemd_user_lifecycle.py
+++ b/tests/test_actions_systemd_user_lifecycle.py
@@ -1,0 +1,184 @@
+"""Tests for `systemd_user.stop` and `systemd_user.restart`.
+
+Both shell out to `systemctl --user <verb> <unit>` via the `RUN`
+indirection that the v0.4.0 start path already uses.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+from auntiepypi._actions import systemd_user
+from auntiepypi._detect._config import ServerSpec
+from auntiepypi._detect._detection import Detection
+
+
+@dataclass
+class _FakeRunner:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    raise_: BaseException | None = None
+    last_call: tuple = ()
+
+    def __call__(self, *args, **kw):
+        self.last_call = (args, kw)
+        if self.raise_:
+            raise self.raise_
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=self.returncode,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
+
+def _spec(unit: str | None = "x.service") -> ServerSpec:
+    return ServerSpec(
+        name="t",
+        flavor="pypiserver",
+        host="127.0.0.1",
+        port=8080,
+        managed_by="systemd-user",
+        unit=unit,
+    )
+
+
+def _det() -> Detection:
+    return Detection(
+        name="t",
+        flavor="pypiserver",
+        host="127.0.0.1",
+        port=8080,
+        url="http://127.0.0.1:8080/",
+        status="up",
+        source="declared",
+    )
+
+
+# --------- stop ---------
+
+
+def test_stop_happy_path(monkeypatch):
+    runner = _FakeRunner(returncode=0)
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+    monkeypatch.setattr(
+        systemd_user,
+        "probe",
+        lambda *a, **kw: type("R", (), {"status": "down", "detail": None})(),
+    )
+
+    result = systemd_user.stop(_det(), _spec())
+    assert result.ok is True
+    assert result.detail == "stopped"
+    assert runner.last_call[0][0] == ["systemctl", "--user", "stop", "x.service"]
+
+
+def test_stop_already_inactive_returns_stopped(monkeypatch):
+    """systemctl returns 0 even when unit is already inactive."""
+    runner = _FakeRunner(returncode=0)
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+    monkeypatch.setattr(
+        systemd_user,
+        "probe",
+        lambda *a, **kw: type("R", (), {"status": "absent", "detail": None})(),
+    )
+
+    result = systemd_user.stop(_det(), _spec())
+    assert result.ok is True
+    assert result.detail == "stopped"
+
+
+def test_stop_systemctl_nonzero(monkeypatch):
+    runner = _FakeRunner(returncode=1, stderr="Failed to stop\nblah")
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+
+    result = systemd_user.stop(_det(), _spec())
+    assert result.ok is False
+    assert "exit 1" in result.detail
+
+
+def test_stop_systemctl_ok_but_port_still_up(monkeypatch):
+    runner = _FakeRunner(returncode=0)
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+    monkeypatch.setattr(
+        systemd_user,
+        "probe",
+        lambda *a, **kw: type("R", (), {"status": "up", "detail": None})(),
+    )
+
+    result = systemd_user.stop(_det(), _spec())
+    assert result.ok is False
+    assert "still responding" in result.detail
+
+
+def test_stop_missing_unit():
+    result = systemd_user.stop(_det(), _spec(unit=None))
+    assert result.ok is False
+    assert "unit" in result.detail
+
+
+def test_stop_systemctl_not_on_path(monkeypatch):
+    runner = _FakeRunner(raise_=FileNotFoundError("systemctl"))
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+
+    result = systemd_user.stop(_det(), _spec())
+    assert result.ok is False
+    assert "systemctl not found" in result.detail
+
+
+# --------- restart ---------
+
+
+def test_restart_happy_path(monkeypatch):
+    runner = _FakeRunner(returncode=0)
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+    monkeypatch.setattr(
+        systemd_user,
+        "probe",
+        lambda *a, **kw: type("R", (), {"status": "up", "detail": None})(),
+    )
+
+    result = systemd_user.restart(_det(), _spec())
+    assert result.ok is True
+    assert result.detail == "restarted"
+    assert runner.last_call[0][0] == ["systemctl", "--user", "restart", "x.service"]
+
+
+def test_restart_systemctl_nonzero(monkeypatch):
+    runner = _FakeRunner(returncode=2, stderr="unit not found")
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+
+    result = systemd_user.restart(_det(), _spec())
+    assert result.ok is False
+    assert "exit 2" in result.detail
+
+
+def test_restart_ok_but_reprobe_fails(monkeypatch):
+    runner = _FakeRunner(returncode=0)
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+    monkeypatch.setattr(
+        systemd_user,
+        "probe",
+        lambda *a, **kw: type("R", (), {"status": "down", "detail": None})(),
+    )
+
+    result = systemd_user.restart(_det(), _spec())
+    assert result.ok is False
+    assert "not responding after restart" in result.detail
+
+
+def test_restart_missing_unit():
+    result = systemd_user.restart(_det(), _spec(unit=None))
+    assert result.ok is False
+    assert "unit" in result.detail
+
+
+def test_restart_timeout(monkeypatch):
+    runner = _FakeRunner(raise_=subprocess.TimeoutExpired(cmd="systemctl", timeout=15))
+    monkeypatch.setattr(systemd_user, "RUN", runner)
+
+    result = systemd_user.restart(_det(), _spec())
+    assert result.ok is False
+    assert "timed out" in result.detail

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -324,8 +324,9 @@ command = ["echo", "hi"]
     )
     captured = {}
 
-    def fake_dispatch(det, spec):
+    def fake_dispatch(action, det, spec):
         captured["called"] = True
+        captured["action"] = action
         return ActionResult(ok=True, detail="started", pid=12345)
 
     monkeypatch.setattr("auntiepypi.cli._commands.doctor._actions.dispatch", fake_dispatch)
@@ -369,7 +370,7 @@ command = ["false"]
     )
     monkeypatch.setattr(
         "auntiepypi.cli._commands.doctor._actions.dispatch",
-        lambda det, spec: ActionResult(ok=False, detail="exited immediately"),
+        lambda action, det, spec: ActionResult(ok=False, detail="exited immediately"),
     )
     with pytest.raises(AfiError) as excinfo:
         cmd_doctor(_make_args(apply=True))
@@ -422,7 +423,7 @@ command = ["echo", "hi"]
     )
     monkeypatch.setattr(
         "auntiepypi.cli._commands.doctor._actions.dispatch",
-        lambda det, spec: ActionResult(ok=True, detail="started"),
+        lambda action, det, spec: ActionResult(ok=True, detail="started"),
     )
     cmd_doctor(_make_args(apply=True))
     bak_files = list(tmp_path.glob("pyproject.toml.*.bak"))
@@ -593,7 +594,7 @@ command = ["echo", "hi"]
     )
     monkeypatch.setattr(
         "auntiepypi.cli._commands.doctor._actions.dispatch",
-        lambda d, s: ActionResult(
+        lambda action, d, s: ActionResult(
             ok=True, detail="started", log_path="/var/log/auntiepypi/x.log", pid=42
         ),
     )
@@ -680,7 +681,7 @@ command = ["echo", "hi"]
     )
     monkeypatch.setattr(
         "auntiepypi.cli._commands.doctor._actions.dispatch",
-        lambda d, s: ActionResult(ok=True, detail="started", pid=42),
+        lambda action, d, s: ActionResult(ok=True, detail="started", pid=42),
     )
     cmd_doctor(_make_args(apply=True, json=True))
     out = capsys.readouterr().out

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -1,0 +1,417 @@
+"""Tests for the v0.5.0 lifecycle verbs (`auntie up` / `down` / `restart`).
+
+These exercise the shared `_lifecycle.run_lifecycle` core. Per-verb
+test files (`test_cli_up.py` etc.) only verify the wiring (parser
+registration + subcommand resolution).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from auntiepypi import _actions
+from auntiepypi._actions._action import ActionResult
+from auntiepypi.cli import main
+from auntiepypi.cli._errors import EXIT_ENV_ERROR, EXIT_SUCCESS, EXIT_USER_ERROR
+
+
+def _write_pyproject(tmp_path, body: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(body)
+
+
+@pytest.fixture
+def stub_dispatch(monkeypatch):
+    """Replace _actions.dispatch with a controllable stub.
+
+    Set the fixture's `result` attribute to control what every dispatch
+    call returns. Inspect `calls` to assert.
+    """
+
+    class _Stub:
+        def __init__(self):
+            self.result = ActionResult(ok=True, detail="started")
+            self.calls: list[tuple] = []
+
+        def __call__(self, action, det, spec):
+            self.calls.append((action, det.name, spec.name, spec.managed_by))
+            return self.result
+
+    stub = _Stub()
+    monkeypatch.setattr(_actions, "dispatch", stub)
+    # _lifecycle imports _actions module; _actions.dispatch is the routing
+    # function so monkeypatching that directly is sufficient.
+    return stub
+
+
+# --------- Bare invocation reservation ---------
+
+
+def test_up_bare_invocation_exits_2_with_v060_message(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    rc = main(["up"])
+    assert rc == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "v0.6.0" in err
+    assert "auntie up <name>" in err or "auntie up --all" in err
+
+
+def test_down_bare_invocation_exits_2(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    rc = main(["down"])
+    assert rc == EXIT_USER_ERROR
+    assert "v0.6.0" in capsys.readouterr().err
+
+
+def test_restart_bare_invocation_exits_2(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    rc = main(["restart"])
+    assert rc == EXIT_USER_ERROR
+    assert "v0.6.0" in capsys.readouterr().err
+
+
+# --------- Single-target happy paths ---------
+
+
+def test_up_single_name_dispatches_start(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+host = "127.0.0.1"
+port = 8080
+managed_by = "command"
+command = ["pypi-server", "run"]
+""",
+    )
+    rc = main(["up", "main"])
+    assert rc == EXIT_SUCCESS
+    assert len(stub_dispatch.calls) == 1
+    assert stub_dispatch.calls[0][0] == "start"
+    assert stub_dispatch.calls[0][2] == "main"
+
+
+def test_down_single_name_dispatches_stop(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "systemd-user"
+unit = "main.service"
+""",
+    )
+    stub_dispatch.result = ActionResult(ok=True, detail="stopped")
+    rc = main(["down", "main"])
+    assert rc == EXIT_SUCCESS
+    assert stub_dispatch.calls[0][0] == "stop"
+
+
+def test_restart_single_name_dispatches_restart(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "systemd-user"
+unit = "main.service"
+""",
+    )
+    stub_dispatch.result = ActionResult(ok=True, detail="restarted")
+    rc = main(["restart", "main"])
+    assert rc == EXIT_SUCCESS
+    assert stub_dispatch.calls[0][0] == "restart"
+
+
+# --------- Refusal for unsupervised modes ---------
+
+
+def test_up_refuses_managed_by_manual(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "manual"
+""",
+    )
+    rc = main(["up", "main"])
+    assert rc == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "manual" in err
+    assert "does not supervise" in err
+    assert stub_dispatch.calls == []  # never reached dispatch
+
+
+def test_up_refuses_managed_by_docker(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "docker"
+dockerfile = "./Dockerfile"
+""",
+    )
+    rc = main(["up", "main"])
+    assert rc == EXIT_USER_ERROR
+    assert "docker" in capsys.readouterr().err
+
+
+# --------- Unknown target ---------
+
+
+def test_up_unknown_target_exits_1(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    rc = main(["up", "nonexistent"])
+    assert rc == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "unknown TARGET" in err
+    assert "'nonexistent'" in err
+
+
+# --------- --all path ---------
+
+
+def test_up_all_dispatches_every_supervised(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "first"
+flavor = "pypiserver"
+port = 18080
+managed_by = "command"
+command = ["pypi-server"]
+
+[[tool.auntiepypi.servers]]
+name = "second"
+flavor = "devpi"
+port = 13141
+managed_by = "systemd-user"
+unit = "second.service"
+
+[[tool.auntiepypi.servers]]
+name = "manual-one"
+flavor = "pypiserver"
+port = 28080
+managed_by = "manual"
+""",
+    )
+    rc = main(["up", "--all"])
+    assert rc == EXIT_SUCCESS
+    # Two supervised dispatches; manual-one skipped
+    names = [c[2] for c in stub_dispatch.calls]
+    assert "first" in names
+    assert "second" in names
+    assert "manual-one" not in names
+
+
+def test_up_all_with_no_servers_returns_success(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    rc = main(["up", "--all"])
+    assert rc == EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "nothing to do" in out
+    assert stub_dispatch.calls == []
+
+
+def test_up_all_partial_failure_exits_2(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "first"
+flavor = "pypiserver"
+port = 18080
+managed_by = "command"
+command = ["pypi-server"]
+
+[[tool.auntiepypi.servers]]
+name = "second"
+flavor = "pypiserver"
+port = 18081
+managed_by = "command"
+command = ["pypi-server"]
+""",
+    )
+    # Second call fails
+    seq = [
+        ActionResult(ok=True, detail="started", pid=111),
+        ActionResult(ok=False, detail="exited immediately"),
+    ]
+    it = iter(seq)
+    stub_dispatch.calls = []  # reset
+    monkeypatch.setattr(
+        _actions,
+        "dispatch",
+        lambda action, det, spec: (
+            stub_dispatch.calls.append((action, det.name, spec.name, spec.managed_by)) or next(it)
+        ),
+    )
+    rc = main(["up", "--all"])
+    assert rc == EXIT_ENV_ERROR
+
+
+# --------- --json envelope ---------
+
+
+def test_up_json_payload(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "command"
+command = ["pypi-server"]
+""",
+    )
+    log_path = str(tmp_path / "x.log")
+    stub_dispatch.result = ActionResult(ok=True, detail="started", pid=999, log_path=log_path)
+    rc = main(["up", "main", "--json"])
+    assert rc == EXIT_SUCCESS
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verb"] == "up"
+    assert len(payload["results"]) == 1
+    entry = payload["results"][0]
+    assert entry["name"] == "main"
+    assert entry["ok"] is True
+    assert entry["detail"] == "started"
+    assert entry["pid"] == 999
+    assert entry["log_path"] == log_path
+
+
+def test_down_json_omits_pid_when_unset(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "systemd-user"
+unit = "main.service"
+""",
+    )
+    stub_dispatch.result = ActionResult(ok=True, detail="stopped")  # no pid
+    rc = main(["down", "main", "--json"])
+    assert rc == EXIT_SUCCESS
+
+    payload = json.loads(capsys.readouterr().out)
+    entry = payload["results"][0]
+    assert "pid" not in entry  # absent when None
+    assert "log_path" not in entry
+
+
+# --------- --decide=duplicate ---------
+
+
+def test_up_duplicate_name_requires_decide(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "command"
+command = ["pypi-server", "-p", "8080"]
+
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "devpi"
+port = 3141
+managed_by = "command"
+command = ["devpi-server", "--port", "3141"]
+""",
+    )
+    rc = main(["up", "main"])
+    assert rc == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "ambiguous" in err
+    assert "duplicate:main=1" in err
+    assert "=2" in err
+
+
+def test_up_decide_picks_specific_duplicate(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "command"
+command = ["pypi-server", "-p", "8080"]
+
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "devpi"
+port = 3141
+managed_by = "command"
+command = ["devpi-server"]
+""",
+    )
+    rc = main(["up", "main", "--decide=duplicate:main=2"])
+    assert rc == EXIT_SUCCESS
+    # Verify the second declaration (devpi) was the one dispatched
+    assert len(stub_dispatch.calls) == 1
+    # Inspect via spec: managed_by + name match, but we don't expose
+    # spec.flavor to the stub_dispatch wrapper. The test trusts that
+    # _resolve_one_spec correctly selected index 2.
+
+
+def test_up_decide_out_of_range_exits_1(tmp_path, monkeypatch, stub_dispatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "pypiserver"
+port = 8080
+managed_by = "command"
+command = ["pypi-server"]
+
+[[tool.auntiepypi.servers]]
+name = "main"
+flavor = "devpi"
+port = 3141
+managed_by = "command"
+command = ["devpi-server"]
+""",
+    )
+    rc = main(["up", "main", "--decide=duplicate:main=5"])
+    assert rc == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "out of range" in err

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -48,7 +48,7 @@ def stub_dispatch(monkeypatch):
 # --------- Bare invocation reservation ---------
 
 
-def test_up_bare_invocation_exits_2_with_v060_message(tmp_path, monkeypatch, capsys):
+def test_up_bare_invocation_exits_1_with_v060_message(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
     _write_pyproject(tmp_path, "")
     rc = main(["up"])
@@ -58,7 +58,7 @@ def test_up_bare_invocation_exits_2_with_v060_message(tmp_path, monkeypatch, cap
     assert "auntie up <name>" in err or "auntie up --all" in err
 
 
-def test_down_bare_invocation_exits_2(tmp_path, monkeypatch, capsys):
+def test_down_bare_invocation_exits_1(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
     _write_pyproject(tmp_path, "")
     rc = main(["down"])
@@ -66,7 +66,7 @@ def test_down_bare_invocation_exits_2(tmp_path, monkeypatch, capsys):
     assert "v0.6.0" in capsys.readouterr().err
 
 
-def test_restart_bare_invocation_exits_2(tmp_path, monkeypatch, capsys):
+def test_restart_bare_invocation_exits_1(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
     _write_pyproject(tmp_path, "")
     rc = main(["restart"])

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "auntiepypi"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Three new lifecycle verbs: `auntie up`, `auntie down`, `auntie restart` against declared servers (`managed_by ∈ {systemd-user, command}`). Bare invocation reserved for v0.6.0's first-party server.
- `_actions/` strategy contract widened from single `apply()` to sibling `start` / `stop` / `restart` per strategy; `dispatch(action, det, spec)` routes on the (managed_by, action) pair.
- PID-file + sidecar tracking for `command`-managed servers (`$XDG_STATE_HOME/auntiepypi/<slug>.{pid,json}`), with a Linux argv-matched port-walk fallback when no PID file exists.

## Brainstorm decisions (locked)

1. **Immediate-action verbs** — no `--apply` gate. The dry-run-first rule protects persistent state (`pyproject.toml`); lifecycle operates on volatile process state. `systemctl start` model.
2. **Eager PID file + argv-matched port-walk fallback** — `command.start` writes `<slug>.pid` + `<slug>.json` atomically (tempfile.mkstemp → os.replace); `down` reads it, SIGTERM-with-grace, SIGKILL fallback. Port-walk fallback covers servers started outside `auntie up`; refuses to kill if the listener's argv doesn't match the declaration.
3. **Three sibling strategy functions** — `start` / `stop` / `restart` per strategy. Internal rename `apply` → `start`. `ACTIONS` is now `dict[str, dict[str, Strategy]]`.
4. **Bare verb reserved for v0.6.0** — `auntie up` / `down` / `restart` with no target and no `--all` exits 1 with a forward-pointing message. v0.5.0 only accepts `<name>` and `--all`.
5. **Strategy-native restart; sidecar advisory** — `systemd-user` uses `systemctl --user restart`; `command` does stop+start, re-spawning from current `pyproject.toml` argv (drift logged, not blocking).

Spec: `docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md`.
Plan: `/home/spark/.claude/plans/dazzling-snacking-kay.md` (14 tasks, 10 commits).

## Test plan

- [x] `uv run pytest -n auto --cov=auntiepypi` → 360 pass, 0 fail, coverage 94.45%
- [x] `uv run black --check && uv run isort --check-only` → clean
- [x] `uv run flake8 auntiepypi tests` → clean
- [x] `uv run bandit -c pyproject.toml -r auntiepypi` → no issues
- [x] `uv run pylint --errors-only auntiepypi` → clean
- [x] `markdownlint-cli2 "**/*.md"` → clean
- [x] `bash .claude/skills/pr-review/scripts/portability-lint.sh` → clean
- [x] `uv run auntie --version` → 0.5.0
- [x] `uv run auntie up` → exit 1 with "lands in v0.6.0" message
- [x] `uv run auntie up --help` → subcommand help renders correctly
- [x] `uv run auntie learn --json | jq '.commands[].path'` → up/down/restart present
- [x] `uv run auntie explain up` → catalog entry renders
- [ ] CI green on PR (Qodo, Copilot, SonarCloud)

## Notes

- Coverage floor stays at 94 (lifecycle adds new OS-error / kill-race branches that are hard to trigger hermetically). Restoring 95 should ride along with the next test pass.
- `find_by_port` is Linux-only; non-Linux platforms get a graceful "already stopped" no-op when no PID file exists.
- The argv-match heuristic (basename(argv0) + every non-flag declared token appears in discovered) is conservative. If it bites in practice, v0.5.x can add `--force`.

- Claude