### PR TITLE
v0.6.0: first-party PEP 503 simple-index server

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,10 +12,10 @@ extend-ignore = E203, W503, S404, S603
 # Per-file ignores. Keep narrow; do not broaden to silence real findings.
 # tests/*:
 #   S101 — pytest tests are asserts by convention; flake8-bandit warns on assert.
-#   S104 — tests assert that "0.0.0.0" is REJECTED by the loopback validator;
-#          the literal is the test fixture, not a real bind.
-#   S108 — tests use literal /tmp paths as argparse fixtures; never created.
 #   S404 — `import subprocess` is a tool of the trade for invoking the CLI under test.
 #   S603 — `subprocess.run([sys.executable, "-m", ...])` is fully trusted input.
+# Narrower ignores (e.g. S104, S108, S5443) belong on the line that triggered
+# them via `# noqa: SXXX` — see tests/test_config_local.py and
+# tests/test_server_main.py for examples.
 per-file-ignores =
-    tests/*:S101,S104,S108,S404,S603
+    tests/*:S101,S404,S603

--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,10 @@ extend-ignore = E203, W503, S404, S603
 # Per-file ignores. Keep narrow; do not broaden to silence real findings.
 # tests/*:
 #   S101 — pytest tests are asserts by convention; flake8-bandit warns on assert.
+#   S104 — tests assert that "0.0.0.0" is REJECTED by the loopback validator;
+#          the literal is the test fixture, not a real bind.
+#   S108 — tests use literal /tmp paths as argparse fixtures; never created.
 #   S404 — `import subprocess` is a tool of the trade for invoking the CLI under test.
 #   S603 — `subprocess.run([sys.executable, "-m", ...])` is fully trusted input.
 per-file-ignores =
-    tests/*:S101,S404,S603
+    tests/*:S101,S104,S108,S404,S603

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-01
+
+### Added
+
+- First-party PEP 503 simple-index server (read-only slice). `python -m auntiepypi._server --host H --port P --root R` serves `GET /simple/`, `GET /simple/<pkg>/`, and `GET /files/<filename>` from a wheelhouse. Stdlib-only (`http.server` + `ThreadingHTTPServer`).
+- `auntie up` / `auntie down` / `auntie restart` (bare invocation) now start, stop, and restart the first-party server. The `auntie up --all` form aggregates the first-party server with every supervised declaration.
+- `[tool.auntiepypi.local]` config block: `host` (loopback only in v0.6.0), `port` (default 3141), `root` (default `$XDG_DATA_HOME/auntiepypi/wheels`). Validated at config-load time; non-loopback host is rejected with a v0.7.0 forward-pointer.
+- `_actions/auntie.py` — third managed_by strategy. Wraps `command.py` with a derived argv (`python -m auntiepypi._server …`) so PID-tracking, reprobe, and SIGTERM/SIGKILL escalation are reused from v0.5.0.
+- `_detect/_local.py` — emits one Detection (`source="local"`, `flavor="auntiepypi"`, `managed_by="auntie"`) on every `auntie overview` call. Runs first in `detect_all` so the default-port scanner skips its endpoint.
+- The name `"auntie"` is reserved. `auntie up auntie` (named target) errors with a clear remediation; the bare form is the only entry point to the first-party server.
+
+### Changed
+
+- `_lifecycle.run_lifecycle` no longer raises on bare invocation. The `_bare_invocation_message` / `_bare_invocation_error` helpers are deleted.
+- `SUPERVISED_MODES` gains `"auntie"`.
+- `_detect/_runtime.detect_all` order: `_local` → `_declared` → `_port` → `_proc`. The local detection's `(host, port)` enters `covered` so `_port.detect` doesn't double-report 127.0.0.1:3141 as `devpi`.
+- Catalog (`_ROOT`, `_LIFECYCLE_PREAMBLE`, `_UP`, `_DOWN`, `_RESTART`) and `learn` synopsis describe the first-party-server lifecycle path; the v0.6.0 forward-pointer prose is removed.
+
+### Fixed
+
 ## [0.5.0] - 2026-04-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,25 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Status: v0.4.0 — `doctor` lifecycle landed
+## Status: v0.6.0 — first-party PEP 503 server landed
 
-`auntie doctor` is now a managed_by-aware lifecycle dispatcher. The
-old `--fix` flag is replaced by `--apply`; `_probes/` is deleted and
-doctor consumes `_detect/` directly. A new `_actions/` module provides
-two dispatch strategies: `systemd-user` (starts a systemd user unit;
-stop is v0.5.0 territory) and `command` (runs an arbitrary shell command). Before any
-`pyproject.toml` mutation, a numbered `.bak` snapshot is written
-(`pyproject.toml.1.bak`, `pyproject.toml.2.bak`, …). The `packages`
-noun is permanently removed — use `auntie overview <PKG>` instead.
-Ambiguous duplicate-name entries are resolved via
-`--decide=duplicate:NAME=N`.
+Bare `auntie up` / `auntie down` / `auntie restart` now start, stop,
+and restart auntie's own PEP 503 simple-index server (read-only slice
+— `GET /simple/`, `GET /simple/<pkg>/`, `GET /files/<filename>`). The
+server is stdlib-only (`http.server` + `ThreadingHTTPServer`),
+configured by `[tool.auntiepypi.local]` (host loopback-only in v0.6.0,
+default port 3141, default wheelhouse
+`$XDG_DATA_HOME/auntiepypi/wheels/`), and plugs into the existing
+lifecycle machinery as a third managed_by strategy `"auntie"` that
+wraps `command.py` with a derived argv. The name `"auntie"` is
+reserved as a server name. `auntie overview` always surfaces a local
+section (status reflects the probe).
 
-See `docs/superpowers/specs/2026-04-30-auntiepypi-v0.4.0-doctor-lifecycle-design.md`
+`auntie publish`, HTTPS termination, and basic-auth are deferred to
+v0.7.0 (the auth + public-binding bundle). The mesh-aware service
+registry is v1.0.0.
+
+See `docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md`
 for the full design rationale.
 
 This file describes the repository **as it exists on disk today**. When
@@ -120,7 +125,7 @@ auntie <verb> [args] [--json]
 Both `auntie` and `auntiepypi` are registered console scripts pointing
 at the same `auntiepypi.cli:main`.
 
-Active verbs registered at v0.5.0:
+Active verbs registered at v0.6.0:
 
 - `auntie learn` (and `learn --json`) — self-teaching prompt generated
   from the `auntiepypi/explain/catalog.py` catalog so it can never
@@ -149,20 +154,21 @@ Active verbs registered at v0.5.0:
   one server. Exits `2` when `--apply` was attempted and any actionable
   server is still down after re-probe.
 - `auntie up [TARGET | --all] [--decide=...] [--json]` — start a
-  declared server. Bare invocation (no TARGET, no `--all`) exits `1`
-  with a forward-pointing message reserving the bare form for v0.6.0's
-  first-party server. `--all` acts on every supervised declaration
-  (managed_by ∈ {systemd-user, command}); other modes are skipped with
-  a stderr note. Per-target refusal for unsupervised modes.
+  server. **Bare** (no TARGET, no `--all`): start the first-party
+  PEP 503 server using `[tool.auntiepypi.local]`. **Named TARGET**:
+  one declared server (managed_by ∈ {systemd-user, command}; the name
+  `"auntie"` is reserved). **`--all`**: first-party server plus every
+  supervised declaration. Other modes are skipped with a stderr note.
 - `auntie down [TARGET | --all] [--decide=...] [--json]` — stop a
-  declared server. For `command`: SIGTERM with 5 s grace, SIGKILL
-  fallback, then PID file cleanup. Linux-only port-walk + argv-match
-  fallback when no PID file exists. Idempotent: nothing-to-stop is
-  `ok=True, detail="already stopped"`.
+  server. Same target shape as `up`. For `command` and `auntie`:
+  SIGTERM with 5 s grace, SIGKILL fallback, then PID file cleanup.
+  Linux-only port-walk + argv-match fallback when no PID file exists.
+  Idempotent: nothing-to-stop is `ok=True, detail="already stopped"`.
 - `auntie restart [TARGET | --all] [--decide=...] [--json]` — atomic
   for `systemd-user` (`systemctl --user restart`); stop+start for
-  `command`, re-spawning from the **current** pyproject `command`.
-  Sidecar argv drift is logged but never blocks the action.
+  `command` and the first-party server, re-spawning from the
+  **current** pyproject (`command` array or `[tool.auntiepypi.local]`
+  respectively). Sidecar argv drift is logged but never blocks.
 - `auntie whoami [--json]` — auth/env probe; reads `$PIP_INDEX_URL` /
   `$UV_INDEX_URL` env vars and pip's global config file. Exact paths
   inspected live in `auntiepypi/cli/_commands/whoami.py`.
@@ -215,10 +221,16 @@ burned on the `agentpypi → auntiepypi` rename. The table below uses
    for `command`; argv-matched port-walk fallback. Bare invocation
    reserved for v0.6.0. See spec
    `docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md`.
-6. **semver 0.6.0 — own server.** First-party PEP 503 simple-index for
-   mesh-private use; bare `auntie up` / `down` / `restart` start/stop
-   the in-process server. HTTPS surface introduced here.
-7. **semver 1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
+6. **semver 0.6.0 — own server (shipped).** First-party PEP 503
+   simple-index for mesh-private use (read-only slice); bare
+   `auntie up` / `down` / `restart` start/stop the in-process server.
+   `auntie` strategy wraps `command.py` with a derived argv. Loopback-
+   only binding; `"auntie"` is a reserved server name. See spec
+   `docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md`.
+7. **semver 0.7.0 — auth + public binding.** Basic-auth and HTTPS
+   termination, lifting the loopback restriction. `auntie publish`
+   upload path lands here too.
+8. **semver 1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
    service registry; trust boundary documented in `docs/threat-model.md`.
 
 This roadmap is descriptive of intent, not a commitment. Reorder or

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
 > running locally, and starts/stops/restarts declared servers —
 > informational first, actionable on demand.
 
-**Status:** v0.5.0 — lifecycle verbs landed. `auntie up`,
-`auntie down`, and `auntie restart` are first-class verbs against
-declared servers (`managed_by ∈ {systemd-user, command}`). The
-`_actions/` strategy contract has widened from a single `apply()` to
-sibling `start` / `stop` / `restart` per strategy. `command`-managed
-servers are now PID-tracked (`$XDG_STATE_HOME/auntiepypi/<slug>.pid`)
-with a Linux port-walk fallback. The bare invocation (`auntie up`
-with no target) is reserved for v0.6.0's first-party PyPI server.
+**Status:** v0.6.0 — first-party PEP 503 server landed. Bare
+`auntie up` / `auntie down` / `auntie restart` now start, stop, and
+restart auntie's own simple-index server (read-only slice; configured
+by `[tool.auntiepypi.local]`; loopback-only). Wheels in
+`$XDG_DATA_HOME/auntiepypi/wheels/` are served from
+`http://127.0.0.1:3141/simple/` and installable via
+`pip install --index-url`. Lifecycle verbs continue to work against
+declared servers (`managed_by ∈ {systemd-user, command}`); `--all`
+now aggregates the first-party server with every supervised
+declaration. `auntie publish`, HTTPS, and basic-auth are deferred to
+v0.7.0.
 
 ## Quick start
 
@@ -24,8 +27,10 @@ auntie overview --json | jq '.sections[] | select(.category == "servers")'
 auntie overview requests            # deep-dive into a PyPI package
 auntie doctor                       # diagnose declared servers (dry-run)
 auntie doctor --apply               # act on actionable remediations
+auntie up                           # start the first-party PEP 503 server
 auntie up <name>                    # start one declared server
-auntie down --all                   # stop every supervised server
+auntie up --all                     # first-party server + every supervised declaration
+auntie down                         # stop the first-party server
 auntie restart <name>               # atomic for systemd-user; stop+start for command
 ```
 

--- a/auntiepypi/_actions/__init__.py
+++ b/auntiepypi/_actions/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Callable, Literal
 
+from auntiepypi._actions import auntie as _auntie
 from auntiepypi._actions import command as _command
 from auntiepypi._actions import systemd_user as _systemd_user
 from auntiepypi._actions._action import ActionResult
@@ -36,6 +37,11 @@ ACTIONS: dict[str, StrategyMap] = {
         "start": _command.start,
         "stop": _command.stop,
         "restart": _command.restart,
+    },
+    "auntie": {
+        "start": _auntie.start,
+        "stop": _auntie.stop,
+        "restart": _auntie.restart,
     },
 }
 

--- a/auntiepypi/_actions/_reprobe.py
+++ b/auntiepypi/_actions/_reprobe.py
@@ -45,8 +45,11 @@ def _attempt(detection: Detection) -> ReprobeResult:
     if not 200 <= outcome.http_status < 300:
         return ReprobeResult(status="down", detail=f"http {outcome.http_status}")
 
-    # 2xx — verify flavor unless declared flavor is "unknown"
-    if detection.flavor != "unknown":
+    # 2xx — verify flavor unless declared flavor is "unknown" or
+    # "auntiepypi" (the first-party server's PEP 503 surface looks
+    # identical to pypiserver via the HREF fingerprint, so the check
+    # would always claim a flavor mismatch).
+    if detection.flavor not in ("unknown", "auntiepypi"):
         observed = fingerprint_flavor(outcome.body, content_type(outcome))
         if observed != detection.flavor and observed != "unknown":
             return ReprobeResult(

--- a/auntiepypi/_actions/auntie.py
+++ b/auntiepypi/_actions/auntie.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 import sys
 from dataclasses import replace
 
+from auntiepypi._actions import _pid
 from auntiepypi._actions import command as _command
 from auntiepypi._actions._action import ActionResult
+from auntiepypi._actions._reprobe import probe
 from auntiepypi._detect._config import ServerSpec, load_local_config
 from auntiepypi._detect._detection import Detection
 from auntiepypi._server._config import LocalConfig
@@ -61,10 +63,25 @@ def _materialize(declaration: ServerSpec) -> ServerSpec:
 
 def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     materialized = _materialize(declaration)
+    cfg = load_local_config()
+
+    # Idempotency: if the configured port is already serving 200 AND we
+    # have a live PID file pointing at it, return success without
+    # spawning a duplicate. Without this, repeated `auntie up` calls
+    # either fail with a bind error or quietly orphan the previous
+    # process by overwriting the PID file.
+    if probe(detection, budget_seconds=0.5).status == "up":
+        record = _pid.read(declaration.name, materialized.port)
+        if record is not None:
+            return ActionResult(
+                ok=True,
+                detail="already started",
+                pid=record.pid,
+            )
+
     # Ensure the wheelhouse exists; the server itself tolerates missing
     # roots (returns empty index), but the operator probably wants the
     # directory created on first ``auntie up``.
-    cfg = load_local_config()
     try:
         cfg.root.mkdir(parents=True, exist_ok=True)
     except OSError as err:

--- a/auntiepypi/_actions/auntie.py
+++ b/auntiepypi/_actions/auntie.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import replace
+from typing import cast
 
 from auntiepypi._actions import _pid
 from auntiepypi._actions import command as _command
@@ -52,12 +53,17 @@ def _materialize(declaration: ServerSpec) -> ServerSpec:
     editing pyproject between start and restart).
     """
     cfg = load_local_config()
-    return replace(
-        declaration,
-        host=cfg.host,
-        port=cfg.port,
-        managed_by="command",
-        command=_argv(cfg),
+    # ``dataclasses.replace`` is annotated as returning ``DataclassInstance``
+    # in the typeshed stubs; cast back to ServerSpec for the call site.
+    return cast(
+        ServerSpec,
+        replace(
+            declaration,
+            host=cfg.host,
+            port=cfg.port,
+            managed_by="command",
+            command=_argv(cfg),
+        ),
     )
 
 

--- a/auntiepypi/_actions/auntie.py
+++ b/auntiepypi/_actions/auntie.py
@@ -1,0 +1,83 @@
+"""Strategy for `managed_by = "auntie"`: the first-party PEP 503 server.
+
+Builds the argv at call time from ``[tool.auntiepypi.local]`` (or
+defaults when the table is absent) and delegates to the ``command``
+strategy. The bare-form CLI (``auntie up`` / ``down`` / ``restart``)
+synthesizes a ``ServerSpec(name="auntie", managed_by="auntie", ...)``
+that lacks a literal ``command`` field; this module fills it in by
+shelling out to ``sys.executable -m auntiepypi._server …``.
+
+Why delegate rather than duplicate command.py: the v0.5.0 lifecycle
+contract (PID file + sidecar + reprobe + SIGTERM/SIGKILL escalation +
+port-walk fallback + argv-match guard) is already covered by
+``command``; reproducing it here would be ~150 lines of drift-prone
+copy. The ``auntie`` strategy is "command with a derived argv."
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+
+from auntiepypi._actions import command as _command
+from auntiepypi._actions._action import ActionResult
+from auntiepypi._detect._config import ServerSpec, load_local_config
+from auntiepypi._detect._detection import Detection
+from auntiepypi._server._config import LocalConfig
+
+
+def _argv(cfg: LocalConfig) -> tuple[str, ...]:
+    return (
+        sys.executable,
+        "-m",
+        "auntiepypi._server",
+        "--host",
+        cfg.host,
+        "--port",
+        str(cfg.port),
+        "--root",
+        str(cfg.root),
+    )
+
+
+def _materialize(declaration: ServerSpec) -> ServerSpec:
+    """Fill in ``command`` from current ``[tool.auntiepypi.local]`` and
+    flip ``managed_by`` so command.py recognizes it.
+
+    The detection's ``host``/``port`` already came from the same
+    config in the bare-form path, so they should agree — but the
+    config is the source of truth on each call (handles the user
+    editing pyproject between start and restart).
+    """
+    cfg = load_local_config()
+    return replace(
+        declaration,
+        host=cfg.host,
+        port=cfg.port,
+        managed_by="command",
+        command=_argv(cfg),
+    )
+
+
+def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    materialized = _materialize(declaration)
+    # Ensure the wheelhouse exists; the server itself tolerates missing
+    # roots (returns empty index), but the operator probably wants the
+    # directory created on first ``auntie up``.
+    cfg = load_local_config()
+    try:
+        cfg.root.mkdir(parents=True, exist_ok=True)
+    except OSError as err:
+        return ActionResult(
+            ok=False,
+            detail=f"could not create wheelhouse {cfg.root}: {err}",
+        )
+    return _command.start(detection, materialized)
+
+
+def stop(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    return _command.stop(detection, _materialize(declaration))
+
+
+def restart(detection: Detection, declaration: ServerSpec) -> ActionResult:
+    return _command.restart(detection, _materialize(declaration))

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -82,41 +82,9 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     pid = proc.pid
     result = probe(detection)
     if result.status == "up":
-        # Port-conflict false-success guard: a 200 from the probe could
-        # come from a *different* process that already owned the port if
-        # our spawn lost the bind race (or failed to bind because the
-        # port was taken). Verify our spawned child is still alive
-        # before claiming success — and on Linux, that the actual port
-        # listener is our PID. Without these checks, we'd persist a
-        # PID file pointing at a dead/wrong process.
-        if proc.poll() is not None:
-            return ActionResult(
-                ok=False,
-                detail=(
-                    f"port {declaration.port} already serves a 200 response, "
-                    f"but our spawn exited (rc={proc.returncode}); see {log_path}"
-                ),
-                log_path=str(log_path),
-                pid=None,
-            )
-        if sys.platform == "linux":
-            owner_pid = _pid.find_by_port(
-                declaration.port,
-                expected_argv=list(declaration.command),
-            )
-            if owner_pid is not None and owner_pid != pid:
-                # Our spawn is alive but isn't the listener — a foreign
-                # process owns the port. Reap and fail.
-                _terminate_orphan(proc)
-                return ActionResult(
-                    ok=False,
-                    detail=(
-                        f"port {declaration.port} already bound by pid {owner_pid} "
-                        f"(our spawn pid={pid} terminated); see {log_path}"
-                    ),
-                    log_path=str(log_path),
-                    pid=None,
-                )
+        guard = _verify_spawned_listener(proc, declaration, log_path)
+        if guard is not None:
+            return guard
         # Persist PID + sidecar for future `auntie down` / `restart`.
         try:
             _pid.write(
@@ -149,6 +117,51 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     return ActionResult(
         ok=False,
         detail=f"command exited immediately (rc={proc.returncode}); see {log_path}",
+        log_path=str(log_path),
+        pid=None,
+    )
+
+
+def _verify_spawned_listener(
+    proc: subprocess.Popen,
+    declaration: ServerSpec,
+    log_path: Path,
+) -> ActionResult | None:
+    """Port-conflict false-success guard: a 200 from the probe could
+    come from a *different* process that already owned the port if our
+    spawn lost the bind race. Verify our spawned child is still alive
+    and (on Linux) that it's the actual port listener.
+
+    Returns ``None`` when the guard passes, or an ``ActionResult`` with
+    ``ok=False`` describing the conflict when it doesn't.
+    """
+    if proc.poll() is not None:
+        return ActionResult(
+            ok=False,
+            detail=(
+                f"port {declaration.port} already serves a 200 response, "
+                f"but our spawn exited (rc={proc.returncode}); see {log_path}"
+            ),
+            log_path=str(log_path),
+            pid=None,
+        )
+    if sys.platform != "linux":
+        return None
+    owner_pid = _pid.find_by_port(
+        declaration.port,
+        expected_argv=list(declaration.command or ()),
+    )
+    if owner_pid is None or owner_pid == proc.pid:
+        return None
+    # Our spawn is alive but isn't the listener — a foreign process
+    # owns the port. Reap and fail.
+    _terminate_orphan(proc)
+    return ActionResult(
+        ok=False,
+        detail=(
+            f"port {declaration.port} already bound by pid {owner_pid} "
+            f"(our spawn pid={proc.pid} terminated); see {log_path}"
+        ),
         log_path=str(log_path),
         pid=None,
     )

--- a/auntiepypi/_actions/command.py
+++ b/auntiepypi/_actions/command.py
@@ -82,6 +82,41 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
     pid = proc.pid
     result = probe(detection)
     if result.status == "up":
+        # Port-conflict false-success guard: a 200 from the probe could
+        # come from a *different* process that already owned the port if
+        # our spawn lost the bind race (or failed to bind because the
+        # port was taken). Verify our spawned child is still alive
+        # before claiming success — and on Linux, that the actual port
+        # listener is our PID. Without these checks, we'd persist a
+        # PID file pointing at a dead/wrong process.
+        if proc.poll() is not None:
+            return ActionResult(
+                ok=False,
+                detail=(
+                    f"port {declaration.port} already serves a 200 response, "
+                    f"but our spawn exited (rc={proc.returncode}); see {log_path}"
+                ),
+                log_path=str(log_path),
+                pid=None,
+            )
+        if sys.platform == "linux":
+            owner_pid = _pid.find_by_port(
+                declaration.port,
+                expected_argv=list(declaration.command),
+            )
+            if owner_pid is not None and owner_pid != pid:
+                # Our spawn is alive but isn't the listener — a foreign
+                # process owns the port. Reap and fail.
+                _terminate_orphan(proc)
+                return ActionResult(
+                    ok=False,
+                    detail=(
+                        f"port {declaration.port} already bound by pid {owner_pid} "
+                        f"(our spawn pid={pid} terminated); see {log_path}"
+                    ),
+                    log_path=str(log_path),
+                    pid=None,
+                )
         # Persist PID + sidecar for future `auntie down` / `restart`.
         try:
             _pid.write(
@@ -117,6 +152,24 @@ def start(detection: Detection, declaration: ServerSpec) -> ActionResult:
         log_path=str(log_path),
         pid=None,
     )
+
+
+def _terminate_orphan(proc: subprocess.Popen) -> None:
+    """Reap a spawned process that lost the bind race. Best effort — the
+    caller already returned ok=False, so a stuck child here just leaks
+    a small amount of state into XDG.
+    """
+    try:
+        KILL(proc.pid, signal.SIGTERM)
+    except OSError:
+        return
+    try:
+        proc.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        try:
+            KILL(proc.pid, signal.SIGKILL)
+        except OSError:
+            pass
 
 
 def _spawn_error(err: OSError, declaration: ServerSpec, log_path: Path) -> ActionResult:

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -265,9 +265,7 @@ def _is_loopback(host: str) -> bool:
 
 def _validate_local_host(host: object) -> str:
     if not isinstance(host, str) or not host:
-        raise ServerConfigError(
-            "[tool.auntiepypi.local] 'host' must be a non-empty string"
-        )
+        raise ServerConfigError("[tool.auntiepypi.local] 'host' must be a non-empty string")
     if not _is_loopback(host):
         raise ServerConfigError(
             f"[tool.auntiepypi.local] 'host'={host!r}: v0.6.0 binds loopback "
@@ -279,17 +277,14 @@ def _validate_local_host(host: object) -> str:
 def _validate_local_port(port: object) -> int:
     if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
         raise ServerConfigError(
-            f"[tool.auntiepypi.local] 'port' out of range "
-            f"(got {port!r}; expected int 1..65535)"
+            f"[tool.auntiepypi.local] 'port' out of range " f"(got {port!r}; expected int 1..65535)"
         )
     return port
 
 
 def _validate_local_root(root: object) -> Path:
     if not isinstance(root, str) or not root:
-        raise ServerConfigError(
-            "[tool.auntiepypi.local] 'root' must be a non-empty string"
-        )
+        raise ServerConfigError("[tool.auntiepypi.local] 'root' must be a non-empty string")
     return Path(root).expanduser()
 
 

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -22,11 +22,13 @@ Hard cases (raise :class:`ServerConfigError`):
 
 from __future__ import annotations
 
+import ipaddress
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
 from auntiepypi._packages_config import find_pyproject
+from auntiepypi._server._config import LocalConfig, default_root
 
 _VALID_FLAVORS = frozenset({"pypiserver", "devpi", "unknown"})
 _VALID_MANAGED_BY = frozenset({"systemd-user", "docker", "compose", "command", "manual"})
@@ -249,6 +251,89 @@ def load_servers(start: Path | None = None) -> ServersConfig:
         )
 
     return ServersConfig(specs=tuple(parsed), scan_processes=scan_processes)
+
+
+def _is_loopback(host: str) -> bool:
+    """True for ``localhost`` (alias) or any literal loopback IP."""
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _validate_local_host(host: object) -> str:
+    if not isinstance(host, str) or not host:
+        raise ServerConfigError(
+            "[tool.auntiepypi.local] 'host' must be a non-empty string"
+        )
+    if not _is_loopback(host):
+        raise ServerConfigError(
+            f"[tool.auntiepypi.local] 'host'={host!r}: v0.6.0 binds loopback "
+            "only (auth + TLS land in v0.7.0). Use 127.0.0.1, localhost, or ::1."
+        )
+    return host
+
+
+def _validate_local_port(port: object) -> int:
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        raise ServerConfigError(
+            f"[tool.auntiepypi.local] 'port' out of range "
+            f"(got {port!r}; expected int 1..65535)"
+        )
+    return port
+
+
+def _validate_local_root(root: object) -> Path:
+    if not isinstance(root, str) or not root:
+        raise ServerConfigError(
+            "[tool.auntiepypi.local] 'root' must be a non-empty string"
+        )
+    return Path(root).expanduser()
+
+
+def load_local_config(start: Path | None = None) -> LocalConfig:
+    """Read ``[tool.auntiepypi.local]`` from the nearest ``pyproject.toml``.
+
+    Returns a :class:`LocalConfig` always — defaults fill in any field
+    the table omits, and a missing table yields a fully-defaulted
+    config. Validates loopback host, port range, and tilde expansion.
+    Raises :class:`ServerConfigError` on structural problems.
+    """
+    found = find_pyproject(start)
+    if found is None:
+        return LocalConfig()
+    try:
+        with found.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as err:
+        raise ServerConfigError(f"cannot parse {found}: {err}") from err
+
+    tool = data.get("tool", {})
+    if not isinstance(tool, dict):
+        return LocalConfig()
+    auntie_table = tool.get("auntiepypi", {})
+    if not isinstance(auntie_table, dict):
+        return LocalConfig()
+    local_table = auntie_table.get("local", {})
+    if not isinstance(local_table, dict):
+        raise ServerConfigError(
+            f"[tool.auntiepypi.local] must be a table, got {type(local_table).__name__}"
+        )
+    if not local_table:
+        return LocalConfig()
+
+    kwargs: dict = {}
+    if "host" in local_table:
+        kwargs["host"] = _validate_local_host(local_table["host"])
+    if "port" in local_table:
+        kwargs["port"] = _validate_local_port(local_table["port"])
+    if "root" in local_table:
+        kwargs["root"] = _validate_local_root(local_table["root"])
+    else:
+        kwargs["root"] = default_root()
+    return LocalConfig(**kwargs)
 
 
 def load_servers_lenient(start: Path | None = None) -> tuple[ServersConfig, list[ConfigGap]]:

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -283,7 +283,7 @@ def _validate_local_host(host: object) -> str:
 def _validate_local_port(port: object) -> int:
     if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
         raise ServerConfigError(
-            f"[tool.auntiepypi.local] 'port' out of range " f"(got {port!r}; expected int 1..65535)"
+            f"[tool.auntiepypi.local] 'port' out of range (got {port!r}; expected int 1..65535)"
         )
     return port
 

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -150,6 +150,12 @@ def _validate_required_strings(entry: dict, idx: int) -> tuple[str, str]:
         raise ServerConfigError(
             f"[[tool.auntiepypi.servers]][{idx}]: missing 'name' (must be a non-empty string)"
         )
+    if name == "auntie":
+        raise ServerConfigError(
+            f"[[tool.auntiepypi.servers]][{idx}]: name 'auntie' is reserved for the "
+            "first-party server (managed by [tool.auntiepypi.local]); "
+            "rename this declaration."
+        )
     flavor = entry.get("flavor")
     if not isinstance(flavor, str):
         raise ServerConfigError(f"[[tool.auntiepypi.servers]][{idx}] {name!r}: missing 'flavor'")

--- a/auntiepypi/_detect/_detection.py
+++ b/auntiepypi/_detect/_detection.py
@@ -18,7 +18,8 @@ class Detection:
     ``status``: ``"up"`` (TCP+HTTP healthy), ``"down"`` (TCP open, HTTP
     unhealthy), ``"absent"`` (nothing listening).
 
-    ``source``: ``"declared"`` (came from ``[[tool.auntiepypi.servers]]``),
+    ``source``: ``"local"`` (the first-party auntie server),
+    ``"declared"`` (came from ``[[tool.auntiepypi.servers]]``),
     ``"port"`` (default port scan), ``"proc"`` (``--proc`` ``/proc`` scan).
     """
 

--- a/auntiepypi/_detect/_http.py
+++ b/auntiepypi/_detect/_http.py
@@ -20,6 +20,17 @@ _MAX_BODY_BYTES = 4096
 _USER_AGENT = f"auntie/{__version__}"
 
 
+def format_http_url(host: str, port: int, path: str = "/") -> str:
+    """Build ``http://host:port<path>`` with IPv6 bracketing.
+
+    Bare ``::1`` (and other IPv6 literals) must be wrapped in ``[...]``
+    in URLs (RFC 3986 §3.2.2). Hostnames and IPv4 literals pass through
+    unchanged.
+    """
+    bracketed = f"[{host}]" if ":" in host else host
+    return f"http://{bracketed}:{port}{path}"  # NOSONAR S5332 (localhost-only)
+
+
 @dataclass(frozen=True)
 class ProbeOutcome:
     """Result of one TCP+HTTP probe."""
@@ -70,7 +81,7 @@ def probe_endpoint(
     """
     # `pypi-server` and `devpi-server` default to plain HTTP on localhost;
     # HTTPS is not the protocol these servers speak in their default config.
-    url = f"http://{host}:{port}{path}"  # NOSONAR S5332 (localhost-only) noqa: S310 nosec B310
+    url = format_http_url(host, port, path)  # noqa: S310 nosec B310
     if not _tcp_open(host, port, timeout):
         return ProbeOutcome(url=url, tcp_open=False, http_status=None, body=None, error=None)
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT, "Accept": "*/*"})

--- a/auntiepypi/_detect/_local.py
+++ b/auntiepypi/_detect/_local.py
@@ -1,0 +1,48 @@
+"""First-party server detector.
+
+Always emits exactly one :class:`Detection` for the auntie-managed
+PEP 503 simple-index server (``[tool.auntiepypi.local]``), regardless
+of whether the server is currently running. When the server is not
+running, the Detection has ``status="absent"``; this lets ``auntie
+overview`` always show a "your local index" section.
+
+The Detection's ``source`` is ``"local"`` so callers can distinguish
+it from the user-declared / port-scanned / proc-walked surfaces.
+
+Runs **first** in :func:`auntiepypi._detect._runtime.detect_all` so
+its ``(host, port)`` enters the ``covered`` set and the default-port
+scanner doesn't double-report the local server as ``devpi`` on 3141.
+"""
+
+from __future__ import annotations
+
+from auntiepypi._detect._detection import Detection
+from auntiepypi._detect._http import probe_endpoint
+
+_TIMEOUT = 1.0
+
+
+def detect() -> Detection:
+    """Return one Detection for the first-party server."""
+    # Local import so module load doesn't reach for pyproject if the
+    # caller never invokes detection.
+    from auntiepypi._detect._config import load_local_config
+
+    cfg = load_local_config()
+    outcome = probe_endpoint(cfg.host, cfg.port, timeout=_TIMEOUT)
+    common = {
+        "name": "auntie",
+        "flavor": "auntiepypi",
+        "host": cfg.host,
+        "port": cfg.port,
+        "url": outcome.url,
+        "source": "local",
+        "managed_by": "auntie",
+    }
+    if not outcome.tcp_open:
+        return Detection(status="absent", **common)
+    if outcome.http_status is None:
+        return Detection(status="down", detail=outcome.error or "http error", **common)
+    if not 200 <= outcome.http_status < 300:
+        return Detection(status="down", detail=f"http {outcome.http_status}", **common)
+    return Detection(status="up", **common)

--- a/auntiepypi/_detect/_runtime.py
+++ b/auntiepypi/_detect/_runtime.py
@@ -2,13 +2,18 @@
 
 Order of operations:
 
-1. ``_declared.detect`` first. Build ``covered = {(host, port) ...}``.
-2. ``_port.detect`` over default ports minus ``covered``. If declarations
-   exist, drop ``status="absent"`` from the port detector's output
-   (the augment + suppress-absent rule).
-3. If ``scan_processes``: ``_proc.detect``. Merge by ``(host, port)`` —
-   proc-found pids enrich existing detections; proc-only detections are
-   appended.
+1. ``_local.detect`` first. The first-party server is always one
+   record (status="absent" when not running). Its ``(host, port)``
+   enters ``covered`` so the default-port scanner doesn't double-
+   report it as ``devpi`` on 3141.
+2. ``_declared.detect`` next. Append to ``covered`` with each
+   declaration's ``(host, port)``.
+3. ``_port.detect`` over default ports minus ``covered``. If
+   declarations exist, drop ``status="absent"`` from the port
+   detector's output (the augment + suppress-absent rule).
+4. If ``scan_processes``: ``_proc.detect``. Merge by ``(host, port)``
+   — proc-found pids enrich existing detections; proc-only
+   detections are appended.
 """
 
 from __future__ import annotations
@@ -18,14 +23,17 @@ from dataclasses import replace
 from auntiepypi._detect._config import ServersConfig
 from auntiepypi._detect._declared import detect as _declared_detect
 from auntiepypi._detect._detection import Detection
+from auntiepypi._detect._local import detect as _local_detect
 from auntiepypi._detect._port import detect as _port_detect
 from auntiepypi._detect._proc import detect as _proc_detect
 
 
 def detect_all(config: ServersConfig) -> list[Detection]:
     """Run all detectors and merge results."""
+    local_result = _local_detect()
     declared_results = _declared_detect(config.specs, scan_processes=config.scan_processes)
-    covered: set[tuple[str, int]] = {(d.host, d.port) for d in declared_results}
+    covered: set[tuple[str, int]] = {(local_result.host, local_result.port)}
+    covered.update((d.host, d.port) for d in declared_results)
 
     port_results = _port_detect(
         config.specs,
@@ -35,7 +43,7 @@ def detect_all(config: ServersConfig) -> list[Detection]:
     if declared_results:
         port_results = [d for d in port_results if d.status != "absent"]
 
-    detections = list(declared_results) + list(port_results)
+    detections = [local_result] + list(declared_results) + list(port_results)
 
     if not config.scan_processes:
         return detections

--- a/auntiepypi/_server/__init__.py
+++ b/auntiepypi/_server/__init__.py
@@ -10,3 +10,48 @@ module). The HTTP layer is :mod:`._app`; filesystem walk lives in
 """
 
 from __future__ import annotations
+
+import signal
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import Callable
+
+from auntiepypi._server._app import make_handler
+
+__all__ = ["serve"]
+
+
+def serve(
+    host: str,
+    port: int,
+    root: Path,
+    *,
+    server_factory: Callable[..., ThreadingHTTPServer] = ThreadingHTTPServer,
+) -> None:
+    """Run the simple-index HTTP server until SIGTERM/SIGINT.
+
+    ``server_factory`` is a test indirection — production callers
+    accept the default ``ThreadingHTTPServer``.
+    """
+    handler_cls = make_handler(root)
+    httpd = server_factory((host, port), handler_cls)
+
+    def _shutdown(_signum: int, _frame: object) -> None:
+        # ``httpd.shutdown()`` is safe to call from a signal handler:
+        # it only sets a flag the serve_forever() loop checks.
+        httpd.shutdown()
+
+    # signal.signal() only works in the main thread; the strategy
+    # module spawns this as a subprocess (its own main thread) so
+    # production callers always succeed. Tests run serve() in a
+    # daemon thread and call httpd.shutdown() directly, so the
+    # ValueError fallback is only hit there.
+    try:
+        signal.signal(signal.SIGTERM, _shutdown)
+        signal.signal(signal.SIGINT, _shutdown)
+    except ValueError:
+        pass
+    try:
+        httpd.serve_forever()
+    finally:
+        httpd.server_close()

--- a/auntiepypi/_server/__init__.py
+++ b/auntiepypi/_server/__init__.py
@@ -1,0 +1,12 @@
+"""auntiepypi's first-party PEP 503 simple-index server.
+
+v0.6.0 ships the read-only slice: serves wheels and sdists from a
+filesystem wheelhouse. Loopback-only by config-load-time enforcement.
+``auntie publish``, HTTPS, and basic-auth are deferred to v0.7.0.
+
+Public surface lives in :mod:`auntiepypi._server.__init__` (this
+module). The HTTP layer is :mod:`._app`; filesystem walk lives in
+:mod:`._wheelhouse`; CLI entry is :mod:`.__main__`.
+"""
+
+from __future__ import annotations

--- a/auntiepypi/_server/__init__.py
+++ b/auntiepypi/_server/__init__.py
@@ -12,6 +12,7 @@ module). The HTTP layer is :mod:`._app`; filesystem walk lives in
 from __future__ import annotations
 
 import signal
+import threading
 from http.server import ThreadingHTTPServer
 from pathlib import Path
 from typing import Callable
@@ -37,9 +38,12 @@ def serve(
     httpd = server_factory((host, port), handler_cls)
 
     def _shutdown(_signum: int, _frame: object) -> None:
-        # ``httpd.shutdown()`` is safe to call from a signal handler:
-        # it only sets a flag the serve_forever() loop checks.
-        httpd.shutdown()
+        # ``httpd.shutdown()`` blocks until ``serve_forever()`` returns
+        # and must therefore run on a *different* thread (Python docs:
+        # http.server.BaseServer.shutdown). Calling it directly from
+        # the signal handler — same thread as ``serve_forever()`` —
+        # would deadlock.
+        threading.Thread(target=httpd.shutdown, daemon=True).start()
 
     # signal.signal() only works in the main thread; the strategy
     # module spawns this as a subprocess (its own main thread) so

--- a/auntiepypi/_server/__main__.py
+++ b/auntiepypi/_server/__main__.py
@@ -1,0 +1,44 @@
+"""``python -m auntiepypi._server`` entry.
+
+Argparse → :func:`auntiepypi._server.serve`. The ``auntie`` CLI's
+lifecycle strategy spawns this module via ``sys.executable -m
+auntiepypi._server …`` so we don't depend on a console-script entry
+point.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from auntiepypi._server import serve
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m auntiepypi._server",
+        description="auntiepypi first-party PEP 503 simple-index server (read-only)",
+    )
+    p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="bind address; v0.6.0 enforces loopback at config-load time",
+    )
+    p.add_argument("--port", type=int, default=3141, help="bind port")
+    p.add_argument(
+        "--root",
+        type=Path,
+        required=True,
+        help="wheelhouse directory served by /simple/ and /files/",
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = _parser().parse_args(argv)
+    serve(args.host, args.port, args.root)
+
+
+if __name__ == "__main__":  # pragma: no cover — executed via -m
+    main()

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import html
 import re
+import shutil
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -119,12 +120,17 @@ def make_handler(root: Path) -> type[BaseHTTPRequestHandler]:
                 return self._send_status(404)
             if not candidate.is_file():
                 return self._send_status(404)
-            data = candidate.read_bytes()
+            # Stream the file rather than read_bytes() — wheels can be
+            # tens of megabytes and a thread-per-request server holds
+            # one buffer per concurrent download. shutil.copyfileobj
+            # uses an 8 KiB default chunk under the hood.
+            size = candidate.stat().st_size
             self.send_response(200)
             self.send_header("Content-Type", "application/octet-stream")
-            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Content-Length", str(size))
             self.end_headers()
-            self.wfile.write(data)
+            with candidate.open("rb") as src:
+                shutil.copyfileobj(src, self.wfile)
 
         # --- helpers -------------------------------------------------------
 

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -1,0 +1,134 @@
+"""HTTP handler factory for the v0.6.0 read-only PEP 503 simple-index.
+
+Three routes:
+
+- ``GET /simple/`` — HTML anchor list of projects in the wheelhouse.
+- ``GET /simple/<pkg>/`` (or without trailing slash) — HTML anchor list
+  of distribution files for ``<pkg>``. PEP 503 name normalization is
+  applied to the request path. 404 when the project has no dists.
+- ``GET /files/<filename>`` — raw file bytes
+  (``application/octet-stream``). 404 when the filename doesn't exist
+  in the wheelhouse, contains separators, or otherwise tries to escape
+  the root.
+
+Any other path or non-GET method → 404 / 405.
+
+The handler is a *factory* (``make_handler(root)``) returning a
+``BaseHTTPRequestHandler`` subclass that closes over ``root``. This
+lets the same module serve multiple wheelhouses in tests.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from auntiepypi._server._wheelhouse import list_projects, normalize
+
+# Strict filename pattern: PEP 427/625 dist files + no path components.
+# Permits the same charset filenames carry on PyPI.
+_SAFE_FILENAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*\.(whl|tar\.gz|zip)$")
+
+
+def make_handler(root: Path) -> type[BaseHTTPRequestHandler]:
+    """Return a request-handler class bound to ``root``."""
+    resolved_root = root.resolve()
+
+    class _Handler(BaseHTTPRequestHandler):
+        # Silence the default request log; tests don't want noise.
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            return
+
+        def do_GET(self) -> None:  # noqa: N802 — stdlib name
+            parsed = urlparse(self.path)
+            path = unquote(parsed.path)
+
+            if path == "/simple/":
+                return self._serve_index()
+            if path.startswith("/simple/"):
+                tail = path[len("/simple/") :]
+                # Strip an optional single trailing slash; reject anything
+                # with internal separators (sub-paths).
+                if tail.endswith("/"):
+                    tail = tail[:-1]
+                if "/" in tail or not tail:
+                    return self._send_status(404)
+                return self._serve_project(tail)
+            if path.startswith("/files/"):
+                tail = path[len("/files/") :]
+                return self._serve_file(tail)
+            return self._send_status(404)
+
+        # --- routes --------------------------------------------------------
+
+        def _serve_index(self) -> None:
+            projects = sorted(list_projects(resolved_root).keys())
+            anchors = "\n".join(
+                f'    <a href="/simple/{html.escape(p)}/">{html.escape(p)}</a><br/>'
+                for p in projects
+            )
+            body = (
+                "<!DOCTYPE html>\n"
+                "<html><head><title>auntiepypi simple index</title></head>\n"
+                f"<body>\n{anchors}\n</body></html>\n"
+            )
+            self._send_html(body)
+
+        def _serve_project(self, name: str) -> None:
+            projects = list_projects(resolved_root)
+            normalized = normalize(name)
+            files = projects.get(normalized)
+            if not files:
+                return self._send_status(404)
+            files_sorted = sorted(files, key=lambda p: p.name)
+            anchors = "\n".join(
+                f'    <a href="/files/{html.escape(p.name)}">{html.escape(p.name)}</a><br/>'
+                for p in files_sorted
+            )
+            body = (
+                "<!DOCTYPE html>\n"
+                f"<html><head><title>{html.escape(normalized)}</title></head>\n"
+                f"<body>\n{anchors}\n</body></html>\n"
+            )
+            self._send_html(body)
+
+        def _serve_file(self, filename: str) -> None:
+            if not _SAFE_FILENAME.match(filename):
+                return self._send_status(404)
+            candidate = (resolved_root / filename).resolve()
+            try:
+                candidate.relative_to(resolved_root)
+            except ValueError:
+                # Symlink or `..` escape attempt.
+                return self._send_status(404)
+            if not candidate.is_file():
+                return self._send_status(404)
+            data = candidate.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        # --- helpers -------------------------------------------------------
+
+        def _send_html(self, body: str) -> None:
+            data = body.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _send_status(self, status: int) -> None:
+            body = f"{status}\n".encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return _Handler

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -29,6 +29,9 @@ from urllib.parse import unquote, urlparse
 
 from auntiepypi._server._wheelhouse import list_projects, normalize
 
+_SIMPLE_PREFIX = "/simple/"
+_FILES_PREFIX = "/files/"
+
 # Strict filename pattern: PEP 427/625 dist files + no path components.
 # Permits the same charset filenames carry on PyPI.
 _SAFE_FILENAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*\.(whl|tar\.gz|zip)$")
@@ -49,10 +52,10 @@ def make_handler(root: Path) -> type[BaseHTTPRequestHandler]:
 
             if path == "/":
                 return self._serve_root()
-            if path == "/simple/":
+            if path == _SIMPLE_PREFIX:
                 return self._serve_index()
-            if path.startswith("/simple/"):
-                tail = path[len("/simple/") :]
+            if path.startswith(_SIMPLE_PREFIX):
+                tail = path[len(_SIMPLE_PREFIX) :]
                 # Strip an optional single trailing slash; reject anything
                 # with internal separators (sub-paths).
                 if tail.endswith("/"):
@@ -60,8 +63,8 @@ def make_handler(root: Path) -> type[BaseHTTPRequestHandler]:
                 if "/" in tail or not tail:
                     return self._send_status(404)
                 return self._serve_project(tail)
-            if path.startswith("/files/"):
-                tail = path[len("/files/") :]
+            if path.startswith(_FILES_PREFIX):
+                tail = path[len(_FILES_PREFIX) :]
                 return self._serve_file(tail)
             return self._send_status(404)
 

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -46,6 +46,8 @@ def make_handler(root: Path) -> type[BaseHTTPRequestHandler]:
             parsed = urlparse(self.path)
             path = unquote(parsed.path)
 
+            if path == "/":
+                return self._serve_root()
             if path == "/simple/":
                 return self._serve_index()
             if path.startswith("/simple/"):
@@ -63,6 +65,17 @@ def make_handler(root: Path) -> type[BaseHTTPRequestHandler]:
             return self._send_status(404)
 
         # --- routes --------------------------------------------------------
+
+        def _serve_root(self) -> None:
+            body = (
+                "<!DOCTYPE html>\n"
+                "<html><head><title>auntiepypi</title></head>\n"
+                "<body><h1>auntiepypi</h1>\n"
+                "<p>First-party PEP 503 simple-index server. "
+                'See <a href="/simple/">/simple/</a> for the index.</p>\n'
+                "</body></html>\n"
+            )
+            self._send_html(body)
 
         def _serve_index(self) -> None:
             projects = sorted(list_projects(resolved_root).keys())

--- a/auntiepypi/_server/_config.py
+++ b/auntiepypi/_server/_config.py
@@ -1,0 +1,42 @@
+"""Configuration for the first-party PEP 503 simple-index server.
+
+``LocalConfig`` is a frozen dataclass with three fields, all defaulted:
+
+- ``host``: bind address. v0.6.0 enforces loopback at config-load time.
+- ``port``: bind port. Default ``3141`` (the conventional private-index
+  port). User overrides via ``[tool.auntiepypi.local].port`` if a
+  declared devpi conflicts.
+- ``root``: wheelhouse directory. Default
+  ``$XDG_DATA_HOME/auntiepypi/wheels/`` (or ``~/.local/share/...`` when
+  ``XDG_DATA_HOME`` is unset). User overrides via
+  ``[tool.auntiepypi.local].root``.
+
+The loader (``auntiepypi._detect._config.load_local_config``) reads
+``[tool.auntiepypi.local]`` from ``pyproject.toml`` if present and
+returns a ``LocalConfig`` regardless — defaults apply when the table
+is missing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_DEFAULT_PORT = 3141
+_DEFAULT_HOST = "127.0.0.1"
+
+
+def default_root() -> Path:
+    """Return ``$XDG_DATA_HOME/auntiepypi/wheels`` (or ``~/.local/share/...``)."""
+    base = os.environ.get("XDG_DATA_HOME") or "~/.local/share"
+    return Path(base).expanduser() / "auntiepypi" / "wheels"
+
+
+@dataclass(frozen=True)
+class LocalConfig:
+    """First-party server config (read from ``[tool.auntiepypi.local]``)."""
+
+    host: str = _DEFAULT_HOST
+    port: int = _DEFAULT_PORT
+    root: Path = field(default_factory=default_root)

--- a/auntiepypi/_server/_wheelhouse.py
+++ b/auntiepypi/_server/_wheelhouse.py
@@ -1,0 +1,71 @@
+"""Filesystem-walk wheelhouse: directory of dists → project index.
+
+Pure-function module. No I/O beyond ``Path.iterdir`` / ``Path.is_file``.
+The HTTP layer (``_app``) calls into here on every request — there is
+no cache. Adding wheels is "drop them in the directory."
+
+Distribution filename parsing:
+
+- Wheels: PEP 427 — ``{name}-{version}(-{build tag})?-{python}-{abi}-{platform}.whl``
+- Sdists: PEP 625 — ``{name}-{version}.tar.gz`` (also ``.zip`` for legacy)
+
+Project bucketing: PEP 503 normalization
+(``re.sub(r"[-_.]+", "-", name).lower()``) so ``Foo_Bar`` and
+``foo-bar`` collapse to the same project.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+# PEP 427: <distribution>-<version>(-<build_tag>)?-<py>-<abi>-<platform>.whl
+# build_tag is digit-prefixed when present, but we don't enforce that here —
+# the first two hyphen-segments are always (name, version).
+_WHEEL_RE = re.compile(r"^(?P<name>[^-]+)-(?P<version>[^-]+)(-.*)?\.whl$")
+
+# PEP 625 sdists: <name>-<version>.tar.gz (or .zip).
+_SDIST_RE = re.compile(r"^(?P<name>.+)-(?P<version>[^-]+)\.(tar\.gz|zip)$")
+
+
+def normalize(name: str) -> str:
+    """PEP 503 canonical name: lowercase + collapse runs of [-_.] to '-'."""
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+def parse_filename(filename: str) -> tuple[str, str] | None:
+    """Return ``(project_name, version)`` for a PEP 427/625 dist file, else None.
+
+    The name is returned **un-normalized** — call :func:`normalize` to
+    get the PEP 503 canonical form for bucketing.
+    """
+    m = _WHEEL_RE.match(filename)
+    if m:
+        return m.group("name"), m.group("version")
+    m = _SDIST_RE.match(filename)
+    if m:
+        return m.group("name"), m.group("version")
+    return None
+
+
+def list_projects(root: Path) -> dict[str, list[Path]]:
+    """Walk ``root`` (one level), bucket dist files by normalized name.
+
+    Missing or non-directory ``root`` → empty dict (server stays up so
+    the user can populate the wheelhouse without restarting).
+    """
+    if not root.is_dir():
+        return {}
+
+    out: dict[str, list[Path]] = {}
+    for entry in root.iterdir():
+        if not entry.is_file():
+            continue
+        parsed = parse_filename(entry.name)
+        if parsed is None:
+            continue
+        project = normalize(parsed[0])
+        out.setdefault(project, []).append(entry)
+    return out

--- a/auntiepypi/cli/_commands/_lifecycle.py
+++ b/auntiepypi/cli/_commands/_lifecycle.py
@@ -23,6 +23,7 @@ from auntiepypi._actions._action import ActionResult
 from auntiepypi._detect import detect_all
 from auntiepypi._detect._config import ServerSpec, load_local_config, load_servers_lenient
 from auntiepypi._detect._detection import Detection
+from auntiepypi._detect._http import format_http_url
 from auntiepypi.cli._commands._decide import Decisions, parse_decisions
 from auntiepypi.cli._errors import EXIT_ENV_ERROR, EXIT_SUCCESS, EXIT_USER_ERROR, AfiError
 from auntiepypi.cli._output import emit_result
@@ -50,7 +51,7 @@ def _local_pair() -> _Pair:
     cfg = load_local_config()
     # HTTP is by design here; HTTPS is deferred to v0.7.0. See
     # docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md.
-    url = f"http://{cfg.host}:{cfg.port}/"  # NOSONAR python:S5332
+    url = format_http_url(cfg.host, cfg.port)
     detection = Detection(
         name=RESERVED_NAME,
         flavor="auntiepypi",
@@ -84,7 +85,7 @@ def _detection_for_spec(detections: list[Detection], spec: ServerSpec) -> Detect
     # HTTP is by design here (matches _detect/_proc.py:169 and the rest
     # of the detection layer). HTTPS is deferred to v0.7.0; see
     # docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-...md.
-    url = f"http://{host}:{spec.port}/"  # NOSONAR python:S5332
+    url = format_http_url(host, spec.port)
     return Detection(
         name=spec.name,
         flavor=spec.flavor or "unknown",

--- a/auntiepypi/cli/_commands/_lifecycle.py
+++ b/auntiepypi/cli/_commands/_lifecycle.py
@@ -101,13 +101,11 @@ def _resolve_one_spec(target: str, specs: list[ServerSpec], decisions: Decisions
     if target == RESERVED_NAME:
         raise AfiError(
             code=EXIT_USER_ERROR,
-            message=(
-                f"name {RESERVED_NAME!r} is reserved for the first-party server"
-            ),
+            message=(f"name {RESERVED_NAME!r} is reserved for the first-party server"),
             remediation=(
-                f"use bare `auntie up`/`down`/`restart` (no target) to act on the "
-                f"first-party server, or rename the conflicting "
-                f"[[tool.auntiepypi.servers]] entry"
+                "use bare `auntie up`/`down`/`restart` (no target) to act on the "
+                "first-party server, or rename the conflicting "
+                "[[tool.auntiepypi.servers]] entry"
             ),
         )
     matching = [s for s in specs if s.name == target]

--- a/auntiepypi/cli/_commands/_lifecycle.py
+++ b/auntiepypi/cli/_commands/_lifecycle.py
@@ -1,9 +1,15 @@
-"""Shared core for the v0.5.0 lifecycle verbs (`up`, `down`, `restart`).
+"""Shared core for the lifecycle verbs (`up`, `down`, `restart`).
 
 All three verbs share resolution logic, supervision filtering, exit-code
 derivation, and output shape. Each verb-specific module is a thin
 wrapper that supplies its action ("start", "stop", "restart") and a few
 strings for help text.
+
+v0.6.0: bare invocation (no target, no `--all`) acts on the
+first-party server (`[tool.auntiepypi.local]`). `--all` aggregates the
+local server with every supervised `[[tool.auntiepypi.servers]]`
+declaration. The name "auntie" is reserved — declared specs that use
+it are rejected at lifecycle resolution time.
 """
 
 from __future__ import annotations
@@ -15,14 +21,15 @@ from typing import Literal
 from auntiepypi import _actions
 from auntiepypi._actions._action import ActionResult
 from auntiepypi._detect import detect_all
-from auntiepypi._detect._config import ServerSpec, load_servers_lenient
+from auntiepypi._detect._config import ServerSpec, load_local_config, load_servers_lenient
 from auntiepypi._detect._detection import Detection
 from auntiepypi.cli._commands._decide import Decisions, parse_decisions
 from auntiepypi.cli._errors import EXIT_ENV_ERROR, EXIT_SUCCESS, EXIT_USER_ERROR, AfiError
 from auntiepypi.cli._output import emit_result
 
 Action = Literal["start", "stop", "restart"]
-SUPERVISED_MODES: frozenset[str] = frozenset({"systemd-user", "command"})
+SUPERVISED_MODES: frozenset[str] = frozenset({"systemd-user", "command", "auntie"})
+RESERVED_NAME = "auntie"
 
 
 @dataclass(frozen=True)
@@ -34,14 +41,34 @@ class _Pair:
     spec: ServerSpec
 
 
-def _bare_invocation_message(verb: str) -> str:
-    """The forward-pointing error for `auntie up` / `auntie down` /
-    `auntie restart` invoked with no target and no --all.
+def _local_pair() -> _Pair:
+    """Synthesize a (Detection, ServerSpec) pair for the first-party server.
+
+    Reads ``[tool.auntiepypi.local]`` fresh on every call so the CLI
+    picks up edits between commands.
     """
-    return (
-        f"auntie {verb}: the first-party auntie server lands in v0.6.0; for now "
-        f"use `auntie {verb} <name>` or `auntie {verb} --all`"
+    cfg = load_local_config()
+    # HTTP is by design here; HTTPS is deferred to v0.7.0. See
+    # docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md.
+    url = f"http://{cfg.host}:{cfg.port}/"  # NOSONAR python:S5332
+    detection = Detection(
+        name=RESERVED_NAME,
+        flavor="auntiepypi",
+        host=cfg.host,
+        port=cfg.port,
+        url=url,
+        status="absent",
+        source="local",
+        managed_by="auntie",
     )
+    spec = ServerSpec(
+        name=RESERVED_NAME,
+        flavor="auntiepypi",
+        host=cfg.host,
+        port=cfg.port,
+        managed_by="auntie",
+    )
+    return _Pair(name=RESERVED_NAME, detection=detection, spec=spec)
 
 
 def _detection_for_spec(detections: list[Detection], spec: ServerSpec) -> Detection:
@@ -55,7 +82,7 @@ def _detection_for_spec(detections: list[Detection], spec: ServerSpec) -> Detect
     # robust.
     host = spec.host or "127.0.0.1"
     # HTTP is by design here (matches _detect/_proc.py:169 and the rest
-    # of the detection layer). HTTPS is deferred to v0.6.0+; see
+    # of the detection layer). HTTPS is deferred to v0.7.0; see
     # docs/superpowers/specs/2026-04-30-auntiepypi-v0.5.0-...md.
     url = f"http://{host}:{spec.port}/"  # NOSONAR python:S5332
     return Detection(
@@ -71,6 +98,18 @@ def _detection_for_spec(detections: list[Detection], spec: ServerSpec) -> Detect
 
 def _resolve_one_spec(target: str, specs: list[ServerSpec], decisions: Decisions) -> ServerSpec:
     """Resolve one ``<name>`` argument against `specs`, with duplicate handling."""
+    if target == RESERVED_NAME:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"name {RESERVED_NAME!r} is reserved for the first-party server"
+            ),
+            remediation=(
+                f"use bare `auntie up`/`down`/`restart` (no target) to act on the "
+                f"first-party server, or rename the conflicting "
+                f"[[tool.auntiepypi.servers]] entry"
+            ),
+        )
     matching = [s for s in specs if s.name == target]
     if not matching:
         raise AfiError(
@@ -113,7 +152,12 @@ def _supervised_specs(
     *,
     skipped_out: list[ServerSpec] | None = None,
 ) -> list[ServerSpec]:
-    """Filter to supervised modes; record skipped specs in `skipped_out` if given."""
+    """Filter to supervised modes; record skipped specs in `skipped_out` if given.
+
+    "auntie" managed_by is supervised but never appears in declared
+    specs (it's a reserved name) — keeping it in SUPERVISED_MODES is
+    cheap insurance against future spec authors leaning on it.
+    """
     out: list[ServerSpec] = []
     for s in specs:
         if (s.managed_by or "manual") in SUPERVISED_MODES:
@@ -170,17 +214,6 @@ def _render_text(verb: str, results: list[tuple[str, ActionResult]]) -> str:
     return f"auntie {verb}:\n" + "\n".join(lines)
 
 
-def _bare_invocation_error(verb: str) -> AfiError:
-    return AfiError(
-        code=EXIT_USER_ERROR,
-        message=_bare_invocation_message(verb),
-        remediation=(
-            f"give a server name (`auntie {verb} <name>`) or use "
-            f"`auntie {verb} --all` to act on every supervised declaration"
-        ),
-    )
-
-
 def _collect_pairs(
     target: str | None,
     all_servers: bool,
@@ -189,12 +222,20 @@ def _collect_pairs(
     decisions: Decisions,
     skipped: list[ServerSpec],
 ) -> list[_Pair]:
-    """Build the (name, detection, spec) list for the lifecycle dispatch loop."""
+    """Build the (name, detection, spec) list for the lifecycle dispatch loop.
+
+    - target=None, all_servers=False → bare form: local server only.
+    - all_servers=True → local server first, then declared supervised pairs.
+    - target!=None → one declared pair (or error if reserved/missing).
+    """
+    if target is None and not all_servers:
+        return [_local_pair()]
     if all_servers:
-        return [
+        declared = [
             _Pair(name=s.name, detection=_detection_for_spec(detections, s), spec=s)
             for s in _supervised_specs(cfg.specs, skipped_out=skipped)
         ]
+        return [_local_pair(), *declared]
     spec = _resolve_one_spec(target or "", cfg.specs, decisions)
     if (spec.managed_by or "manual") not in SUPERVISED_MODES:
         _refuse_unsupervised(spec)
@@ -214,9 +255,6 @@ def run_lifecycle(args: argparse.Namespace, *, verb: str, action: Action) -> int
     all_servers = bool(getattr(args, "all_servers", False))
     json_mode = bool(getattr(args, "json", False))
     decisions = parse_decisions(getattr(args, "decide", None) or [])
-
-    if target is None and not all_servers:
-        raise _bare_invocation_error(verb)
 
     cfg, _gaps = load_servers_lenient()
     detections = detect_all(cfg)
@@ -251,13 +289,19 @@ def add_lifecycle_parser(
         "target",
         nargs="?",
         default=None,
-        help="server name; omit and pass --all to act on every supervised declaration",
+        help=(
+            "server name; omit (and skip --all) to act on the first-party "
+            "server, or pass --all to act on every supervised declaration"
+        ),
     )
     p.add_argument(
         "--all",
         action="store_true",
         dest="all_servers",
-        help="act on every supervised declaration (managed_by=systemd-user|command)",
+        help=(
+            "act on the first-party server plus every supervised "
+            "declaration (managed_by=systemd-user|command)"
+        ),
     )
     p.add_argument(
         "--decide",

--- a/auntiepypi/cli/_commands/learn.py
+++ b/auntiepypi/cli/_commands/learn.py
@@ -41,15 +41,17 @@ Commands
     [--decide KEY=VALUE]       supervised entries. --decide resolves
                                ambiguous cases (duplicate names). Default
                                is dry-run. Supports --json.
-  auntie up <name>|--all       Start a declared server (or every supervised
-                               one). Bare `auntie up` is reserved for
-                               v0.6.0's first-party server. Supports --json.
-  auntie down <name>|--all     Stop a declared server (or every supervised
-                               one). Same bare-form reservation as `up`.
+  auntie up [name|--all]       Start a server. Bare form starts auntie's
+                               own first-party PEP 503 simple-index
+                               ([tool.auntiepypi.local]); a name targets
+                               one declared server; --all aggregates the
+                               first-party server plus every supervised
+                               declaration. Supports --json.
+  auntie down [name|--all]     Stop a server. Same target shape as `up`.
                                Supports --json.
-  auntie restart <name>|--all  Restart a declared server (atomic for
-                               systemd-user; stop+start for command).
-                               Same bare-form reservation. Supports --json.
+  auntie restart [name|--all]  Restart a server (atomic for systemd-user;
+                               stop+start for command and the first-party
+                               server). Supports --json.
   auntie whoami                Auth/env probe — which PyPI / TestPyPI /
                                local index is the active environment
                                pointing at? Supports --json.
@@ -60,8 +62,13 @@ Configuration
     packages = [...]                      # for overview package sections
     scan_processes = false                # opt into /proc scan; same as --proc
 
-  pyproject.toml [[tool.auntiepypi.servers]]   # one block per server
-    name = "main"
+  pyproject.toml [tool.auntiepypi.local]  # first-party PEP 503 server (v0.6.0)
+    host = "127.0.0.1"                    # loopback only in v0.6.0
+    port = 3141                           # default
+    root = "~/.local/share/auntiepypi/wheels"  # wheelhouse directory
+
+  pyproject.toml [[tool.auntiepypi.servers]]   # one block per declared server
+    name = "main"                         # "auntie" is reserved
     flavor = "pypiserver"                 # | "devpi" | "unknown"
     port = 8080
     managed_by = "systemd-user"          # | "command" | "manual" | (unset)
@@ -122,23 +129,25 @@ def _as_json_payload() -> dict[str, object]:
             {
                 "path": ["up"],
                 "summary": (
-                    "Start a declared server (one by name; --all for every "
-                    "supervised). Bare `auntie up` reserved for v0.6.0's "
-                    "first-party server."
+                    "Start a server. Bare form starts auntie's own first-party "
+                    "PEP 503 simple-index; <name> targets one declared server; "
+                    "--all aggregates the first-party server with every supervised "
+                    "declaration."
                 ),
             },
             {
                 "path": ["down"],
                 "summary": (
-                    "Stop a declared server (one by name; --all for every "
-                    "supervised). PID-tracked for managed_by=command."
+                    "Stop a server. Same target shape as up; PID-tracked for "
+                    "managed_by=command and managed_by=auntie."
                 ),
             },
             {
                 "path": ["restart"],
                 "summary": (
-                    "Restart a declared server. Atomic for systemd-user; "
-                    "stop+start for command (re-spawn from current pyproject argv)."
+                    "Restart a server. Atomic for systemd-user; stop+start for "
+                    "command and the first-party server. Re-spawn uses current "
+                    "pyproject config."
                 ),
             },
             {

--- a/auntiepypi/explain/catalog.py
+++ b/auntiepypi/explain/catalog.py
@@ -29,15 +29,17 @@ locally. Informational, not gating.
 - `auntie doctor [TARGET] [--apply] [--decide KEY=VALUE] [--json]` —
   probe + diagnose declared inventory; `--apply` starts servers and
   deletes half-supervised entries; `--decide` resolves ambiguous cases.
-- `auntie up <name> | --all` — start a declared server (or every
-  supervised one). Bare `auntie up` is reserved for v0.6.0's
-  first-party server.
-- `auntie down <name> | --all` — stop a declared server (or every
-  supervised one). For `command` strategy: SIGTERM with 5 s grace,
-  SIGKILL fallback.
-- `auntie restart <name> | --all` — atomic restart for `systemd-user`,
+- `auntie up [name | --all]` — start a server. Bare form starts the
+  first-party PEP 503 simple-index (v0.6.0+); a `<name>` targets one
+  declared `[[tool.auntiepypi.servers]]`; `--all` aggregates the
+  first-party server plus every supervised declaration.
+- `auntie down [name | --all]` — stop a server. Same target shape as
+  `up`. For `command` strategy: SIGTERM with 5 s grace, SIGKILL
+  fallback.
+- `auntie restart [name | --all]` — atomic restart for `systemd-user`,
   stop+start for `command`. Always re-spawns from the current
-  `pyproject.toml` argv.
+  `pyproject.toml` argv (or `[tool.auntiepypi.local]` for the bare
+  form).
 - `auntie whoami` — auth/env probe; reports configured indexes.
 
 ## Console scripts
@@ -229,23 +231,26 @@ a remediation hint to clean up old `.bak` files.
 """
 
 _LIFECYCLE_PREAMBLE = """\
-The lifecycle verbs (`up`, `down`, `restart`) operate on declared servers
-in `[[tool.auntiepypi.servers]]` whose `managed_by` is `systemd-user` or
-`command`. Other modes (`manual`, `docker`, `compose`, unset) are
-out-of-scope for v0.5.0 and refused with a clear error.
+The lifecycle verbs (`up`, `down`, `restart`) operate on three classes of
+target:
 
-## Bare invocation reserved
+- The **first-party server** — auntie's own PEP 503 simple-index,
+  configured by `[tool.auntiepypi.local]`. Default port 3141; default
+  wheelhouse `$XDG_DATA_HOME/auntiepypi/wheels/`. Loopback-only in
+  v0.6.0; auth + TLS land in v0.7.0.
+- A **named declaration** in `[[tool.auntiepypi.servers]]` whose
+  `managed_by` is `systemd-user` or `command`.
+- All supervised targets at once via `--all`.
 
-`auntie up` (and `down` / `restart`) with no target and no `--all` is
-reserved for v0.6.0, where it will start auntie's own first-party
-PEP 503 simple-index server. v0.5.0 only accepts the `<name>` and
-`--all` forms.
+Other modes (`manual`, `docker`, `compose`, unset) are out-of-scope and
+refused with a clear error. The name `"auntie"` is reserved — declared
+specs that use it are rejected.
 
 ## Common shape
 
-    auntie <verb>                       # exit 1, "lands in v0.6.0"
+    auntie <verb>                       # first-party server
     auntie <verb> <name>                # one declared server
-    auntie <verb> --all                 # every supervised declaration
+    auntie <verb> --all                 # first-party + every supervised
     auntie <verb> --json                # JSON envelope
     auntie <verb> --decide=duplicate:NAME=N <name>
 
@@ -259,19 +264,24 @@ PEP 503 simple-index server. v0.5.0 only accepts the `<name>` and
 _UP = """\
 # auntie up
 
-Start a declared server.
+Start a server.
 
 %s
 
 ## What it does
 
+- **bare** (`auntie up`) → start the first-party PEP 503 simple-index
+  on `[tool.auntiepypi.local].host:port`. The auntie strategy spawns
+  `python -m auntiepypi._server --host H --port P --root R` detached
+  and tracks it via `auntie_<port>.pid`. The wheelhouse is created
+  with `mkdir -p` if missing.
 - `managed_by = "systemd-user"` → `systemctl --user start <unit>` +
   re-probe (5 s budget; "up" wins).
 - `managed_by = "command"` → detached `Popen` with
   `start_new_session=True`; logs to
   `$XDG_STATE_HOME/auntiepypi/<slug>.log`; on success writes
-  `<slug>.pid` + `<slug>.json` sidecar so future `auntie down` /
-  `restart` can find the process.
+  `<slug>_<port>.pid` + `<slug>_<port>.json` sidecar so future
+  `auntie down` / `restart` can find the process.
 - Idempotent: an already-up server is a successful no-op.
 
 ## Drift handling
@@ -283,16 +293,20 @@ fresh spawn.
 _DOWN = """\
 # auntie down
 
-Stop a declared server.
+Stop a server.
 
 %s
 
 ## What it does
 
+- **bare** (`auntie down`) → stop the first-party PEP 503 simple-index.
+  Reads `auntie_<port>.pid`, SIGTERMs, escalates to SIGKILL if needed,
+  clears the PID file. Idempotent.
 - `managed_by = "systemd-user"` → `systemctl --user stop <unit>` +
   re-probe with `desired="down"`.
-- `managed_by = "command"` → read `<slug>.pid`; SIGTERM; poll the port
-  for up to 5 s; if still bound, SIGKILL with another 2 s grace.
+- `managed_by = "command"` → read `<slug>_<port>.pid`; SIGTERM; poll
+  the port for up to 5 s; if still bound, SIGKILL with another 2 s
+  grace.
 - Fallback: when no PID file exists (Linux only), walks
   `/proc/net/tcp` + `/proc/<pid>/fd/*` to find the listener on the
   declared port. Refuses to kill unless the discovered process's argv
@@ -310,12 +324,15 @@ kill`. Inspect with `auntie overview --proc`.
 _RESTART = """\
 # auntie restart
 
-Restart a declared server.
+Restart a server.
 
 %s
 
 ## What it does
 
+- **bare** (`auntie restart`) → stop + start the first-party server
+  using the current `[tool.auntiepypi.local]` config (so a port or
+  wheelhouse change between starts takes effect on restart).
 - `managed_by = "systemd-user"` → `systemctl --user restart <unit>`
   (atomic; faster and safer than stop+start).
 - `managed_by = "command"` → `down` then `up`. The new spawn re-uses
@@ -327,7 +344,8 @@ Restart a declared server.
 ## Drift policy
 
 Source of truth is always current `pyproject.toml`. Edit your
-`command` array, then `auntie restart <name>`.
+`command` array (or `[tool.auntiepypi.local]` for the first-party
+server), then `auntie restart [<name>]`.
 """ % _LIFECYCLE_PREAMBLE
 
 _WHOAMI = """\

--- a/docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md
+++ b/docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md
@@ -1,0 +1,358 @@
+# auntiepypi v0.6.0 — first-party PEP 503 simple-index server
+
+**Status:** approved 2026-05-01
+**Implements:** the bare form of `auntie up` / `down` / `restart` reserved by v0.5.0
+**Related specs:**
+[v0.5.0 lifecycle verbs](2026-04-30-auntiepypi-v0.5.0-lifecycle-verbs-design.md),
+[v0.4.0 doctor lifecycle](2026-04-30-auntiepypi-v0.4.0-doctor-lifecycle-design.md)
+
+## Context
+
+v0.5.0 wired three lifecycle verbs against declared third-party servers
+(`systemd-user`, `command`) but reserved the **bare** form
+(`auntie up` with no target and no `--all`) for v0.6.0.
+`_lifecycle.py:173` raises:
+
+> "auntie {verb}: the first-party auntie server lands in v0.6.0; for now
+> use `auntie {verb} <name>` or `auntie {verb} --all`"
+
+This spec fills that reservation: a stdlib-only PEP 503 simple-index
+server that auntie owns end-to-end, plugged into the existing
+`_actions` × `_detect` machinery as a third managed_by strategy
+("auntie"), with bare-form CLI semantics that synthesize a
+Detection + ServerSpec from `[tool.auntiepypi.local]` and dispatch
+through the same code path as `command` and `systemd-user`.
+
+This is the **read-only slice**. `auntie publish`, HTTPS, basic-auth,
+and the mesh-aware service registry are out of scope (see "Out of
+scope" below). Loopback-only binding (127.0.0.1) is the v0.6.0 trust
+model: the missing auth is not a foot-gun because the server is not
+reachable off-host. Public binding requires the deferred auth work
+and is rejected at config-load time in v0.6.0.
+
+## Locked design decisions
+
+### D1. Read-only slice
+
+v0.6.0 ships **only** the read side of a PEP 503 index:
+
+- `GET /simple/` — HTML anchor list of project names found in the
+  wheelhouse.
+- `GET /simple/<pkg>/` — HTML anchor list of distribution files
+  (wheels + sdists) for `<pkg>` after PEP 503 name normalization;
+  404 when the project has no dists.
+- `GET /files/<filename>` — `application/octet-stream` body of the
+  file; 404 when missing or path-traversal-rejected.
+
+No `auntie publish`. No HTTPS. No basic-auth. No write side.
+Loopback-only binding so missing auth is not exploitable from the
+network.
+
+**Why:** the v0.5.0 brainstorm validated the small-landable-PR pattern
+(option A every time). A full-bundle v0.6.0 (read + publish +
+HTTPS + auth) would multiply the testing surface and stretch the PR
+beyond reviewable size. Read-only is the smallest slice that fills
+the bare-form reservation. Publish, HTTPS, and auth get their own
+patch versions.
+
+### D2. `auntie` is a third managed_by strategy
+
+`_actions/__init__.py:ACTIONS` gains an `"auntie"` entry alongside
+`"systemd-user"` and `"command"`. The bare-form CLI synthesizes:
+
+```python
+spec = ServerSpec(
+    name="auntie",
+    flavor="auntiepypi",
+    host=cfg.host,
+    port=cfg.port,
+    managed_by="auntie",
+)
+```
+
+…and dispatches through the existing `_actions.dispatch("start" | "stop"
+| "restart", detection, spec)` machinery. The strategy module
+`_actions/auntie.py` mirrors `_actions/command.py` (Popen → `_pid` →
+`_reprobe`) but with a derived argv:
+
+```python
+argv = [
+    sys.executable,
+    "-m", "auntiepypi._server",
+    "--host", cfg.host,
+    "--port", str(cfg.port),
+    "--root", str(cfg.root),
+]
+```
+
+PID + sidecar live at `state_root() / "auntie_<port>.pid"` (and
+`.json`), reusing the v0.5.0 port-disambiguated convention.
+
+**Why over alternatives:**
+
+- **vs. special-cased bare-form short-circuit**: dispatching through the
+  existing strategy table means `_actions.dispatch` stays the single
+  source of truth for "how do I act on a managed server." Adding a
+  bypass would split the model.
+- **vs. synthesizing managed_by="command"** with an internal argv:
+  blurs the boundary. The first-party server is a *first-class
+  feature*, not "a command we happen to invoke." A dedicated
+  `_actions/auntie.py` keeps the defaults, config, and argv logic
+  together.
+
+### D3. stdlib `http.server` + `ThreadingHTTPServer`
+
+No external runtime deps (consistent with the AgentCulture sibling
+pattern). PEP 503 minimum surface is two GET routes; filename parsing
+is stdlib regex; PEP 503 name normalization is `re.sub` on the
+canonicalized form.
+
+`ThreadingHTTPServer` (stdlib `http.server`) gives concurrent reads
+without an event loop. Connection volume is bounded (mesh-internal,
+agents-only); thread-per-request is appropriate.
+
+### D4. Filesystem-walk wheelhouse
+
+Default root: `$XDG_DATA_HOME/auntiepypi/wheels/` (override via
+`[tool.auntiepypi.local].root`).
+
+Each `/simple/<pkg>/` request walks the directory directly:
+
+```python
+def list_projects(root: Path) -> dict[str, list[Path]]:
+    """{normalized_name: [paths]} for all dist files in root."""
+```
+
+No index file. No cache. No write-side concerns. Adding wheels means
+"drop them into the directory"; removing means "delete the file."
+Because there is no write side in v0.6.0, the absence of an index
+isn't a coordination problem.
+
+Filename parsing follows PEP 427 (wheels) and PEP 625 (sdists,
+`.tar.gz` and `.zip`). Names extracted from filenames are normalized
+per PEP 503 (`re.sub(r"[-_.]+", "-", name).lower()`).
+
+### D5. Bare form is privileged; `--all` includes the local server
+
+CLI semantics:
+
+| Invocation                     | Acts on                                   |
+|--------------------------------|-------------------------------------------|
+| `auntie up`                    | first-party server only                   |
+| `auntie up --all`              | local server + every supervised declared  |
+| `auntie up <name>`             | one declared server (unchanged from v0.5) |
+| `auntie up auntie`             | error: name reserved                      |
+
+The local server is **always** supervised (managed_by="auntie" is in
+`SUPERVISED_MODES`), so `--all` always picks it up. The local pair is
+inserted **first** in the dispatch list so a failed declared start
+doesn't shadow the local result.
+
+Reserved name: `"auntie"` cannot be used as the `name` of any
+`[[tool.auntiepypi.servers]]` entry. Detected at config-load time;
+raises `AfiError(EXIT_USER_ERROR)` with a remediation pointing at the
+conflict.
+
+## Architecture
+
+### File layout
+
+```text
+auntiepypi/_server/                # NEW package
+├── __init__.py                    # public surface; serve(host, port, root)
+├── __main__.py                    # `python -m auntiepypi._server` entry
+├── _app.py                        # BaseHTTPRequestHandler + routes
+├── _wheelhouse.py                 # filesystem walk + filename parsing
+└── _config.py                     # LocalConfig dataclass + defaults
+
+auntiepypi/_actions/
+├── __init__.py                    # ACTIONS["auntie"] registered
+└── auntie.py                      # NEW: spawn → _pid → _reprobe
+
+auntiepypi/_detect/
+├── _config.py                     # MODIFY: load_local_config()
+├── _local.py                      # NEW: probe the first-party server
+└── _runtime.py                    # MODIFY: chain _local first
+
+auntiepypi/cli/_commands/
+├── _lifecycle.py                  # MODIFY: bare → local pair dispatch
+└── overview.py                    # MODIFY: surface local section
+
+auntiepypi/explain/catalog.py      # MODIFY: bare-form docs
+```
+
+### `[tool.auntiepypi.local]` config block
+
+```toml
+[tool.auntiepypi.local]
+host = "127.0.0.1"   # default; non-loopback rejected in v0.6.0
+port = 3141          # default; conflict → user override
+root = "~/.local/share/auntiepypi/wheels"  # default; XDG_DATA_HOME aware
+```
+
+`LocalConfig` (frozen dataclass), all fields defaulted:
+
+```python
+@dataclass(frozen=True)
+class LocalConfig:
+    host: str = "127.0.0.1"
+    port: int = 3141
+    root: Path = field(default_factory=default_root)
+```
+
+`load_local_config(start: Path | None = None) -> LocalConfig`:
+
+- Walks to `pyproject.toml` (same logic as
+  `load_servers_lenient`).
+- Reads `[tool.auntiepypi.local]`; absent table → defaults.
+- Validates: `port` is `int` 1–65535; `host` is loopback (IPv4
+  127.0.0.0/8 or IPv6 `::1`); `root` expands `~`.
+- Non-loopback host → `AfiError(EXIT_USER_ERROR)` with v0.7.0
+  forward-pointer.
+
+### Dispatch flow (bare-form `auntie up`)
+
+```text
+auntie up                              (CLI parse)
+  → _lifecycle.run_lifecycle(target=None, all_servers=False)
+  → _local_pair()
+      → load_local_config()
+      → Detection(name="auntie", source="local", ...)
+      → ServerSpec(name="auntie", managed_by="auntie", ...)
+  → _actions.dispatch("start", detection, spec)
+      → ACTIONS["auntie"]["start"](detection, spec)
+      → auntie.start():
+          - argv = [python, -m, auntiepypi._server, --host, --port, --root]
+          - Popen(argv, start_new_session=True, stdout=log)
+          - _pid.write("auntie", pid=..., argv=..., port=...)
+          - probe(detection, desired="up", budget_seconds=5.0)
+          - return ActionResult(ok=True, detail="started", pid=...)
+  → emit_result({"verb": "up", "results": [{"name": "auntie", "ok": ...}]})
+```
+
+### Detection wiring
+
+`_detect/_runtime.detect_all()` order, after v0.6.0:
+
+1. `_local.detect(config)` → first-party server (always one record)
+2. `_declared.detect(config, covered)` → user-declared servers,
+   skipping the local endpoint
+3. `_port.detect(covered)` → default-port scan, skipping `covered`
+4. `_proc.detect(covered)` → `/proc` walker (opt-in)
+
+The local detection's `(host, port)` enters `covered` so the port
+scanner doesn't re-discover it as `devpi` on 3141.
+
+`Detection.source` gains the value `"local"` (alongside `"declared"`,
+`"port"`, `"proc"`). `Detection.to_section()` already renders any
+source value.
+
+### `auntie overview` integration
+
+The local server appears as a regular detection block with
+`source="local"` and `flavor="auntiepypi"`:
+
+```text
+servers:
+  auntie@127.0.0.1:3141 up (auntiepypi/local)
+    pid 12345 (sidecar 2026-05-01T10:23:45+00:00)
+    log: ~/.local/state/auntiepypi/auntie_3141.log
+  pypiserver-stage@10.0.0.5:8080 up (pypiserver/declared)
+```
+
+JSON section: a regular `Detection` JSON dict with `source: "local"`.
+
+## CLI shape after v0.6.0
+
+```text
+auntie up                          start the first-party server
+auntie down                        stop the first-party server
+auntie restart                     restart the first-party server
+auntie up <name>                   unchanged from v0.5.0
+auntie up --all                    declared supervised + local server
+auntie overview                    composite (packages + servers + local)
+```
+
+Exit codes unchanged from v0.5.0:
+0 = all targets reached desired state, 2 = action attempted but
+failed, 1 = user/config error before any action attempted.
+
+## Out of scope (deferred to v0.6.x or v0.7.0)
+
+- **`auntie publish` upload path.** Write side of the mesh-private
+  index. Likely a separate verb that writes to `cfg.root`. v0.6.1 or
+  v0.7.0.
+- **HTTPS termination.** Requires a `[tool.auntiepypi.local].cert` /
+  `.key` pair (or self-signed via Python `ssl.SSLContext.load_cert_chain`).
+  Pairs naturally with public-binding, deferred together. v0.7.0.
+- **Basic auth (and tokens).** Loopback-only is the v0.6.0 trust
+  model; auth lifts the loopback restriction. v0.7.0.
+- **Mesh-aware service registry.** The local server's
+  `(host, port)` discoverable via Culture-mesh service registry;
+  cross-machine pulls. v1.0.0 (sketched in CLAUDE.md roadmap).
+- **Multiple wheelhouses.** Single root in v0.6.0. Multi-root
+  layering (think devpi user/index) is post-v1.0.
+
+## Threat model (v0.6.0 only)
+
+The v0.6.0 server is **not internet-exposed**. The
+`load_local_config` validator rejects non-loopback hosts, so the
+attack surface is limited to processes on the same host. The
+following remain possible and are accepted:
+
+- A local user other than the auntie operator can read the wheelhouse
+  by hitting `http://127.0.0.1:3141/`. **Mitigation:** wheelhouse
+  contents are presumed-public; private content shouldn't live there.
+- Path traversal in `/files/<filename>` could expose files outside
+  the wheelhouse if the guard is wrong. **Mitigation:** explicit
+  resolved-path-must-be-inside-root check; tests cover `..`,
+  absolute paths, symlink escapes; bandit gates the PR.
+- A local user can spam GET requests against the server. **Mitigation:**
+  not addressed in v0.6.0; mesh-internal traffic only.
+
+When v0.7.0 introduces auth + TLS, the threat model expands to
+"public network" and these mitigations get formalized.
+
+## Compat notes
+
+- The reserved name `"auntie"` is rejected if used as a declared
+  server name. Existing siblings should not have collided (the name
+  is new), but if a user did pick it, they get a clear error pointing
+  at the rename.
+- Default port 3141 collides with running devpi instances. The
+  detection-layer `covered` set prevents `auntie overview` from
+  reporting both, but a hard bind conflict on `start` is a real
+  failure. The error message points at
+  `[tool.auntiepypi.local].port` for override.
+- The bare-form forward-pointer message in
+  `_lifecycle._bare_invocation_message` becomes dead code and is
+  deleted. Tests that exercised the exit-1 path are updated to
+  expect dispatch.
+
+## Verification
+
+The plan's "Verification" section (`$CLAUDE_HOME/plans/dazzling-snacking-kay.md`)
+covers the smoke-test flow:
+
+1. Bare-form lifecycle (`up` / `down` / `restart`) on a stock
+   wheelhouse.
+2. Wheelhouse round-trip (drop a wheel, `pip install --index-url`).
+3. `--all` aggregates local + declared.
+4. `auntie overview` surfaces the local section in both text and
+   JSON.
+
+Quality pipeline (same gauntlet v0.5.0 passed):
+
+- `pytest -n auto --cov=auntiepypi`, coverage ≥ 94%
+- `black`, `isort`, `flake8`, `pylint --errors-only`, `bandit`
+- `markdownlint-cli2`
+- `bash .claude/skills/pr-review/scripts/portability-lint.sh`
+
+Expected SonarCloud findings (and resolutions):
+
+- `python:S5332` (HTTP-without-TLS hotspot) on
+  `_server/_app.py` and `_lifecycle.py:_local_pair`. Resolution:
+  NOSONAR with comment linking to the v0.7.0 deferred-auth section
+  (mirrors v0.5.0 treatment).
+- No new code smells expected; cognitive-complexity budgets
+  preserved by keeping `_app.py` route handlers thin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auntiepypi"
-version = "0.5.0"
+version = "0.6.0"
 description = "auntiepypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_actions_auntie.py
+++ b/tests/test_actions_auntie.py
@@ -1,0 +1,204 @@
+"""Tests for `auntiepypi._actions.auntie` — the first-party-server strategy.
+
+The strategy is a thin wrapper around ``_actions.command`` that
+synthesizes the argv from ``[tool.auntiepypi.local]`` on each call.
+We test (1) the argv shape, (2) that start/stop/restart delegate to
+``command`` with a materialized spec, (3) wheelhouse mkdir, and
+(4) ACTIONS table registration.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from auntiepypi import _actions
+from auntiepypi._actions import auntie as _auntie
+from auntiepypi._actions import command as _command
+from auntiepypi._actions._action import ActionResult
+from auntiepypi._detect._config import ServerSpec
+from auntiepypi._detect._detection import Detection
+from auntiepypi._server._config import LocalConfig
+
+
+@pytest.fixture
+def base_spec() -> ServerSpec:
+    return ServerSpec(
+        name="auntie",
+        flavor="auntiepypi",
+        host="127.0.0.1",
+        port=3141,
+        managed_by="auntie",
+    )
+
+
+@pytest.fixture
+def base_detection() -> Detection:
+    return Detection(
+        name="auntie",
+        flavor="auntiepypi",
+        host="127.0.0.1",
+        port=3141,
+        url="http://127.0.0.1:3141/",
+        status="absent",
+        source="local",
+    )
+
+
+# --------- _argv ---------
+
+
+def test_argv_shape(tmp_path):
+    cfg = LocalConfig(host="127.0.0.1", port=8080, root=tmp_path / "wheels")
+    argv = _auntie._argv(cfg)
+    assert argv[0] == sys.executable
+    assert argv[1] == "-m"
+    assert argv[2] == "auntiepypi._server"
+    assert "--host" in argv
+    assert "127.0.0.1" in argv
+    assert "--port" in argv
+    assert "8080" in argv
+    assert "--root" in argv
+    assert str(tmp_path / "wheels") in argv
+
+
+# --------- ACTIONS registration ---------
+
+
+def test_actions_table_has_auntie():
+    assert "auntie" in _actions.ACTIONS
+    assert set(_actions.ACTIONS["auntie"].keys()) == {"start", "stop", "restart"}
+
+
+def test_dispatch_routes_to_auntie(monkeypatch, base_detection, base_spec):
+    captured: dict[str, object] = {}
+
+    def fake_start(det: Detection, spec: ServerSpec) -> ActionResult:
+        captured["det"] = det
+        captured["spec"] = spec
+        return ActionResult(ok=True, detail="started")
+
+    monkeypatch.setitem(_actions.ACTIONS["auntie"], "start", fake_start)
+    result = _actions.dispatch("start", base_detection, base_spec)
+    assert result.ok
+    assert captured["det"] is base_detection
+    assert captured["spec"] is base_spec
+
+
+# --------- _materialize ---------
+
+
+def test_materialize_flips_managed_by(monkeypatch, tmp_path, base_spec):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    materialized = _auntie._materialize(base_spec)
+    assert materialized.managed_by == "command"
+    assert materialized.command is not None
+    # The argv reflects the (defaulted) LocalConfig.
+    assert materialized.command[0] == sys.executable
+    assert "auntiepypi._server" in materialized.command
+
+
+def test_materialize_uses_current_pyproject(tmp_path, monkeypatch, base_spec):
+    """The argv comes from current pyproject, not from declaration fields."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.auntiepypi.local]\nport = 9999\nhost = "127.0.0.1"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    materialized = _auntie._materialize(base_spec)
+    assert "9999" in materialized.command
+
+
+# --------- start delegates to command.start ---------
+
+
+def test_start_delegates_to_command(monkeypatch, tmp_path, base_detection, base_spec):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    captured: dict[str, object] = {}
+
+    def fake_command_start(det: Detection, spec: ServerSpec) -> ActionResult:
+        captured["spec"] = spec
+        return ActionResult(ok=True, detail="started")
+
+    monkeypatch.setattr(_command, "start", fake_command_start)
+    result = _auntie.start(base_detection, base_spec)
+    assert result.ok
+    spec: ServerSpec = captured["spec"]  # type: ignore[assignment]
+    assert spec.managed_by == "command"
+    assert spec.command is not None
+    assert spec.command[0] == sys.executable
+
+
+def test_start_creates_wheelhouse(monkeypatch, tmp_path, base_detection, base_spec):
+    """First ``auntie up`` should mkdir -p the wheelhouse."""
+    wheel_root = tmp_path / "fresh-wheels"
+    assert not wheel_root.exists()
+    (tmp_path / "pyproject.toml").write_text(
+        f'[tool.auntiepypi.local]\nroot = "{wheel_root}"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(_command, "start", lambda d, s: ActionResult(ok=True, detail="started"))
+    _auntie.start(base_detection, base_spec)
+    assert wheel_root.is_dir()
+
+
+def test_start_propagates_mkdir_error(monkeypatch, tmp_path, base_detection, base_spec):
+    """If mkdir fails (e.g. permission denied), surface as failure
+    without invoking command.start.
+    """
+    wheel_root = tmp_path / "wheels"
+    (tmp_path / "pyproject.toml").write_text(
+        f'[tool.auntiepypi.local]\nroot = "{wheel_root}"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise OSError("EPERM")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    called = {"start": False}
+
+    def fake_start(d, s):
+        called["start"] = True
+        return ActionResult(ok=True, detail="started")
+
+    monkeypatch.setattr(_command, "start", fake_start)
+    result = _auntie.start(base_detection, base_spec)
+    assert not result.ok
+    assert "wheelhouse" in result.detail
+    assert not called["start"]
+
+
+# --------- stop / restart delegate to command ---------
+
+
+def test_stop_delegates(monkeypatch, tmp_path, base_detection, base_spec):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    captured = {}
+
+    def fake_stop(d, s):
+        captured["spec"] = s
+        return ActionResult(ok=True, detail="stopped")
+
+    monkeypatch.setattr(_command, "stop", fake_stop)
+    result = _auntie.stop(base_detection, base_spec)
+    assert result.ok
+    assert captured["spec"].managed_by == "command"
+
+
+def test_restart_delegates(monkeypatch, tmp_path, base_detection, base_spec):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    captured = {}
+
+    def fake_restart(d, s):
+        captured["spec"] = s
+        return ActionResult(ok=True, detail="restarted")
+
+    monkeypatch.setattr(_command, "restart", fake_restart)
+    result = _auntie.restart(base_detection, base_spec)
+    assert result.ok
+    assert captured["spec"].managed_by == "command"

--- a/tests/test_actions_auntie.py
+++ b/tests/test_actions_auntie.py
@@ -10,7 +10,6 @@ We test (1) the argv shape, (2) that start/stop/restart delegate to
 from __future__ import annotations
 
 import sys
-from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -136,9 +135,7 @@ def test_start_creates_wheelhouse(monkeypatch, tmp_path, base_detection, base_sp
     """First ``auntie up`` should mkdir -p the wheelhouse."""
     wheel_root = tmp_path / "fresh-wheels"
     assert not wheel_root.exists()
-    (tmp_path / "pyproject.toml").write_text(
-        f'[tool.auntiepypi.local]\nroot = "{wheel_root}"\n'
-    )
+    (tmp_path / "pyproject.toml").write_text(f'[tool.auntiepypi.local]\nroot = "{wheel_root}"\n')
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(_command, "start", lambda d, s: ActionResult(ok=True, detail="started"))
@@ -151,9 +148,7 @@ def test_start_propagates_mkdir_error(monkeypatch, tmp_path, base_detection, bas
     without invoking command.start.
     """
     wheel_root = tmp_path / "wheels"
-    (tmp_path / "pyproject.toml").write_text(
-        f'[tool.auntiepypi.local]\nroot = "{wheel_root}"\n'
-    )
+    (tmp_path / "pyproject.toml").write_text(f'[tool.auntiepypi.local]\nroot = "{wheel_root}"\n')
     monkeypatch.chdir(tmp_path)
 
     def boom(*args, **kwargs):

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -45,33 +45,87 @@ def stub_dispatch(monkeypatch):
     return stub
 
 
-# --------- Bare invocation reservation ---------
+# --------- Bare invocation: first-party server ---------
 
 
-def test_up_bare_invocation_exits_1_with_v060_message(tmp_path, monkeypatch, capsys):
+def test_up_bare_invocation_dispatches_local(tmp_path, monkeypatch, stub_dispatch):
     monkeypatch.chdir(tmp_path)
     _write_pyproject(tmp_path, "")
     rc = main(["up"])
+    assert rc == EXIT_SUCCESS
+    assert len(stub_dispatch.calls) == 1
+    action, det_name, spec_name, managed_by = stub_dispatch.calls[0]
+    assert action == "start"
+    assert det_name == "auntie"
+    assert spec_name == "auntie"
+    assert managed_by == "auntie"
+
+
+def test_down_bare_invocation_dispatches_stop(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    stub_dispatch.result = ActionResult(ok=True, detail="stopped")
+    rc = main(["down"])
+    assert rc == EXIT_SUCCESS
+    assert stub_dispatch.calls[0][0] == "stop"
+    assert stub_dispatch.calls[0][2] == "auntie"
+
+
+def test_restart_bare_invocation_dispatches_restart(tmp_path, monkeypatch, stub_dispatch):
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(tmp_path, "")
+    stub_dispatch.result = ActionResult(ok=True, detail="restarted")
+    rc = main(["restart"])
+    assert rc == EXIT_SUCCESS
+    assert stub_dispatch.calls[0][0] == "restart"
+    assert stub_dispatch.calls[0][2] == "auntie"
+
+
+def test_up_bare_uses_configured_local_port(tmp_path, monkeypatch, stub_dispatch):
+    """Bare invocation reads [tool.auntiepypi.local] for host/port."""
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[tool.auntiepypi.local]
+host = "127.0.0.1"
+port = 9999
+""",
+    )
+
+    captured: dict = {}
+
+    def stub(action, det, spec):
+        captured["det"] = det
+        captured["spec"] = spec
+        return ActionResult(ok=True, detail="started")
+
+    monkeypatch.setattr(_actions, "dispatch", stub)
+    rc = main(["up"])
+    assert rc == EXIT_SUCCESS
+    assert captured["spec"].port == 9999
+    assert captured["det"].port == 9999
+
+
+def test_named_target_auntie_is_reserved(tmp_path, monkeypatch, capsys):
+    """`auntie up auntie` is rejected — bare form is the only way to act on the local server."""
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path,
+        """
+[[tool.auntiepypi.servers]]
+name = "auntie"
+flavor = "pypiserver"
+host = "127.0.0.1"
+port = 8080
+managed_by = "command"
+command = ["python", "-m", "http.server"]
+""",
+    )
+    rc = main(["up", "auntie"])
     assert rc == EXIT_USER_ERROR
     err = capsys.readouterr().err
-    assert "v0.6.0" in err
-    assert "auntie up <name>" in err or "auntie up --all" in err
-
-
-def test_down_bare_invocation_exits_1(tmp_path, monkeypatch, capsys):
-    monkeypatch.chdir(tmp_path)
-    _write_pyproject(tmp_path, "")
-    rc = main(["down"])
-    assert rc == EXIT_USER_ERROR
-    assert "v0.6.0" in capsys.readouterr().err
-
-
-def test_restart_bare_invocation_exits_1(tmp_path, monkeypatch, capsys):
-    monkeypatch.chdir(tmp_path)
-    _write_pyproject(tmp_path, "")
-    rc = main(["restart"])
-    assert rc == EXIT_USER_ERROR
-    assert "v0.6.0" in capsys.readouterr().err
+    assert "reserved" in err
 
 
 # --------- Single-target happy paths ---------
@@ -228,14 +282,15 @@ managed_by = "manual"
     assert "manual-one" not in names
 
 
-def test_up_all_with_no_servers_returns_success(tmp_path, monkeypatch, stub_dispatch, capsys):
+def test_up_all_with_no_servers_acts_on_local_only(tmp_path, monkeypatch, stub_dispatch):
+    """v0.6.0: --all always includes the first-party server, even when no servers are declared."""
     monkeypatch.chdir(tmp_path)
     _write_pyproject(tmp_path, "")
     rc = main(["up", "--all"])
     assert rc == EXIT_SUCCESS
-    out = capsys.readouterr().out
-    assert "nothing to do" in out
-    assert stub_dispatch.calls == []
+    assert len(stub_dispatch.calls) == 1
+    assert stub_dispatch.calls[0][2] == "auntie"
+    assert stub_dispatch.calls[0][3] == "auntie"
 
 
 def test_up_all_partial_failure_exits_2(tmp_path, monkeypatch, stub_dispatch):
@@ -258,8 +313,9 @@ managed_by = "command"
 command = ["pypi-server"]
 """,
     )
-    # Second call fails
+    # 3 calls: local first (ok), then first declared (ok), then second declared (fails)
     seq = [
+        ActionResult(ok=True, detail="started", pid=42),
         ActionResult(ok=True, detail="started", pid=111),
         ActionResult(ok=False, detail="exited immediately"),
     ]

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -14,7 +14,6 @@ from auntiepypi._detect._config import (
 )
 from auntiepypi._server._config import LocalConfig, default_root
 
-
 # --------- default_root() ---------
 
 

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -1,0 +1,220 @@
+"""Tests for `[tool.auntiepypi.local]` loader and `LocalConfig`."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from auntiepypi._detect._config import (
+    ServerConfigError,
+    _is_loopback,
+    load_local_config,
+)
+from auntiepypi._server._config import LocalConfig, default_root
+
+
+# --------- default_root() ---------
+
+
+def test_default_root_uses_xdg_data_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert default_root() == tmp_path / "auntiepypi" / "wheels"
+
+
+def test_default_root_falls_back_to_local_share(monkeypatch):
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setenv("HOME", "/fake/home")
+    assert default_root() == Path("/fake/home/.local/share/auntiepypi/wheels")
+
+
+# --------- LocalConfig defaults ---------
+
+
+def test_localconfig_defaults(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    cfg = LocalConfig()
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 3141
+    assert cfg.root == tmp_path / "auntiepypi" / "wheels"
+
+
+def test_localconfig_is_frozen():
+    from dataclasses import FrozenInstanceError
+
+    cfg = LocalConfig()
+    with pytest.raises(FrozenInstanceError):
+        cfg.port = 9999  # type: ignore[misc]
+
+
+# --------- _is_loopback helper ---------
+
+
+def test_is_loopback_recognizes_aliases():
+    assert _is_loopback("127.0.0.1")
+    assert _is_loopback("127.0.0.5")  # anywhere in 127.0.0.0/8
+    assert _is_loopback("localhost")
+    assert _is_loopback("LocalHost")  # case-insensitive
+    assert _is_loopback("::1")
+
+
+def test_is_loopback_rejects_public():
+    assert not _is_loopback("0.0.0.0")
+    assert not _is_loopback("10.0.0.1")
+    assert not _is_loopback("8.8.8.8")
+    assert not _is_loopback("example.com")
+    assert not _is_loopback("")
+
+
+# --------- load_local_config() ---------
+
+
+def _write_pyproject(path: Path, body: str) -> None:
+    (path / "pyproject.toml").write_text(textwrap.dedent(body))
+
+
+def test_load_local_config_no_pyproject(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    cfg = load_local_config(tmp_path)
+    # Defaults apply.
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 3141
+    assert cfg.root == tmp_path / "auntiepypi" / "wheels"
+
+
+def test_load_local_config_table_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi]
+        scan_processes = false
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 3141
+
+
+def test_load_local_config_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    wheel_dir = tmp_path / "wheels-custom"
+    _write_pyproject(
+        tmp_path,
+        f"""
+        [tool.auntiepypi.local]
+        host = "::1"
+        port = 9999
+        root = "{wheel_dir}"
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.host == "::1"
+    assert cfg.port == 9999
+    assert cfg.root == wheel_dir
+
+
+def test_load_local_config_partial_override(tmp_path, monkeypatch):
+    """Setting just `port` keeps host and root at defaults."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        port = 4242
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 4242
+    assert cfg.root == tmp_path / "auntiepypi" / "wheels"
+
+
+def test_load_local_config_expands_tilde(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        root = "~/wheels"
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.root == tmp_path / "wheels"
+
+
+def test_load_local_config_rejects_non_loopback(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        host = "0.0.0.0"
+        """,
+    )
+    with pytest.raises(ServerConfigError, match="loopback only"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_public_ip(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        host = "10.0.0.5"
+        """,
+    )
+    with pytest.raises(ServerConfigError, match="loopback only"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_bad_port_type(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        port = "not-an-int"
+        """,
+    )
+    with pytest.raises(ServerConfigError, match="port"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_port_out_of_range(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        port = 70000
+        """,
+    )
+    with pytest.raises(ServerConfigError, match="port"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_non_table(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi]
+        local = "not a table"
+        """,
+    )
+    with pytest.raises(ServerConfigError, match="must be a table"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_localhost_accepted(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        host = "localhost"
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.host == "localhost"

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -59,9 +59,13 @@ def test_is_loopback_recognizes_aliases():
 
 
 def test_is_loopback_rejects_public():
-    assert not _is_loopback("0.0.0.0")
-    assert not _is_loopback("10.0.0.1")
-    assert not _is_loopback("8.8.8.8")
+    # The hardcoded IPs below are fixtures asserting that _is_loopback
+    # REJECTS them; they are never used to dial out. NOSONAR/noqa pin
+    # the rule explicitly so future linter updates don't silently flag
+    # the surrounding test as a real-world IP usage.
+    assert not _is_loopback("0.0.0.0")  # noqa: S104
+    assert not _is_loopback("10.0.0.1")  # NOSONAR python:S1313
+    assert not _is_loopback("8.8.8.8")  # NOSONAR python:S1313
     assert not _is_loopback("example.com")
     assert not _is_loopback("")
 

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -60,9 +60,10 @@ def test_is_loopback_recognizes_aliases():
 
 def test_is_loopback_rejects_public():
     # The hardcoded IPs below are fixtures asserting that _is_loopback
-    # REJECTS them; they are never used to dial out. NOSONAR/noqa pin
-    # the rule explicitly so future linter updates don't silently flag
-    # the surrounding test as a real-world IP usage.
+    # rejects them; they are never used to dial out. The trailing
+    # markers pin the linter rule on each line so future linter
+    # updates don't silently flag the surrounding test as a
+    # real-world IP usage.
     assert not _is_loopback("0.0.0.0")  # noqa: S104
     assert not _is_loopback("10.0.0.1")  # NOSONAR python:S1313
     assert not _is_loopback("8.8.8.8")  # NOSONAR python:S1313

--- a/tests/test_detect_local.py
+++ b/tests/test_detect_local.py
@@ -2,19 +2,15 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
-from unittest.mock import patch
-
-import pytest
-
 from auntiepypi._detect import _local, _runtime
 from auntiepypi._detect._config import ServersConfig
 from auntiepypi._detect._detection import Detection
 from auntiepypi._detect._http import ProbeOutcome
 
 
-def _outcome(*, tcp_open: bool, http_status: int | None, body: bytes | None = None,
-             error: str | None = None) -> ProbeOutcome:
+def _outcome(
+    *, tcp_open: bool, http_status: int | None, body: bytes | None = None, error: str | None = None
+) -> ProbeOutcome:
     return ProbeOutcome(
         url="http://127.0.0.1:3141/",
         tcp_open=tcp_open,
@@ -45,7 +41,8 @@ def test_local_detect_absent(monkeypatch, tmp_path):
 def test_local_detect_up(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr(
-        _local, "probe_endpoint",
+        _local,
+        "probe_endpoint",
         lambda h, p, timeout: _outcome(tcp_open=True, http_status=200, body=b"<html>"),
     )
     det = _local.detect()
@@ -56,7 +53,8 @@ def test_local_detect_up(monkeypatch, tmp_path):
 def test_local_detect_down_http_error(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr(
-        _local, "probe_endpoint",
+        _local,
+        "probe_endpoint",
         lambda h, p, timeout: _outcome(tcp_open=True, http_status=None, error="timeout"),
     )
     det = _local.detect()
@@ -67,7 +65,8 @@ def test_local_detect_down_http_error(monkeypatch, tmp_path):
 def test_local_detect_down_5xx(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr(
-        _local, "probe_endpoint",
+        _local,
+        "probe_endpoint",
         lambda h, p, timeout: _outcome(tcp_open=True, http_status=503),
     )
     det = _local.detect()
@@ -77,9 +76,7 @@ def test_local_detect_down_5xx(monkeypatch, tmp_path):
 
 def test_local_detect_uses_configured_host_port(tmp_path, monkeypatch):
     """_local reads pyproject's [tool.auntiepypi.local] each call."""
-    (tmp_path / "pyproject.toml").write_text(
-        '[tool.auntiepypi.local]\nhost = "::1"\nport = 9999\n'
-    )
+    (tmp_path / "pyproject.toml").write_text('[tool.auntiepypi.local]\nhost = "::1"\nport = 9999\n')
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
 
@@ -104,10 +101,16 @@ def test_detect_all_includes_local_first(monkeypatch, tmp_path):
     """The local detection appears first in the result list."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr(
-        _runtime, "_local_detect",
+        _runtime,
+        "_local_detect",
         lambda: Detection(
-            name="auntie", flavor="auntiepypi", host="127.0.0.1", port=3141,
-            url="http://127.0.0.1:3141/", status="absent", source="local",
+            name="auntie",
+            flavor="auntiepypi",
+            host="127.0.0.1",
+            port=3141,
+            url="http://127.0.0.1:3141/",
+            status="absent",
+            source="local",
             managed_by="auntie",
         ),
     )
@@ -123,10 +126,16 @@ def test_detect_all_passes_local_into_covered(monkeypatch, tmp_path):
     """Port scanner sees local (host, port) in `covered` and skips it."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr(
-        _runtime, "_local_detect",
+        _runtime,
+        "_local_detect",
         lambda: Detection(
-            name="auntie", flavor="auntiepypi", host="127.0.0.1", port=3141,
-            url="http://127.0.0.1:3141/", status="absent", source="local",
+            name="auntie",
+            flavor="auntiepypi",
+            host="127.0.0.1",
+            port=3141,
+            url="http://127.0.0.1:3141/",
+            status="absent",
+            source="local",
         ),
     )
     monkeypatch.setattr(_runtime, "_declared_detect", lambda specs, *, scan_processes: [])
@@ -148,12 +157,22 @@ def test_detect_all_dedup_with_declared_on_same_port(monkeypatch, tmp_path):
     """
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     local = Detection(
-        name="auntie", flavor="auntiepypi", host="127.0.0.1", port=3141,
-        url="http://127.0.0.1:3141/", status="absent", source="local",
+        name="auntie",
+        flavor="auntiepypi",
+        host="127.0.0.1",
+        port=3141,
+        url="http://127.0.0.1:3141/",
+        status="absent",
+        source="local",
     )
     declared = Detection(
-        name="my-devpi", flavor="devpi", host="127.0.0.1", port=3141,
-        url="http://127.0.0.1:3141/", status="up", source="declared",
+        name="my-devpi",
+        flavor="devpi",
+        host="127.0.0.1",
+        port=3141,
+        url="http://127.0.0.1:3141/",
+        status="up",
+        source="declared",
     )
     monkeypatch.setattr(_runtime, "_local_detect", lambda: local)
     monkeypatch.setattr(_runtime, "_declared_detect", lambda specs, *, scan_processes: [declared])

--- a/tests/test_detect_local.py
+++ b/tests/test_detect_local.py
@@ -1,0 +1,173 @@
+"""Tests for `auntiepypi._detect._local` and the runtime chain order."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+from auntiepypi._detect import _local, _runtime
+from auntiepypi._detect._config import ServersConfig
+from auntiepypi._detect._detection import Detection
+from auntiepypi._detect._http import ProbeOutcome
+
+
+def _outcome(*, tcp_open: bool, http_status: int | None, body: bytes | None = None,
+             error: str | None = None) -> ProbeOutcome:
+    return ProbeOutcome(
+        url="http://127.0.0.1:3141/",
+        tcp_open=tcp_open,
+        http_status=http_status,
+        body=body,
+        error=error,
+    )
+
+
+# --------- _local.detect() ---------
+
+
+def test_local_detect_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        _local, "probe_endpoint", lambda h, p, timeout: _outcome(tcp_open=False, http_status=None)
+    )
+    det = _local.detect()
+    assert det.name == "auntie"
+    assert det.flavor == "auntiepypi"
+    assert det.source == "local"
+    assert det.managed_by == "auntie"
+    assert det.host == "127.0.0.1"
+    assert det.port == 3141
+    assert det.status == "absent"
+
+
+def test_local_detect_up(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        _local, "probe_endpoint",
+        lambda h, p, timeout: _outcome(tcp_open=True, http_status=200, body=b"<html>"),
+    )
+    det = _local.detect()
+    assert det.status == "up"
+    assert det.source == "local"
+
+
+def test_local_detect_down_http_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        _local, "probe_endpoint",
+        lambda h, p, timeout: _outcome(tcp_open=True, http_status=None, error="timeout"),
+    )
+    det = _local.detect()
+    assert det.status == "down"
+    assert det.detail == "timeout"
+
+
+def test_local_detect_down_5xx(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        _local, "probe_endpoint",
+        lambda h, p, timeout: _outcome(tcp_open=True, http_status=503),
+    )
+    det = _local.detect()
+    assert det.status == "down"
+    assert "503" in det.detail
+
+
+def test_local_detect_uses_configured_host_port(tmp_path, monkeypatch):
+    """_local reads pyproject's [tool.auntiepypi.local] each call."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.auntiepypi.local]\nhost = "::1"\nport = 9999\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    captured = {}
+
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return _outcome(tcp_open=False, http_status=None)
+
+    monkeypatch.setattr(_local, "probe_endpoint", fake_probe)
+    det = _local.detect()
+    assert captured == {"host": "::1", "port": 9999}
+    assert det.host == "::1"
+    assert det.port == 9999
+
+
+# --------- detect_all chain ---------
+
+
+def test_detect_all_includes_local_first(monkeypatch, tmp_path):
+    """The local detection appears first in the result list."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        _runtime, "_local_detect",
+        lambda: Detection(
+            name="auntie", flavor="auntiepypi", host="127.0.0.1", port=3141,
+            url="http://127.0.0.1:3141/", status="absent", source="local",
+            managed_by="auntie",
+        ),
+    )
+    monkeypatch.setattr(_runtime, "_declared_detect", lambda specs, *, scan_processes: [])
+    monkeypatch.setattr(_runtime, "_port_detect", lambda specs, *, scan_processes, covered: [])
+
+    results = _runtime.detect_all(ServersConfig())
+    assert results[0].source == "local"
+    assert results[0].name == "auntie"
+
+
+def test_detect_all_passes_local_into_covered(monkeypatch, tmp_path):
+    """Port scanner sees local (host, port) in `covered` and skips it."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        _runtime, "_local_detect",
+        lambda: Detection(
+            name="auntie", flavor="auntiepypi", host="127.0.0.1", port=3141,
+            url="http://127.0.0.1:3141/", status="absent", source="local",
+        ),
+    )
+    monkeypatch.setattr(_runtime, "_declared_detect", lambda specs, *, scan_processes: [])
+
+    captured: dict[str, set] = {}
+
+    def fake_port_detect(specs, *, scan_processes, covered):
+        captured["covered"] = set(covered)
+        return []
+
+    monkeypatch.setattr(_runtime, "_port_detect", fake_port_detect)
+    _runtime.detect_all(ServersConfig())
+    assert ("127.0.0.1", 3141) in captured["covered"]
+
+
+def test_detect_all_dedup_with_declared_on_same_port(monkeypatch, tmp_path):
+    """If a declared server happens to be on 127.0.0.1:3141, both
+    appear (local first); the port scanner sees both in covered.
+    """
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    local = Detection(
+        name="auntie", flavor="auntiepypi", host="127.0.0.1", port=3141,
+        url="http://127.0.0.1:3141/", status="absent", source="local",
+    )
+    declared = Detection(
+        name="my-devpi", flavor="devpi", host="127.0.0.1", port=3141,
+        url="http://127.0.0.1:3141/", status="up", source="declared",
+    )
+    monkeypatch.setattr(_runtime, "_local_detect", lambda: local)
+    monkeypatch.setattr(_runtime, "_declared_detect", lambda specs, *, scan_processes: [declared])
+
+    captured: dict = {}
+
+    def fake_port_detect(specs, *, scan_processes, covered):
+        captured["covered"] = set(covered)
+        return []
+
+    monkeypatch.setattr(_runtime, "_port_detect", fake_port_detect)
+    results = _runtime.detect_all(ServersConfig())
+    # Local first, then declared.
+    assert results[0].source == "local"
+    assert results[1].source == "declared"
+    # Only one (host, port) in covered (set semantics).
+    assert ("127.0.0.1", 3141) in captured["covered"]

--- a/tests/test_detect_runtime.py
+++ b/tests/test_detect_runtime.py
@@ -86,6 +86,25 @@ def _det(name, port, source, status="up", flavor="pypiserver", pid=None) -> Dete
     )
 
 
+def _local_stub() -> Detection:
+    """Sentinel returned by the _local detector in these merge tests."""
+    return Detection(
+        name="auntie",
+        flavor="auntiepypi",
+        host="127.0.0.1",
+        port=3141,
+        url="http://127.0.0.1:3141/",
+        status="absent",
+        source="local",
+        managed_by="auntie",
+    )
+
+
+def _without_local(detections: list[Detection]) -> list[Detection]:
+    """Filter out the local detection so existing merge assertions stay focused."""
+    return [d for d in detections if d.source != "local"]
+
+
 def test_detect_all_empty_config_runs_port_scan_only() -> None:
     cfg = ServersConfig(specs=(), scan_processes=False)
     declared_calls: list = []
@@ -101,11 +120,12 @@ def test_detect_all_empty_config_runs_port_scan_only() -> None:
         return []
 
     with (
+        patch("auntiepypi._detect._runtime._local_detect", _local_stub),
         patch("auntiepypi._detect._runtime._declared_detect", fake_declared),
         patch("auntiepypi._detect._runtime._port_detect", fake_port),
         patch("auntiepypi._detect._runtime._proc_detect", fake_proc),
     ):
-        result = detect_all(cfg)
+        result = _without_local(detect_all(cfg))
     assert len(result) == 1
     assert result[0].source == "port"
     assert declared_calls == [[]]
@@ -120,11 +140,12 @@ def test_detect_all_augment_suppresses_absent_from_scan_when_declared_exists() -
     ]
 
     with (
+        patch("auntiepypi._detect._runtime._local_detect", _local_stub),
         patch("auntiepypi._detect._runtime._declared_detect", lambda *a, **kw: declared_results),
         patch("auntiepypi._detect._runtime._port_detect", lambda *a, **kw: port_results),
         patch("auntiepypi._detect._runtime._proc_detect", lambda *a, **kw: []),
     ):
-        result = detect_all(cfg)
+        result = _without_local(detect_all(cfg))
     sources = [d.source for d in result]
     assert "declared" in sources
     port_absent = [d for d in result if d.source == "port" and d.status == "absent"]
@@ -139,11 +160,12 @@ def test_detect_all_keeps_port_scan_finds_when_declared_exists() -> None:
     port_results = [_det("pypiserver:8080", 8080, "port", status="up")]
 
     with (
+        patch("auntiepypi._detect._runtime._local_detect", _local_stub),
         patch("auntiepypi._detect._runtime._declared_detect", lambda *a, **kw: declared_results),
         patch("auntiepypi._detect._runtime._port_detect", lambda *a, **kw: port_results),
         patch("auntiepypi._detect._runtime._proc_detect", lambda *a, **kw: []),
     ):
-        result = detect_all(cfg)
+        result = _without_local(detect_all(cfg))
     sources = {d.source for d in result}
     assert sources == {"declared", "port"}
 
@@ -155,11 +177,12 @@ def test_detect_all_proc_enriches_existing_detection_with_pid() -> None:
     proc_d = _det("pypiserver:8080", 8080, "proc", status="up", pid=1234)
 
     with (
+        patch("auntiepypi._detect._runtime._local_detect", _local_stub),
         patch("auntiepypi._detect._runtime._declared_detect", lambda *a, **kw: []),
         patch("auntiepypi._detect._runtime._port_detect", lambda *a, **kw: [port_d]),
         patch("auntiepypi._detect._runtime._proc_detect", lambda *a, **kw: [proc_d]),
     ):
-        result = detect_all(cfg)
+        result = _without_local(detect_all(cfg))
     assert len(result) == 1
     assert result[0].pid == 1234
     assert result[0].source == "port"
@@ -170,11 +193,12 @@ def test_detect_all_proc_only_finds_appended() -> None:
     proc_d = _det("pypiserver:9001", 9001, "proc", pid=999)
 
     with (
+        patch("auntiepypi._detect._runtime._local_detect", _local_stub),
         patch("auntiepypi._detect._runtime._declared_detect", lambda *a, **kw: []),
         patch("auntiepypi._detect._runtime._port_detect", lambda *a, **kw: []),
         patch("auntiepypi._detect._runtime._proc_detect", lambda *a, **kw: [proc_d]),
     ):
-        result = detect_all(cfg)
+        result = _without_local(detect_all(cfg))
     assert len(result) == 1
     assert result[0].source == "proc"
     assert result[0].port == 9001

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -14,9 +14,10 @@ def test_overview_text_no_args(capsys: pytest.CaptureFixture[str]) -> None:
     out = capsys.readouterr().out
     assert out.strip()
     assert "# auntie" in out
-    # v0.1.0: servers appear by their probe name (devpi / pypiserver), not
-    # as the legacy "local-pypi-servers" aggregate section header.
-    assert any(name in out for name in ("devpi", "pypiserver"))
+    # Servers appear by their probe name. v0.6.0 always emits the
+    # first-party "auntie" detection (status="absent" when not running),
+    # so the section is reliably populated even on bare environments.
+    assert any(name in out for name in ("auntie", "devpi", "pypiserver"))
 
 
 def test_overview_json_shape(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_overview_local.py
+++ b/tests/test_overview_local.py
@@ -1,0 +1,100 @@
+"""v0.6.0: `auntie overview` surfaces the first-party server.
+
+The integration was wired in Task 7 (``_detect/_local``); these tests
+just verify the rendered output shows the local server in both text
+and JSON modes, regardless of whether it's running.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from auntiepypi._detect import _runtime
+from auntiepypi._detect._detection import Detection
+from auntiepypi.cli import main
+
+
+def _local_stub_up() -> Detection:
+    return Detection(
+        name="auntie",
+        flavor="auntiepypi",
+        host="127.0.0.1",
+        port=3141,
+        url="http://127.0.0.1:3141/",
+        status="up",
+        source="local",
+        managed_by="auntie",
+    )
+
+
+def _local_stub_absent() -> Detection:
+    return Detection(
+        name="auntie",
+        flavor="auntiepypi",
+        host="127.0.0.1",
+        port=3141,
+        url="http://127.0.0.1:3141/",
+        status="absent",
+        source="local",
+        managed_by="auntie",
+    )
+
+
+def test_overview_renders_local_up(monkeypatch, capsys, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_runtime, "_local_detect", _local_stub_up)
+    rc = main(["overview"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "auntie" in out
+    assert "auntiepypi" in out
+    assert "127.0.0.1" in out
+    assert "3141" in out
+    assert "local" in out  # source field rendered
+
+
+def test_overview_renders_local_absent(monkeypatch, capsys, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_runtime, "_local_detect", _local_stub_absent)
+    rc = main(["overview"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "auntie" in out
+    assert "absent" in out
+
+
+def test_overview_json_local_shape(monkeypatch, capsys, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_runtime, "_local_detect", _local_stub_up)
+    rc = main(["overview", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    sections = payload["sections"]
+    local_sections = [
+        s
+        for s in sections
+        if s.get("category") == "servers"
+        and any(f["name"] == "source" and f["value"] == "local" for f in s["fields"])
+    ]
+    assert len(local_sections) == 1
+    section = local_sections[0]
+    assert section["title"] == "auntie"
+    field_map = {f["name"]: f["value"] for f in section["fields"]}
+    assert field_map["flavor"] == "auntiepypi"
+    assert field_map["managed_by"] == "auntie"
+    assert field_map["status"] == "up"
+
+
+def test_overview_local_target_drilldown(monkeypatch, capsys, tmp_path):
+    """`auntie overview auntie` drills into the local server."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_runtime, "_local_detect", _local_stub_up)
+    rc = main(["overview", "auntie"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The target-specific output should still surface auntie's
+    # detection block (overview's TARGET resolution falls back to
+    # detection name lookup).
+    assert "auntie" in out

--- a/tests/test_overview_local.py
+++ b/tests/test_overview_local.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from auntiepypi._detect import _runtime
 from auntiepypi._detect._detection import Detection
 from auntiepypi.cli import main

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -185,9 +185,20 @@ def test_files_rejects_subdirectory(served):
 
 def test_unknown_path_404(served):
     port, _ = served
-    for path in ("/", "/index.html", "/api/v1/whatever", "/simple"):
+    for path in ("/index.html", "/api/v1/whatever", "/simple"):
         status, _body, _ = _get(port, path)
         assert status == 404, path
+
+
+def test_root_landing_page(served):
+    """`/` returns a small 200 landing page so reprobe and curious users
+    see something other than a 404 at the root."""
+    port, _ = served
+    status, body, _ = _get(port, "/")
+    assert status == 200
+    text = body.decode()
+    assert "auntiepypi" in text
+    assert 'href="/simple/"' in text
 
 
 def test_post_method_405(served):

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -151,7 +151,7 @@ def test_files_404_when_absent(served):
 
 def test_files_rejects_path_traversal(served, tmp_path):
     """`..` segments must not escape the wheelhouse root."""
-    port, root = served
+    port, _ = served
     secret = tmp_path.parent / "secret.txt"
     secret.write_text("private")
     # http.client URL-encodes %2e%2e; try both the raw and encoded forms.

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -1,0 +1,204 @@
+"""Tests for `auntiepypi._server._app` — PEP 503 simple-index handler."""
+
+from __future__ import annotations
+
+import threading
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from auntiepypi._server._app import make_handler
+
+
+@pytest.fixture
+def served(tmp_path: Path) -> Iterator[tuple[int, Path]]:
+    """Spin up a ThreadingHTTPServer against a per-test wheelhouse on a
+    free port. Yields ``(port, root)``.
+    """
+    handler_cls = make_handler(tmp_path)
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, tmp_path
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def _get(port: int, path: str) -> tuple[int, bytes, dict[str, str]]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        return resp.status, resp.read(), dict(resp.getheaders())
+    finally:
+        conn.close()
+
+
+# --------- /simple/ index ---------
+
+
+def test_simple_index_empty(served):
+    port, _ = served
+    status, body, _ = _get(port, "/simple/")
+    assert status == 200
+    text = body.decode()
+    assert "<html>" in text.lower()
+    assert "<body>" in text.lower()
+    # No project anchors yet.
+    assert 'href="/simple/' not in text
+
+
+def test_simple_index_lists_projects(served):
+    port, root = served
+    (root / "requests-2.31.0-py3-none-any.whl").touch()
+    (root / "Django-4.2.0.tar.gz").touch()
+    status, body, _ = _get(port, "/simple/")
+    text = body.decode()
+    assert status == 200
+    assert 'href="/simple/requests/"' in text
+    assert 'href="/simple/django/"' in text  # PEP 503 normalized to lowercase
+    assert ">requests<" in text
+    assert ">django<" in text
+
+
+def test_simple_index_html_escapes(served):
+    """Filenames can't contain HTML-magic chars (filesystem rejects most),
+    but we still escape — defence in depth.
+    """
+    port, root = served
+    # Project name with a dot in it — must show up un-mangled.
+    (root / "ruamel.yaml-0.18.0.tar.gz").touch()
+    status, body, _ = _get(port, "/simple/")
+    text = body.decode()
+    assert status == 200
+    assert 'href="/simple/ruamel-yaml/"' in text
+
+
+# --------- /simple/<pkg>/ project page ---------
+
+
+def test_simple_project_page(served):
+    port, root = served
+    (root / "requests-2.30.0-py3-none-any.whl").touch()
+    (root / "requests-2.31.0-py3-none-any.whl").touch()
+    (root / "requests-2.31.0.tar.gz").touch()
+    status, body, _ = _get(port, "/simple/requests/")
+    text = body.decode()
+    assert status == 200
+    assert 'href="/files/requests-2.30.0-py3-none-any.whl"' in text
+    assert 'href="/files/requests-2.31.0-py3-none-any.whl"' in text
+    assert 'href="/files/requests-2.31.0.tar.gz"' in text
+
+
+def test_simple_project_normalizes_request(served):
+    """PEP 503 says clients must normalize; we accept any form and
+    serve from the canonical bucket.
+    """
+    port, root = served
+    (root / "Foo_Bar-1.0-py3-none-any.whl").touch()
+    for path in ("/simple/foo-bar/", "/simple/Foo_Bar/", "/simple/foo.bar/"):
+        status, body, _ = _get(port, path)
+        assert status == 200, path
+        assert "Foo_Bar-1.0-py3-none-any.whl" in body.decode()
+
+
+def test_simple_project_404_for_missing(served):
+    port, _ = served
+    status, _body, _ = _get(port, "/simple/nonexistent/")
+    assert status == 404
+
+
+def test_simple_project_no_trailing_slash(served):
+    """PEP 503 requires the trailing slash; serve a redirect or the page.
+    Our minimal impl serves the page when given /simple/<pkg> too.
+    """
+    port, root = served
+    (root / "requests-2.31.0-py3-none-any.whl").touch()
+    status, body, _ = _get(port, "/simple/requests")
+    # Either 200 (we serve it) or 301/308 (redirect) is acceptable for
+    # PEP 503 clients; we choose 200 since the trailing slash is a
+    # minor pedantry and pip handles both.
+    assert status in (200, 301, 308)
+    if status == 200:
+        assert "requests-2.31.0-py3-none-any.whl" in body.decode()
+
+
+# --------- /files/<filename> file download ---------
+
+
+def test_files_serves_wheel_bytes(served):
+    port, root = served
+    wheel = root / "requests-2.31.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04fake-wheel-bytes")
+    status, body, headers = _get(port, "/files/requests-2.31.0-py3-none-any.whl")
+    assert status == 200
+    assert body == b"PK\x03\x04fake-wheel-bytes"
+    assert headers["Content-Type"] == "application/octet-stream"
+
+
+def test_files_404_when_absent(served):
+    port, _ = served
+    status, _body, _ = _get(port, "/files/nope-1.0.tar.gz")
+    assert status == 404
+
+
+def test_files_rejects_path_traversal(served, tmp_path):
+    """`..` segments must not escape the wheelhouse root."""
+    port, root = served
+    secret = tmp_path.parent / "secret.txt"
+    secret.write_text("private")
+    # http.client URL-encodes %2e%2e; try both the raw and encoded forms.
+    for path in (
+        "/files/../secret.txt",
+        "/files/..%2Fsecret.txt",
+        "/files/%2e%2e%2Fsecret.txt",
+    ):
+        status, body, _ = _get(port, path)
+        assert status == 404, f"{path} returned {status}: {body!r}"
+
+
+def test_files_rejects_absolute_path(served):
+    port, _ = served
+    status, _body, _ = _get(port, "/files//etc/passwd")
+    assert status == 404
+
+
+def test_files_rejects_subdirectory(served):
+    """Files in subdirectories of the wheelhouse aren't reachable."""
+    port, root = served
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / "hidden-1.0-py3-none-any.whl").write_bytes(b"x")
+    status, _body, _ = _get(port, "/files/sub/hidden-1.0-py3-none-any.whl")
+    assert status == 404
+
+
+# --------- catch-all ---------
+
+
+def test_unknown_path_404(served):
+    port, _ = served
+    for path in ("/", "/index.html", "/api/v1/whatever", "/simple"):
+        status, _body, _ = _get(port, path)
+        assert status == 404, path
+
+
+def test_post_method_405(served):
+    """Read-only server: POST should not succeed."""
+    port, _ = served
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("POST", "/simple/", body=b"")
+        resp = conn.getresponse()
+        # 405 Method Not Allowed or 501 Not Implemented are both fine.
+        assert resp.status in (405, 501)
+        resp.read()
+    finally:
+        conn.close()

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -11,7 +11,6 @@ import pytest
 from auntiepypi import _server
 from auntiepypi._server import __main__ as server_main
 
-
 # --------- argparse ---------
 
 

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -16,12 +16,11 @@ from auntiepypi._server import __main__ as server_main
 
 def test_parser_defaults():
     # /tmp path is an argparse fixture, never created on disk.
-    args = server_main._parser().parse_args(
-        ["--root", "/tmp/wh"]
-    )  # noqa: S108  # NOSONAR python:S5443
+    fixture_root = "/tmp/wh"  # noqa: S108  # NOSONAR python:S5443
+    args = server_main._parser().parse_args(["--root", fixture_root])
     assert args.host == "127.0.0.1"
     assert args.port == 3141
-    assert args.root == Path("/tmp/wh")  # noqa: S108  # NOSONAR python:S5443
+    assert args.root == Path(fixture_root)
 
 
 def test_parser_overrides():

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -16,7 +16,7 @@ from auntiepypi._server import __main__ as server_main
 
 def test_parser_defaults():
     # /tmp path is an argparse fixture, never created on disk.
-    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108
+    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108  # NOSONAR python:S5443
     assert args.host == "127.0.0.1"
     assert args.port == 3141
     assert args.root == Path("/tmp/wh")  # noqa: S108  # NOSONAR python:S5443

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -1,0 +1,104 @@
+"""Tests for `auntiepypi._server.__main__` and the `serve()` helper."""
+
+from __future__ import annotations
+
+import threading
+from http.client import HTTPConnection
+from pathlib import Path
+
+import pytest
+
+from auntiepypi import _server
+from auntiepypi._server import __main__ as server_main
+
+
+# --------- argparse ---------
+
+
+def test_parser_defaults():
+    args = server_main._parser().parse_args(["--root", "/tmp/wh"])
+    assert args.host == "127.0.0.1"
+    assert args.port == 3141
+    assert args.root == Path("/tmp/wh")
+
+
+def test_parser_overrides():
+    args = server_main._parser().parse_args(
+        ["--host", "0.0.0.0", "--port", "8080", "--root", "/var/wheels"]
+    )
+    assert args.host == "0.0.0.0"
+    assert args.port == 8080
+    assert args.root == Path("/var/wheels")
+
+
+def test_parser_requires_root():
+    with pytest.raises(SystemExit):
+        server_main._parser().parse_args([])
+
+
+def test_main_calls_serve(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    def fake_serve(host: str, port: int, root: Path) -> None:
+        captured.update({"host": host, "port": port, "root": root})
+
+    monkeypatch.setattr(server_main, "serve", fake_serve)
+    server_main.main(["--host", "127.0.0.1", "--port", "9999", "--root", str(tmp_path)])
+    assert captured == {"host": "127.0.0.1", "port": 9999, "root": tmp_path}
+
+
+# --------- serve() integration ---------
+
+
+def test_serve_handles_request_and_shuts_down(tmp_path):
+    """End-to-end smoke test: serve() responds to /simple/ and exits cleanly."""
+    (tmp_path / "demo-1.0-py3-none-any.whl").touch()
+
+    started = threading.Event()
+    captured: dict[str, object] = {}
+
+    class _Recording:
+        """Wrap ThreadingHTTPServer so the test can grab the instance and
+        call shutdown() from outside.
+        """
+
+        def __init__(self, address, handler):
+            from http.server import ThreadingHTTPServer
+
+            self.inner = ThreadingHTTPServer(address, handler)
+            self.server_address = self.inner.server_address
+            captured["server"] = self
+            started.set()
+
+        def serve_forever(self):
+            return self.inner.serve_forever()
+
+        def shutdown(self):
+            return self.inner.shutdown()
+
+        def server_close(self):
+            return self.inner.server_close()
+
+    def runner():
+        _server.serve("127.0.0.1", 0, tmp_path, server_factory=_Recording)
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    assert started.wait(timeout=5), "server didn't start"
+
+    server = captured["server"]
+    port = server.server_address[1]
+
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", "/simple/")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        body = resp.read().decode()
+        assert 'href="/simple/demo/"' in body
+    finally:
+        conn.close()
+
+    server.shutdown()
+    thread.join(timeout=5)
+    assert not thread.is_alive()

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -15,17 +15,20 @@ from auntiepypi._server import __main__ as server_main
 
 
 def test_parser_defaults():
-    args = server_main._parser().parse_args(["--root", "/tmp/wh"])
+    # /tmp path is an argparse fixture, never created on disk.
+    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108
     assert args.host == "127.0.0.1"
     assert args.port == 3141
-    assert args.root == Path("/tmp/wh")
+    assert args.root == Path("/tmp/wh")  # noqa: S108  # NOSONAR python:S5443
 
 
 def test_parser_overrides():
+    # "0.0.0.0" is a fixture asserting argparse passes the value through;
+    # the bind would be rejected at config-load time by load_local_config.
     args = server_main._parser().parse_args(
-        ["--host", "0.0.0.0", "--port", "8080", "--root", "/var/wheels"]
+        ["--host", "0.0.0.0", "--port", "8080", "--root", "/var/wheels"]  # noqa: S104
     )
-    assert args.host == "0.0.0.0"
+    assert args.host == "0.0.0.0"  # noqa: S104
     assert args.port == 8080
     assert args.root == Path("/var/wheels")
 

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -16,7 +16,9 @@ from auntiepypi._server import __main__ as server_main
 
 def test_parser_defaults():
     # /tmp path is an argparse fixture, never created on disk.
-    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108  # NOSONAR python:S5443
+    args = server_main._parser().parse_args(
+        ["--root", "/tmp/wh"]
+    )  # noqa: S108  # NOSONAR python:S5443
     assert args.host == "127.0.0.1"
     assert args.port == 3141
     assert args.root == Path("/tmp/wh")  # noqa: S108  # NOSONAR python:S5443

--- a/tests/test_server_wheelhouse.py
+++ b/tests/test_server_wheelhouse.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from auntiepypi._server import _wheelhouse
-
 
 # --------- PEP 503 name normalization ---------
 
@@ -48,9 +45,10 @@ def test_parse_wheel_simple():
 
 def test_parse_wheel_with_build_tag():
     """PEP 427: optional build tag is digit-prefixed (3rd segment)."""
-    assert _wheelhouse.parse_filename(
-        "tensorflow-2.0.0-1-cp37-cp37m-manylinux2010_x86_64.whl"
-    ) == ("tensorflow", "2.0.0")
+    assert _wheelhouse.parse_filename("tensorflow-2.0.0-1-cp37-cp37m-manylinux2010_x86_64.whl") == (
+        "tensorflow",
+        "2.0.0",
+    )
 
 
 def test_parse_wheel_underscore_in_name():

--- a/tests/test_server_wheelhouse.py
+++ b/tests/test_server_wheelhouse.py
@@ -1,0 +1,151 @@
+"""Tests for `auntiepypi._server._wheelhouse` — filename parsing + project listing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from auntiepypi._server import _wheelhouse
+
+
+# --------- PEP 503 name normalization ---------
+
+
+def test_normalize_lowercases():
+    assert _wheelhouse.normalize("Foo") == "foo"
+
+
+def test_normalize_collapses_separators():
+    assert _wheelhouse.normalize("Foo_Bar.Baz") == "foo-bar-baz"
+
+
+def test_normalize_collapses_runs():
+    assert _wheelhouse.normalize("foo___bar...baz") == "foo-bar-baz"
+
+
+def test_normalize_mixed_separators():
+    assert _wheelhouse.normalize("foo_-_bar") == "foo-bar"
+
+
+def test_normalize_already_canonical():
+    assert _wheelhouse.normalize("foo-bar") == "foo-bar"
+
+
+def test_normalize_keeps_digits():
+    assert _wheelhouse.normalize("Pillow9") == "pillow9"
+
+
+# --------- parse_filename ---------
+
+
+def test_parse_wheel_simple():
+    assert _wheelhouse.parse_filename("requests-2.31.0-py3-none-any.whl") == (
+        "requests",
+        "2.31.0",
+    )
+
+
+def test_parse_wheel_with_build_tag():
+    """PEP 427: optional build tag is digit-prefixed (3rd segment)."""
+    assert _wheelhouse.parse_filename(
+        "tensorflow-2.0.0-1-cp37-cp37m-manylinux2010_x86_64.whl"
+    ) == ("tensorflow", "2.0.0")
+
+
+def test_parse_wheel_underscore_in_name():
+    """Wheels canonicalize the dist name with underscores."""
+    assert _wheelhouse.parse_filename(
+        "scikit_learn-1.3.0-cp311-cp311-manylinux_2_17_x86_64.whl"
+    ) == ("scikit_learn", "1.3.0")
+
+
+def test_parse_sdist_tar_gz():
+    assert _wheelhouse.parse_filename("requests-2.31.0.tar.gz") == ("requests", "2.31.0")
+
+
+def test_parse_sdist_zip():
+    assert _wheelhouse.parse_filename("requests-2.31.0.zip") == ("requests", "2.31.0")
+
+
+def test_parse_sdist_with_dot_in_version():
+    assert _wheelhouse.parse_filename("Django-4.2.7.tar.gz") == ("Django", "4.2.7")
+
+
+def test_parse_rejects_non_dist():
+    assert _wheelhouse.parse_filename("README.md") is None
+    assert _wheelhouse.parse_filename("requirements.txt") is None
+    assert _wheelhouse.parse_filename("foo.exe") is None
+
+
+def test_parse_rejects_malformed_wheel():
+    """Wheel without enough segments → None."""
+    assert _wheelhouse.parse_filename("foo.whl") is None
+
+
+def test_parse_rejects_malformed_sdist():
+    """Sdist without version separator → None."""
+    assert _wheelhouse.parse_filename("foo.tar.gz") is None
+
+
+# --------- list_projects ---------
+
+
+def test_list_projects_empty(tmp_path):
+    assert _wheelhouse.list_projects(tmp_path) == {}
+
+
+def test_list_projects_single_wheel(tmp_path):
+    (tmp_path / "requests-2.31.0-py3-none-any.whl").touch()
+    result = _wheelhouse.list_projects(tmp_path)
+    assert set(result.keys()) == {"requests"}
+    assert len(result["requests"]) == 1
+    assert result["requests"][0].name == "requests-2.31.0-py3-none-any.whl"
+
+
+def test_list_projects_groups_by_normalized_name(tmp_path):
+    """Both 'Foo_Bar' and 'foo-bar' filenames bucket under 'foo-bar'."""
+    (tmp_path / "Foo_Bar-1.0-py3-none-any.whl").touch()
+    (tmp_path / "foo-bar-2.0.tar.gz").touch()
+    result = _wheelhouse.list_projects(tmp_path)
+    assert set(result.keys()) == {"foo-bar"}
+    assert len(result["foo-bar"]) == 2
+
+
+def test_list_projects_multiple_versions(tmp_path):
+    (tmp_path / "requests-2.30.0-py3-none-any.whl").touch()
+    (tmp_path / "requests-2.31.0-py3-none-any.whl").touch()
+    (tmp_path / "requests-2.31.0.tar.gz").touch()
+    result = _wheelhouse.list_projects(tmp_path)
+    assert set(result.keys()) == {"requests"}
+    assert len(result["requests"]) == 3
+
+
+def test_list_projects_skips_non_dist(tmp_path):
+    (tmp_path / "requests-2.31.0-py3-none-any.whl").touch()
+    (tmp_path / "README.md").touch()
+    (tmp_path / ".gitkeep").touch()
+    result = _wheelhouse.list_projects(tmp_path)
+    assert set(result.keys()) == {"requests"}
+
+
+def test_list_projects_missing_root(tmp_path):
+    """Missing root → empty dict, not exception (server keeps running)."""
+    assert _wheelhouse.list_projects(tmp_path / "does-not-exist") == {}
+
+
+def test_list_projects_skips_subdirectories(tmp_path):
+    """Walk is one-level only; subdirs are not recursed."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "should-not-be-found-1.0-py3-none-any.whl").touch()
+    (tmp_path / "found-1.0-py3-none-any.whl").touch()
+    result = _wheelhouse.list_projects(tmp_path)
+    assert set(result.keys()) == {"found"}
+
+
+def test_list_projects_returns_paths_in_root(tmp_path):
+    (tmp_path / "requests-2.31.0-py3-none-any.whl").touch()
+    result = _wheelhouse.list_projects(tmp_path)
+    path: Path = result["requests"][0]
+    assert path.parent == tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "auntiepypi"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Fills the v0.5.0 bare-form reservation: `auntie up` / `auntie down` / `auntie restart` now manage a stdlib-only PEP 503 simple-index server (read-only slice). Configured by `[tool.auntiepypi.local]`; loopback-only in v0.6.0.
- New strategy `_actions/auntie.py` plugs into the existing `dispatch(action, det, spec)` table by wrapping `command.py` with a derived argv (`python -m auntiepypi._server …`). PID-tracking, reprobe, and SIGTERM/SIGKILL escalation reused from v0.5.0.
- New detector `_detect/_local.py` always emits one Detection (`source="local"`, `flavor="auntiepypi"`, `managed_by="auntie"`) so `auntie overview` always surfaces the local server's status.

## Out of scope (deferred)

- `auntie publish`, HTTPS termination, basic-auth → v0.7.0 (auth + public-binding bundle).
- Mesh-aware service registry → v1.0.0.

## Test plan

- [x] `pytest -n auto --cov=auntiepypi` — 447 passed, coverage 94.41% (above 94 floor)
- [x] `black --check`, `isort --check-only`, `flake8`, `pylint --errors-only`, `bandit -c pyproject.toml -r auntiepypi`
- [x] `markdownlint-cli2 "**/*.md"` — 23 files clean
- [x] `bash .claude/skills/pr-review/scripts/portability-lint.sh` — 13 files clean
- [x] End-to-end smoke (in a tmpdir with `pyproject.toml` setting port=18080 and root=wheels):
  - `auntie up` → `[ok] auntie: started (pid=...)`
  - `curl http://127.0.0.1:18080/simple/` → 200, anchor list of projects
  - `auntie down` → `[ok] auntie: stopped (SIGTERM)`

## Notable implementation choices

- **Port 3141 default** — matches the conventional private-index port (devpi). The `_local` detector runs first in `detect_all` so its `(host, port)` enters `covered`, preventing the default-port scanner from double-counting it as `devpi`.
- **Reserved name `"auntie"`** — declared specs that use it are rejected at lifecycle resolution time with a clear remediation. Bare form is the only entry point to the first-party server.
- **`auntiepypi` flavor skips the reprobe fingerprint check** — our PEP 503 HTML fingerprints as `pypiserver` (via the HREF regex), which would otherwise produce a flavor-mismatch false negative on every successful start. Both `"unknown"` and `"auntiepypi"` skip the check now.
- **GET `/` returns a 200 landing page** — the reprobe loop hits `/` by default; a 404 there made every `auntie up` report "not responding" even when the server was healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude