### PR TITLE
v0.8.0: auntie publish — twine-compatible POST upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-05-03
+
+### Added
+
+- `auntie publish <path>` — new CLI verb that uploads wheels and sdists to the configured first-party local index. Reads credentials from `$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` or interactive prompt; refuses to block in non-TTY environments. Exit codes: 0 on 2xx, 1 on 4xx/5xx, 2 on transport error.
+- Twine-compatible POST upload endpoint at `/`. The first-party server now accepts the legacy PyPI upload protocol (`multipart/form-data` with `:action=file_upload`); twine, flit, hatch all work unchanged. Authorization requires both authentication AND membership in the new `publish_users` allowlist.
+- `[tool.auntiepypi.local].publish_users` — list of htpasswd usernames permitted to POST uploads. Empty / unset preserves read-only mode (POST returns 403 "publish disabled"). `publish_users` set without `htpasswd` is rejected at config-load time. Each name must reference an actual htpasswd entry; the cross-check fires before the server starts.
+- `[tool.auntiepypi.local].max_upload_bytes` — per-request body cap, default 100 MiB. Enforced both pre-read (Content-Length) and during-read (counted reader). Operators with multi-GiB ML wheels override.
+- `_server/_multipart.py` — twine-shape multipart parser using stdlib `email.parser.BytesParser`. Consumes `:action`, `name`, and `content` (with filename); silently ignores the ~17 other metadata fields PyPI clients send.
+- `_server/_publish.py` — atomic upload writer. `tempfile.NamedTemporaryFile(dir=root, prefix=".upload-", suffix=".part")` keeps the rename on the same filesystem (atomic on POSIX). Existing-target collision returns 409 (no overwrite, ever); ENOSPC / EROFS / EACCES return 500 with cleanup; the finally-block unlinks the temp on every error path so partial uploads never litter `cfg.root`.
+- `_server/_auth.authenticate_user(header, map) -> str | None` — new primitive that returns the authenticated username (publish authz needs to know *which* user uploaded). `verify_basic` becomes a thin bool adapter; existing v0.7.0 read-side callers (`do_GET`) are unchanged.
+- `cli/_commands/_publish_client.py` — stdlib HTTP client. `build_multipart` assembles the request body; `post` wraps `urllib.request` with `Authorization: Basic …`, captures `HTTPError` as `(status, body)`, propagates `URLError` for transport failures.
+
+### Changed
+
+- `make_handler` widens with two new kwargs: `publish_users: tuple[str, ...] = ()` and `max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES`. v0.7.0 callers (no kwargs) get the same behaviour.
+- `serve()` and `python -m auntiepypi._server` gain `--publish-user NAME` (repeatable) and `--max-upload-bytes N`. `_actions/auntie._argv()` appends them conditionally so v0.7.0 pyprojects produce the exact same argv.
+- `auntie explain auntiepypi` and `auntie learn` document the new verb plus the two new `[tool.auntiepypi.local]` keys.
+
+### Threat model expansion
+
+- Read surface unchanged: "single-host LAN with auth + TLS."
+- Write surface: "single-host LAN with auth + TLS + per-user authz." Every publisher must be both authenticated AND in `publish_users`. POST `/` returns 405 when auth is not configured (operator opted into read-only); 401 / 403 / 404 / 400 / 413 / 409 / 201 by failure mode otherwise.
+
+### Compat notes
+
+- `LocalConfig` adds two optional fields with sane defaults; v0.7.0 default tables still parse identically.
+- `do_POST` is a real verb now. v0.7.0 servers without `publish_users` configured still answer it (with 403 "publish disabled"), where v0.7.0 returned 501. The behaviour-sealed-by-default property holds: read-only mode requires no operator opt-in.
+- The `cgi` stdlib module is removed in Python 3.13. `_multipart.py` uses `email.parser.BytesParser` instead — no third-party dep.
+
+### Fixed
+
 ## [0.7.0] - 2026-05-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,33 +2,42 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Status: v0.7.0 — HTTPS + basic-auth landed
+## Status: v0.8.0 — `auntie publish` (write side) landed
 
-The first-party server gains optional **HTTPS** (operator-supplied PEM
-via `[tool.auntiepypi.local].cert` / `.key`, loaded with
-`ssl.SSLContext.load_cert_chain`, TLS 1.2 floor) and **HTTP Basic auth**
-(Apache htpasswd file, bcrypt-only, via
-`[tool.auntiepypi.local].htpasswd`). Public binding (non-loopback) is
-allowed when both are configured; either alone is rejected at
-config-load time with a `missing: …` tail naming the gap. The detection
-probe switches scheme based on `cfg.tls_enabled` and treats 401 as `up`
-when `cfg.auth_enabled` (a working auth gate is a stronger liveness
-signal than an open 200; the detector deliberately doesn't read
-htpasswd).
+The first-party server gains a **twine-compatible POST upload
+endpoint** at `/`. The legacy PyPI upload protocol
+(`multipart/form-data` with `:action=file_upload`) is what twine,
+flit, and hatch all speak; the auntiepypi server speaks it too.
 
-`bcrypt>=4.0,<5` becomes the **first runtime dependency** — stdlib has
-no htpasswd-compatible verifier and rolling our own bcrypt is
-malpractice. `cryptography` is dev-only (test cert fixture).
+Authorization is a strict superset of authentication: every publisher
+must be both authenticated AND in the new `publish_users` allowlist.
+Empty / unset allowlist preserves read-only mode (POST → 403 "publish
+disabled"). Names in the allowlist must reference actual htpasswd
+entries; the cross-check fires at config-load time.
 
-`auntie publish` (write side) remains deferred — the v0.7.0 slice is
-"read-only safe to expose to the LAN," consistent with the small-
-landable-PR pattern from v0.5.0 and v0.6.0. The mesh-aware service
-registry is v1.0.0.
+`[tool.auntiepypi.local].max_upload_bytes` caps each request body
+(default 100 MiB; enforced both pre-read via `Content-Length` and
+during-read via a counted reader). Writes are atomic:
+`tempfile.NamedTemporaryFile(dir=cfg.root, prefix=".upload-", suffix=".part")`
+followed by `os.rename` on the same filesystem. Existing-target
+collisions return 409 (no overwrite, ever); yank/delete is out of
+scope (operators delete from `cfg.root` directly to retract).
 
-See `docs/superpowers/specs/2026-05-02-auntiepypi-v0.7.0-tls-auth-design.md`
-for the full design rationale; v0.6.0's read-only loopback foundation
-is documented in
-`docs/superpowers/specs/2026-05-01-auntiepypi-v0.6.0-local-server-design.md`.
+The new CLI verb is `auntie publish <path>`. Credentials come from
+`$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` or interactive
+prompt; non-TTY without env vars exits 2 (no silent block). Exit
+codes: 0 on 2xx, 1 on 4xx/5xx, 2 on transport / local-file error.
+
+Multipart parsing uses stdlib `email.parser.BytesParser` (the `cgi`
+module was removed in Python 3.13). No new runtime dependency:
+`bcrypt>=4.0,<5` (added in v0.7.0) is reused for the new
+`authenticate_user` primitive that returns the username instead of a
+bool.
+
+See `docs/superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md`
+for the full design rationale; v0.7.0's TLS + auth foundation is
+documented in
+`docs/superpowers/specs/2026-05-02-auntiepypi-v0.7.0-tls-auth-design.md`.
 
 This file describes the repository **as it exists on disk today**. When
 you edit, keep claims grounded in checked-in reality; the moment a
@@ -176,6 +185,14 @@ Active verbs registered at v0.6.0:
   `command` and the first-party server, re-spawning from the
   **current** pyproject (`command` array or `[tool.auntiepypi.local]`
   respectively). Sidecar argv drift is logged but never blocks.
+- `auntie publish <path> [--json]` — upload a wheel/sdist to the
+  configured local index via the legacy PyPI POST upload protocol
+  (`multipart/form-data` with `:action=file_upload`). Reads creds from
+  `$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` or interactive
+  prompt; refuses to block in non-TTY without env vars. HTTPS verify
+  is on by default; `AUNTIE_INSECURE_SKIP_VERIFY=1` disables it for
+  self-signed certs (loud stderr warning). Exit 0 on 2xx, 1 on 4xx /
+  5xx (401 / 403 / 409 / 413 / …), 2 on transport / local-file error.
 - `auntie whoami [--json]` — auth/env probe; reads `$PIP_INDEX_URL` /
   `$UV_INDEX_URL` env vars and pip's global config file. Exact paths
   inspected live in `auntiepypi/cli/_commands/whoami.py`.
@@ -241,11 +258,25 @@ burned on the `agentpypi → auntiepypi` rename. The table below uses
    dependency. Read-only invariant preserved; `auntie publish` slid
    forward to v0.8.0. See spec
    `docs/superpowers/specs/2026-05-02-auntiepypi-v0.7.0-tls-auth-design.md`.
-8. **semver 0.8.0 — `auntie publish`.** Write side of the first-party
-   index. POST upload path with the same trust model as v0.7.0 (TLS
-   - Basic auth) plus an authorization step (which users can publish).
-9. **semver 1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
-   service registry; trust boundary documented in `docs/threat-model.md`.
+8. **semver 0.8.0 — `auntie publish` (shipped).** Write side of the
+   first-party index. Twine-compatible POST upload at `/`, gated by
+   v0.7.0's TLS + auth bundle plus a `publish_users` allowlist
+   (cross-checked against htpasswd at config-load). New CLI verb
+   `auntie publish <path>`; new `[tool.auntiepypi.local].publish_users`
+   and `.max_upload_bytes` config keys. No new runtime dep —
+   `email.parser.BytesParser` parses the multipart body. See spec
+   `docs/superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md`.
+9. **semver 0.8.1 — keyring / netrc.** Credential plumbing for
+   `auntie publish`: read username/password from system keyring or a
+   netrc-format file (location resolved via `$NETRC` or stdlib
+   defaults). Reduces the `$AUNTIE_PUBLISH_*` env-var ergonomics gap.
+10. **semver 0.9.0 — streaming multipart.** Replace the v0.8.0
+    in-memory parser with a streaming variant so multi-GiB ML wheels
+    don't pay the memory cost. Same on-the-wire protocol.
+11. **semver 1.0.0 — mesh-aware.** Local index discoverable via
+    Culture-mesh service registry; trust boundary documented in
+    `docs/threat-model.md`. Per-package ownership maps
+    (`{"alice": ["mypkg-*"]}`) likely land here too.
 
 This roadmap is descriptive of intent, not a commitment. Reorder or
 replace as the design lands.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 > running locally, and starts/stops/restarts declared servers —
 > informational first, actionable on demand.
 
-**Status:** v0.7.0 — HTTPS + basic-auth landed. The first-party server
-now supports optional TLS termination (operator-supplied PEM via
-`[tool.auntiepypi.local].cert` / `.key`, TLS 1.2 floor) and HTTP Basic
-auth (Apache htpasswd file, bcrypt-only, via
-`[tool.auntiepypi.local].htpasswd`). Public binding (non-loopback) is
-allowed when both are configured; either alone is rejected at
-config-load time. `bcrypt>=4.0,<5` is the first runtime dependency.
+**Status:** v0.8.0 — `auntie publish` (write side) landed. The
+first-party server now accepts twine-compatible POST uploads at `/`
+(legacy PyPI upload protocol — `multipart/form-data` with
+`:action=file_upload`). Authorization is gated by both v0.7.0 auth
+AND a new `publish_users` allowlist; empty allowlist preserves
+read-only mode. New CLI verb `auntie publish <path>` reads creds from
+`$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` or interactive
+prompt. Per-request body cap via `[tool.auntiepypi.local].max_upload_bytes`
+(default 100 MiB). No new runtime dep.
 
 Bare `auntie up` / `auntie down` / `auntie restart` (introduced in
 v0.6.0) continue to start, stop, and restart auntie's own simple-index
@@ -21,8 +23,7 @@ server. Wheels in `$XDG_DATA_HOME/auntiepypi/wheels/` are served from
 configured) and installable via `pip install --index-url`. Lifecycle
 verbs continue to work against declared servers (`managed_by ∈
 {systemd-user, command}`); `--all` aggregates the first-party server
-with every supervised declaration. `auntie publish` (write side) is
-deferred to v0.8.0.
+with every supervised declaration.
 
 ## Quick start
 
@@ -38,6 +39,9 @@ auntie up <name>                    # start one declared server
 auntie up --all                     # first-party server + every supervised declaration
 auntie down                         # stop the first-party server
 auntie restart <name>               # atomic for systemd-user; stop+start for command
+AUNTIE_PUBLISH_USER=alice \
+AUNTIE_PUBLISH_PASSWORD=secret \
+  auntie publish dist/mypkg-1.0.whl  # upload via twine-compatible POST (v0.8.0)
 ```
 
 Example servers-section output (one declared server):
@@ -74,12 +78,37 @@ unit = "pypi-server.service"
 # v0.7.0: HTTPS + Basic auth on the first-party server.
 # Loopback host (127.0.0.1, ::1, localhost) is always allowed.
 # Non-loopback host requires BOTH cert+key AND htpasswd.
+# v0.8.0: publish_users gates the POST upload endpoint; empty list
+# preserves read-only mode. max_upload_bytes caps per-request body.
 [tool.auntiepypi.local]
 host = "0.0.0.0"
 cert = "/etc/ssl/private/auntie.pem"
 key  = "/etc/ssl/private/auntie.key"
 htpasswd = "/etc/auntie/htpasswd"      # bcrypt-only; populate via `htpasswd -B`
+publish_users = ["alice", "bob"]       # v0.8.0: who can POST uploads
+max_upload_bytes = 104857600           # v0.8.0: 100 MiB default
 ```
+
+### Publishing a wheel (v0.8.0)
+
+```bash
+# Operator: configure auth + publish_users (above), then start the server.
+auntie up
+
+# Publisher: build a wheel and upload via auntie's CLI.
+uv build
+AUNTIE_PUBLISH_USER=alice AUNTIE_PUBLISH_PASSWORD=secret \
+  auntie publish dist/mypkg-1.0-py3-none-any.whl
+# expect: "published mypkg-1.0-py3-none-any.whl → /files/..."
+
+# Or via twine — the server speaks the legacy PyPI upload protocol.
+TWINE_USERNAME=alice TWINE_PASSWORD=secret \
+  twine upload --repository-url https://0.0.0.0:3141/ dist/*.whl
+```
+
+Self-signed certs need `AUNTIE_INSECURE_SKIP_VERIFY=1` (loud stderr
+warning fires on each invocation). Existing-file uploads return 409
+(no overwrite, ever — pick a new version).
 
 > **pip + Basic auth note.** `pip install --index-url
 > https://user:pass@host:port/simple/` works but embeds creds in URL,

--- a/auntiepypi/_actions/auntie.py
+++ b/auntiepypi/_actions/auntie.py
@@ -71,13 +71,22 @@ def _check_readable(path: Path, label: str) -> str | None:
 
 
 def _verify_tls_auth_paths(cfg: LocalConfig) -> ActionResult | None:
-    """Pre-flight readability check on configured cert/key/htpasswd.
+    """Pre-flight readability + publish-authz check.
 
-    Returns None when all configured paths are readable; otherwise
-    an ActionResult(ok=False) with a clear detail. Surfacing the miss
-    as a strategy-level failure (instead of a raise) preserves
-    `--all`'s independent-dispatch semantics — a broken local server
-    config doesn't strand the operator's declared mirrors.
+    Three checks, server-start time only (never reached via detection):
+
+    1. TLS pair readable (when ``cfg.tls_enabled``).
+    2. htpasswd readable (when ``cfg.auth_enabled``).
+    3. Every ``cfg.publish_users`` name has an htpasswd entry. This
+       last check **must** live here, not in
+       :mod:`auntiepypi._detect._config`: detection paths must never
+       read credential files.
+
+    Returns None when all checks pass; otherwise an
+    ``ActionResult(ok=False)`` with a clear detail. Surfacing as a
+    strategy-level failure (instead of a raise) preserves ``--all``'s
+    independent-dispatch semantics — a broken local server config
+    doesn't strand the operator's declared mirrors.
     """
     if cfg.tls_enabled:
         # tls_enabled is True only when both cert and key are set.
@@ -91,6 +100,19 @@ def _verify_tls_auth_paths(cfg: LocalConfig) -> ActionResult | None:
         err = _check_readable(cfg.htpasswd, "htpasswd")
         if err is not None:
             return ActionResult(ok=False, detail=err)
+    # Publish-users membership: htpasswd is read here, in the
+    # server-start path, never in detection. Delayed import avoids the
+    # _detect → _server hop entirely.
+    if cfg.publish_users:
+        from auntiepypi._server._auth import (
+            PublishAuthzError,
+            assert_publish_users_in_htpasswd,
+        )
+
+        try:
+            assert_publish_users_in_htpasswd(cfg.htpasswd, cfg.publish_users)
+        except PublishAuthzError as err:
+            return ActionResult(ok=False, detail=str(err))
     return None
 
 

--- a/auntiepypi/_actions/auntie.py
+++ b/auntiepypi/_actions/auntie.py
@@ -27,7 +27,7 @@ from auntiepypi._actions._action import ActionResult
 from auntiepypi._actions._reprobe import probe
 from auntiepypi._detect._config import ServerSpec, load_local_config
 from auntiepypi._detect._detection import Detection
-from auntiepypi._server._config import LocalConfig
+from auntiepypi._server._config import _DEFAULT_MAX_UPLOAD_BYTES, LocalConfig
 
 
 def _argv(cfg: LocalConfig) -> tuple[str, ...]:
@@ -48,6 +48,10 @@ def _argv(cfg: LocalConfig) -> tuple[str, ...]:
         args += ["--cert", str(cfg.cert), "--key", str(cfg.key)]
     if cfg.auth_enabled:
         args += ["--htpasswd", str(cfg.htpasswd)]
+    for user in cfg.publish_users:
+        args += ["--publish-user", user]
+    if cfg.max_upload_bytes != _DEFAULT_MAX_UPLOAD_BYTES:
+        args += ["--max-upload-bytes", str(cfg.max_upload_bytes)]
     return tuple(args)
 
 

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -371,37 +371,6 @@ def _validate_publish_authz_dependency(
         )
 
 
-def _validate_publish_users_in_htpasswd(
-    htpasswd: Path | None, publish_users: tuple[str, ...]
-) -> None:
-    """Cross-check: every publish_users entry must exist in htpasswd.
-
-    Runs at config-load when both are present; the goal is to catch
-    typos and stale rotations before the server starts. We tolerate a
-    missing/unreadable htpasswd file at config-load time (the strategy
-    will surface a clearer error at start-time) — only run the
-    membership check when the file actually parses.
-    """
-    if not publish_users or htpasswd is None:
-        return
-    # Delayed import: parse_htpasswd lives in _server, _detect mustn't
-    # take a hard dep on it for the lenient detection paths.
-    from auntiepypi._server._auth import HtpasswdError, parse_htpasswd
-
-    try:
-        table = parse_htpasswd(htpasswd)
-    except (OSError, HtpasswdError):
-        # Fall through — the strategy will report it at start-time.
-        return
-    missing = [name for name in publish_users if name not in table]
-    if missing:
-        raise ServerConfigError(
-            f"[tool.auntiepypi.local] publish_users contains name(s) not in "
-            f"{htpasswd}: {missing}. Either remove from publish_users or re-add "
-            "to htpasswd."
-        )
-
-
 def _validate_local_lift_rule(
     host: str,
     cert: Path | None,
@@ -502,10 +471,12 @@ def load_local_config(start: Path | None = None) -> LocalConfig:
         htpasswd=kwargs.get("htpasswd"),
         publish_users=kwargs.get("publish_users", ()),
     )
-    _validate_publish_users_in_htpasswd(
-        htpasswd=kwargs.get("htpasswd"),
-        publish_users=kwargs.get("publish_users", ()),
-    )
+    # Note: the cross-check that publish_users entries actually exist
+    # in the htpasswd file lives in _server (it requires reading the
+    # credential file, which detection paths must never do). The
+    # server-start path calls
+    # ``auntiepypi._server._auth.assert_publish_users_in_htpasswd``
+    # before binding.
     return LocalConfig(**kwargs)
 
 

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -321,6 +321,91 @@ def _validate_local_tls_pair(cert: Path | None, key: Path | None) -> None:
     )
 
 
+def _validate_local_publish_users(value: object) -> tuple[str, ...]:
+    """Type-validate the v0.8.0 ``publish_users`` allowlist.
+
+    Returns a tuple of names. Empty list is allowed (= read-only mode).
+    """
+    if not isinstance(value, list):
+        raise ServerConfigError(
+            "[tool.auntiepypi.local] 'publish_users' must be a list of strings"
+        )
+    out: list[str] = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            raise ServerConfigError(
+                f"[tool.auntiepypi.local] publish_users[{i}] must be a non-empty string"
+            )
+        out.append(item)
+    return tuple(out)
+
+
+def _validate_local_max_upload_bytes(value: object) -> int:
+    """Type-validate the v0.8.0 ``max_upload_bytes`` cap.
+
+    Reject sub-1024 values: that's well below any real wheel and
+    suggests a config bug (e.g. someone wrote ``104857600`` as
+    ``104.857600``).
+    """
+    # bool is a subclass of int — reject it explicitly (would otherwise
+    # let `max_upload_bytes = true` pass as 1).
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ServerConfigError(
+            "[tool.auntiepypi.local] 'max_upload_bytes' must be an integer"
+        )
+    if value < 1024:
+        raise ServerConfigError(
+            f"[tool.auntiepypi.local] 'max_upload_bytes' must be >= 1024 (got {value})"
+        )
+    return value
+
+
+def _validate_publish_authz_dependency(
+    htpasswd: Path | None, publish_users: tuple[str, ...]
+) -> None:
+    """publish_users without htpasswd is a misconfiguration.
+
+    You can't authorize a user the server can't authenticate. The
+    error names both fields so the operator knows where to look.
+    """
+    if publish_users and htpasswd is None:
+        raise ServerConfigError(
+            "[tool.auntiepypi.local] 'publish_users' requires 'htpasswd'; "
+            "publish authorization without authentication is not allowed."
+        )
+
+
+def _validate_publish_users_in_htpasswd(
+    htpasswd: Path | None, publish_users: tuple[str, ...]
+) -> None:
+    """Cross-check: every publish_users entry must exist in htpasswd.
+
+    Runs at config-load when both are present; the goal is to catch
+    typos and stale rotations before the server starts. We tolerate a
+    missing/unreadable htpasswd file at config-load time (the strategy
+    will surface a clearer error at start-time) — only run the
+    membership check when the file actually parses.
+    """
+    if not publish_users or htpasswd is None:
+        return
+    # Delayed import: parse_htpasswd lives in _server, _detect mustn't
+    # take a hard dep on it for the lenient detection paths.
+    from auntiepypi._server._auth import HtpasswdError, parse_htpasswd
+
+    try:
+        table = parse_htpasswd(htpasswd)
+    except (FileNotFoundError, OSError, HtpasswdError):
+        # Fall through — the strategy will report it at start-time.
+        return
+    missing = [name for name in publish_users if name not in table]
+    if missing:
+        raise ServerConfigError(
+            f"[tool.auntiepypi.local] publish_users contains name(s) not in "
+            f"{htpasswd}: {missing}. Either remove from publish_users or re-add "
+            "to htpasswd."
+        )
+
+
 def _validate_local_lift_rule(
     host: str,
     cert: Path | None,
@@ -399,6 +484,12 @@ def load_local_config(start: Path | None = None) -> LocalConfig:
         kwargs["key"] = _validate_local_path_field(local_table["key"], "key")
     if "htpasswd" in local_table:
         kwargs["htpasswd"] = _validate_local_path_field(local_table["htpasswd"], "htpasswd")
+    if "publish_users" in local_table:
+        kwargs["publish_users"] = _validate_local_publish_users(local_table["publish_users"])
+    if "max_upload_bytes" in local_table:
+        kwargs["max_upload_bytes"] = _validate_local_max_upload_bytes(
+            local_table["max_upload_bytes"]
+        )
 
     # Cross-field validation. TLS pairing is host-independent — a
     # loopback config with only `cert` (no `key`) would otherwise be
@@ -410,6 +501,14 @@ def load_local_config(start: Path | None = None) -> LocalConfig:
         cert=kwargs.get("cert"),
         key=kwargs.get("key"),
         htpasswd=kwargs.get("htpasswd"),
+    )
+    _validate_publish_authz_dependency(
+        htpasswd=kwargs.get("htpasswd"),
+        publish_users=kwargs.get("publish_users", ()),
+    )
+    _validate_publish_users_in_htpasswd(
+        htpasswd=kwargs.get("htpasswd"),
+        publish_users=kwargs.get("publish_users", ()),
     )
     return LocalConfig(**kwargs)
 

--- a/auntiepypi/_detect/_config.py
+++ b/auntiepypi/_detect/_config.py
@@ -327,9 +327,7 @@ def _validate_local_publish_users(value: object) -> tuple[str, ...]:
     Returns a tuple of names. Empty list is allowed (= read-only mode).
     """
     if not isinstance(value, list):
-        raise ServerConfigError(
-            "[tool.auntiepypi.local] 'publish_users' must be a list of strings"
-        )
+        raise ServerConfigError("[tool.auntiepypi.local] 'publish_users' must be a list of strings")
     out: list[str] = []
     for i, item in enumerate(value):
         if not isinstance(item, str) or not item:
@@ -350,9 +348,7 @@ def _validate_local_max_upload_bytes(value: object) -> int:
     # bool is a subclass of int — reject it explicitly (would otherwise
     # let `max_upload_bytes = true` pass as 1).
     if not isinstance(value, int) or isinstance(value, bool):
-        raise ServerConfigError(
-            "[tool.auntiepypi.local] 'max_upload_bytes' must be an integer"
-        )
+        raise ServerConfigError("[tool.auntiepypi.local] 'max_upload_bytes' must be an integer")
     if value < 1024:
         raise ServerConfigError(
             f"[tool.auntiepypi.local] 'max_upload_bytes' must be >= 1024 (got {value})"
@@ -394,7 +390,7 @@ def _validate_publish_users_in_htpasswd(
 
     try:
         table = parse_htpasswd(htpasswd)
-    except (FileNotFoundError, OSError, HtpasswdError):
+    except (OSError, HtpasswdError):
         # Fall through — the strategy will report it at start-time.
         return
     missing = [name for name in publish_users if name not in table]

--- a/auntiepypi/_server/__init__.py
+++ b/auntiepypi/_server/__init__.py
@@ -5,8 +5,11 @@ filesystem wheelhouse, loopback-only.
 
 v0.7.0 adds optional HTTPS termination (``ssl_context=...``) and HTTP
 Basic auth (``htpasswd_map=...``). When both are configured at
-config-load time, the loopback restriction lifts. ``auntie publish``
-remains deferred to v0.8.0.
+config-load time, the loopback restriction lifts.
+
+v0.8.0 adds the write side: ``publish_users`` (allowlist of
+htpasswd usernames permitted to POST uploads) and ``max_upload_bytes``
+(per-request body cap). Empty allowlist preserves read-only mode.
 
 Public surface lives in :mod:`auntiepypi._server.__init__` (this
 module). The HTTP layer is :mod:`._app`; filesystem walk lives in
@@ -24,6 +27,7 @@ from pathlib import Path
 from typing import Callable
 
 from auntiepypi._server._app import make_handler
+from auntiepypi._server._config import _DEFAULT_MAX_UPLOAD_BYTES
 
 __all__ = ["serve"]
 
@@ -35,6 +39,8 @@ def serve(
     *,
     ssl_context: ssl.SSLContext | None = None,
     htpasswd_map: dict[str, bytes] | None = None,
+    publish_users: tuple[str, ...] = (),
+    max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES,
     server_factory: Callable[..., ThreadingHTTPServer] = ThreadingHTTPServer,
 ) -> None:
     """Run the simple-index HTTP(S) server until SIGTERM/SIGINT.
@@ -46,10 +52,20 @@ def serve(
     ``htpasswd_map`` (when set) gates every GET through Basic auth
     (see :mod:`._app`).
 
+    ``publish_users`` (when non-empty, requires ``htpasswd_map``) lets
+    those usernames POST uploads at ``/``. Empty allowlist → POST
+    returns 403 ``"publish disabled"``. ``max_upload_bytes`` caps the
+    POST body size (default 100 MiB).
+
     ``server_factory`` is a test indirection — production callers
     accept the default ``ThreadingHTTPServer``.
     """
-    handler_cls = make_handler(root, htpasswd_map=htpasswd_map)
+    handler_cls = make_handler(
+        root,
+        htpasswd_map=htpasswd_map,
+        publish_users=publish_users,
+        max_upload_bytes=max_upload_bytes,
+    )
     httpd = server_factory((host, port), handler_cls)
     if ssl_context is not None:
         # In-flight TLS connections may log noisy ssl.SSLError on

--- a/auntiepypi/_server/__main__.py
+++ b/auntiepypi/_server/__main__.py
@@ -82,8 +82,7 @@ def _parser() -> argparse.ArgumentParser:
         "--max-upload-bytes",
         type=int,
         default=_DEFAULT_MAX_UPLOAD_BYTES,
-        help=f"reject uploads larger than this (bytes; default "
-        f"{_DEFAULT_MAX_UPLOAD_BYTES})",
+        help=f"reject uploads larger than this (bytes; default " f"{_DEFAULT_MAX_UPLOAD_BYTES})",
     )
     return p
 

--- a/auntiepypi/_server/__main__.py
+++ b/auntiepypi/_server/__main__.py
@@ -86,7 +86,7 @@ def _parser() -> argparse.ArgumentParser:
         "--max-upload-bytes",
         type=int,
         default=_DEFAULT_MAX_UPLOAD_BYTES,
-        help=f"reject uploads larger than this (bytes; default " f"{_DEFAULT_MAX_UPLOAD_BYTES})",
+        help=f"reject uploads larger than this (bytes; default {_DEFAULT_MAX_UPLOAD_BYTES})",
     )
     return p
 

--- a/auntiepypi/_server/__main__.py
+++ b/auntiepypi/_server/__main__.py
@@ -30,7 +30,11 @@ from pathlib import Path
 from typing import Sequence
 
 from auntiepypi._server import serve
-from auntiepypi._server._auth import parse_htpasswd
+from auntiepypi._server._auth import (
+    PublishAuthzError,
+    assert_publish_users_in_htpasswd,
+    parse_htpasswd,
+)
 from auntiepypi._server._config import _DEFAULT_MAX_UPLOAD_BYTES
 from auntiepypi._server._tls import build_ssl_context
 
@@ -107,13 +111,22 @@ def main(argv: Sequence[str] | None = None) -> None:
     if args.htpasswd is not None:
         htpasswd_map = parse_htpasswd(args.htpasswd)
 
+    publish_users = tuple(args.publish_user)
+    # Cross-check publish_users against htpasswd here, at the
+    # server-start boundary. Detection paths never run this.
+    try:
+        assert_publish_users_in_htpasswd(args.htpasswd, publish_users)
+    except PublishAuthzError as err:
+        print(str(err), file=sys.stderr)
+        raise SystemExit(2) from err
+
     serve(
         args.host,
         args.port,
         args.root,
         ssl_context=ssl_context,
         htpasswd_map=htpasswd_map,
-        publish_users=tuple(args.publish_user),
+        publish_users=publish_users,
         max_upload_bytes=args.max_upload_bytes,
     )
 

--- a/auntiepypi/_server/__main__.py
+++ b/auntiepypi/_server/__main__.py
@@ -13,6 +13,13 @@ not enforced here — the ``[tool.auntiepypi.local]`` validator in
 :mod:`auntiepypi._detect._config` is the source of truth on legality.
 This module only enforces ``--cert``+``--key`` pairing as a usability
 guard against accidentally invoking with a half-configured TLS pair.
+
+v0.8.0 adds ``--publish-user NAME`` (repeatable) and
+``--max-upload-bytes N``: the publish allowlist and per-request body
+cap. Defaults preserve v0.7.0 read-only behavior — no ``--publish-user``
+means no one can POST. The cross-checks (publish_users requires
+htpasswd, names must exist in htpasswd) live in the config-load
+validator; this module just passes the values through.
 """
 
 from __future__ import annotations
@@ -24,6 +31,7 @@ from typing import Sequence
 
 from auntiepypi._server import serve
 from auntiepypi._server._auth import parse_htpasswd
+from auntiepypi._server._config import _DEFAULT_MAX_UPLOAD_BYTES
 from auntiepypi._server._tls import build_ssl_context
 
 
@@ -62,6 +70,21 @@ def _parser() -> argparse.ArgumentParser:
         default=None,
         help="Apache htpasswd file (bcrypt-only) for HTTP Basic auth",
     )
+    p.add_argument(
+        "--publish-user",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="username allowed to POST uploads (repeatable; "
+        "requires --htpasswd; empty list = no one publishes)",
+    )
+    p.add_argument(
+        "--max-upload-bytes",
+        type=int,
+        default=_DEFAULT_MAX_UPLOAD_BYTES,
+        help=f"reject uploads larger than this (bytes; default "
+        f"{_DEFAULT_MAX_UPLOAD_BYTES})",
+    )
     return p
 
 
@@ -91,6 +114,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         args.root,
         ssl_context=ssl_context,
         htpasswd_map=htpasswd_map,
+        publish_users=tuple(args.publish_user),
+        max_upload_bytes=args.max_upload_bytes,
     )
 
 

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -50,6 +50,8 @@ from auntiepypi._server._wheelhouse import list_projects, normalize, parse_filen
 _SIMPLE_PREFIX = "/simple/"
 _FILES_PREFIX = "/files/"
 
+_TEXT_PLAIN_UTF8 = "text/plain; charset=utf-8"
+
 # Strict filename pattern: PEP 427/625 dist files + no path components.
 # Permits the same charset filenames carry on PyPI.
 _SAFE_FILENAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*\.(whl|tar\.gz|zip)$")
@@ -64,7 +66,7 @@ class _UploadReadError(Exception):
         self.detail = detail
 
 
-def make_handler(
+def make_handler(  # NOSONAR python:S3776 - factory closure; see note below
     root: Path,
     *,
     htpasswd_map: dict[str, bytes] | None = None,
@@ -84,6 +86,16 @@ def make_handler(
     one can publish (read-only mode preserved with 403 "publish
     disabled"). ``max_upload_bytes`` is enforced both pre-read
     (Content-Length) and during-read (counted reader).
+
+    .. note::
+       Cognitive complexity is high (Sonar S3776) because this is a
+       closure factory: ``_Handler`` and all its helpers close over
+       ``root`` / ``htpasswd_map`` / ``publish_users`` /
+       ``max_upload_bytes``. Hoisting the methods out as module-level
+       functions would require explicit-passing of all four to every
+       call site — net cognitive cost goes up, not down. The v0.9.0
+       streaming-multipart refactor will revisit this; for v0.8.0 the
+       trade-off is deliberate.
     """
     resolved_root = root.resolve()
 
@@ -196,7 +208,7 @@ def make_handler(
         def _send_status(self, status: int) -> None:
             body = f"{status}\n".encode()
             self.send_response(status)
-            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Type", _TEXT_PLAIN_UTF8)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -226,7 +238,7 @@ def make_handler(
                 'Basic realm="auntiepypi", charset="UTF-8"',
             )
             self.send_header("Connection", "close")
-            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Type", _TEXT_PLAIN_UTF8)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -248,7 +260,7 @@ def make_handler(
             else:
                 assert text is not None  # noqa: S101 - mypy hint
                 body = f"{text}\n".encode("utf-8")
-                ctype = "text/plain; charset=utf-8"
+                ctype = _TEXT_PLAIN_UTF8
             self.send_response(status)
             self.send_header("Content-Type", ctype)
             self.send_header("Content-Length", str(len(body)))

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -55,6 +55,15 @@ _FILES_PREFIX = "/files/"
 _SAFE_FILENAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*\.(whl|tar\.gz|zip)$")
 
 
+class _UploadReadError(Exception):
+    """Body-read failure during POST. Carries an HTTP status hint."""
+
+    def __init__(self, status: int, detail: str, *args: object) -> None:
+        super().__init__(detail, status, *args)
+        self.status = status
+        self.detail = detail
+
+
 def make_handler(
     root: Path,
     *,
@@ -222,19 +231,28 @@ def make_handler(
             self.end_headers()
             self.wfile.write(body)
 
-        def _send_text(self, status: int, text: str) -> None:
-            body = f"{text}\n".encode("utf-8")
-            self.send_response(status)
-            self.send_header("Content-Type", "text/plain; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+        def _send_post_response(
+            self, status: int, *, text: str | None = None, payload: dict | None = None
+        ) -> None:
+            """Single-shot POST response emitter.
 
-        def _send_json(self, status: int, payload: dict) -> None:
-            body = _json.dumps(payload).encode("utf-8")
+            Always sends ``Connection: close``: the upload body might
+            be partially-read or oversized, and HTTP/1.1 keep-alive
+            with leftover bytes leads to request desync. Closing the
+            socket is cheap (uploads are infrequent) and safer.
+            """
+            assert (text is None) != (payload is None)  # noqa: S101 - one-of contract
+            if payload is not None:
+                body = _json.dumps(payload).encode("utf-8")
+                ctype = "application/json"
+            else:
+                assert text is not None  # noqa: S101 - mypy hint
+                body = f"{text}\n".encode("utf-8")
+                ctype = "text/plain; charset=utf-8"
             self.send_response(status)
-            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Type", ctype)
             self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.write(body)
 
@@ -247,73 +265,133 @@ def make_handler(
             405. Caller must authenticate AND be in publish_users —
             otherwise 401 / 403. Path must be exactly ``/`` — anything
             else is 404 (we don't leak alternate routes via 405).
+
+            Every response sends ``Connection: close`` (see
+            :meth:`_send_post_response`); upload bodies don't benefit
+            from keep-alive, and leftover unread bytes on a kept-alive
+            socket lead to request desync.
             """
             if htpasswd_map is None:
-                return self._send_text(405, "405 Method Not Allowed")
+                return self._send_post_response(405, text="405 Method Not Allowed")
             user = authenticate_user(self.headers.get("Authorization", ""), htpasswd_map)
             if user is None:
+                # _send_401 already includes Connection: close.
                 return self._send_401()
             if not publish_users:
-                return self._send_text(403, "publish disabled")
+                return self._send_post_response(403, text="publish disabled")
             if user not in publish_users:
-                return self._send_text(403, f"user {user!r} cannot publish")
+                return self._send_post_response(403, text=f"user {user!r} cannot publish")
             if self.path != "/":
-                return self._send_text(404, "404 Not Found")
+                return self._send_post_response(404, text="404 Not Found")
             return self._handle_upload()
 
         def _handle_upload(self) -> None:
             ctype = self.headers.get("Content-Type", "")
             if not ctype.lower().startswith("multipart/form-data"):
-                return self._send_text(400, "expected Content-Type: multipart/form-data")
-            length = self._content_length_or_zero()
+                return self._send_post_response(
+                    400, text="expected Content-Type: multipart/form-data"
+                )
+            length = self._content_length_strict()
+            if length is None:
+                # No / invalid Content-Length: refuse rather than
+                # read-until-EOF (which would block keep-alive).
+                return self._send_post_response(411, text="Content-Length required for upload")
             if length > max_upload_bytes:
-                return self._send_text(413, f"upload too large (max {max_upload_bytes} bytes)")
-            # Counted read defends against missing/lying Content-Length:
-            # we never read more than the cap regardless of what the
-            # client claims.
+                return self._send_post_response(
+                    413, text=f"upload too large (max {max_upload_bytes} bytes)"
+                )
             try:
-                body = self.rfile.read(min(length, max_upload_bytes)) if length else b""
-            except OSError as err:
-                return self._send_text(400, f"read error: {err}")
-            if length and len(body) != length:
-                return self._send_text(400, "incomplete body (Content-Length mismatch)")
+                body = self._read_body(length)
+            except _UploadReadError as err:
+                return self._send_post_response(err.status, text=err.detail)
             try:
                 fields = parse_multipart_upload(ctype, body, max_upload_bytes)
             except MultipartError as err:
-                return self._send_text(400, str(err))
+                return self._send_post_response(400, text=str(err))
             if fields.action != "file_upload":
-                return self._send_text(400, f"expected :action=file_upload, got {fields.action!r}")
+                return self._send_post_response(
+                    400, text=f"expected :action=file_upload, got {fields.action!r}"
+                )
             if not _SAFE_FILENAME.match(fields.filename):
-                return self._send_text(400, f"invalid filename: {fields.filename!r}")
+                return self._send_post_response(400, text=f"invalid filename: {fields.filename!r}")
             parsed = parse_filename(fields.filename)
             if parsed is None:
-                return self._send_text(
-                    400, f"unrecognized distribution filename: {fields.filename!r}"
+                return self._send_post_response(
+                    400, text=f"unrecognized distribution filename: {fields.filename!r}"
                 )
             project, _version = parsed
             if normalize(fields.name) != normalize(project):
-                return self._send_text(
+                return self._send_post_response(
                     400,
-                    f"name field {fields.name!r} does not match filename " f"project {project!r}",
+                    text=(
+                        f"name field {fields.name!r} does not match filename "
+                        f"project {project!r}"
+                    ),
                 )
             result = write_upload(resolved_root, fields.filename, fields.content)
             if result.status == 201:
-                return self._send_json(
+                return self._send_post_response(
                     201,
-                    {
+                    payload={
                         "ok": True,
                         "filename": fields.filename,
                         "url": f"/files/{fields.filename}",
                         "written": result.written,
                     },
                 )
-            return self._send_text(result.status, result.detail or str(result.status))
+            return self._send_post_response(result.status, text=result.detail or str(result.status))
 
-        def _content_length_or_zero(self) -> int:
+        def _content_length_strict(self) -> int | None:
+            """Parse ``Content-Length``; ``None`` if missing/invalid.
+
+            v0.8.0 requires Content-Length on POST (411 Length Required
+            when absent). The alternative — read-until-EOF — would
+            block on a keep-alive client that doesn't half-close.
+            """
             raw = self.headers.get("Content-Length", "")
+            if not raw:
+                return None
             try:
-                return max(int(raw), 0)
+                value = int(raw)
             except ValueError:
-                return 0
+                return None
+            if value < 0:
+                return None
+            return value
+
+        def _read_body(self, length: int) -> bytes:
+            """Counted read with a hard cap.
+
+            Loops on ``rfile.read`` rather than calling once: the
+            stdlib ``BufferedReader`` *should* return everything
+            requested, but the contract permits short reads on a
+            partial flush from the client. Counting bytes locally
+            defends against a lying ``Content-Length``: we never read
+            past the cap and never trust the header alone.
+
+            Raises :class:`_UploadReadError` on incomplete or
+            oversized reads — caller maps to a 400 / 413.
+            """
+            cap = min(length, max_upload_bytes)
+            chunks: list[bytes] = []
+            remaining = cap
+            while remaining > 0:
+                try:
+                    # 64 KiB chunk — small enough to bound memory growth
+                    # on a slow client, large enough that wheel-sized
+                    # uploads finish in a handful of iterations.
+                    chunk = self.rfile.read(min(65536, remaining))
+                except OSError as err:
+                    raise _UploadReadError(400, f"read error: {err}") from err
+                if not chunk:
+                    # Client closed before delivering Content-Length
+                    # bytes — legitimate truncation; reject as 400.
+                    raise _UploadReadError(
+                        400,
+                        f"incomplete body (got {cap - remaining} of {length} bytes)",
+                    )
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            return b"".join(chunks)
 
     return _Handler

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -1,6 +1,6 @@
-"""HTTP handler factory for the read-only PEP 503 simple-index.
+"""HTTP handler factory for the PEP 503 simple-index.
 
-Three routes (since v0.6.0):
+Read routes (since v0.6.0):
 
 - ``GET /simple/`` — HTML anchor list of projects in the wheelhouse.
 - ``GET /simple/<pkg>/`` (or without trailing slash) — HTML anchor list
@@ -11,18 +11,20 @@ Three routes (since v0.6.0):
   in the wheelhouse, contains separators, or otherwise tries to escape
   the root.
 
-Any other path or non-GET method → 404 / 405.
+Write route (v0.8.0):
+
+- ``POST /`` — twine-shape ``multipart/form-data`` upload. Requires
+  authentication (htpasswd_map non-None) AND the authenticated user in
+  ``publish_users``. 401 / 403 / 400 / 409 / 413 / 201 by failure mode.
+
+Any other path or method → 404.
 
 v0.7.0 adds an optional auth gate: when ``make_handler(root,
-htpasswd_map=...)`` is called with a non-None map, every ``GET``
-request must present a valid ``Authorization: Basic`` header
-(verified against :mod:`._auth`). Missing or invalid → 401 with
-``WWW-Authenticate``. Non-GET methods fall through to
-``BaseHTTPRequestHandler``'s default (typically 501 Not Implemented)
-because the read-only server has no other verbs to gate; the auth
-check lives on the GET dispatch and is not reached on other methods.
-When the map is None, the handler is unauthenticated (v0.6.0
-behavior preserved).
+htpasswd_map=...)`` is called with a non-None map, every GET request
+must present a valid ``Authorization: Basic`` header (verified against
+:mod:`._auth`). v0.8.0 extends this: POST always requires auth (405
+when ``htpasswd_map`` is None), and the authenticated user must
+additionally be in ``publish_users``.
 
 The handler is a *factory* (``make_handler(root)``) returning a
 ``BaseHTTPRequestHandler`` subclass that closes over ``root``. This
@@ -32,14 +34,18 @@ lets the same module serve multiple wheelhouses in tests.
 from __future__ import annotations
 
 import html
+import json as _json
 import re
 import shutil
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
-from auntiepypi._server._auth import verify_basic
-from auntiepypi._server._wheelhouse import list_projects, normalize
+from auntiepypi._server._auth import authenticate_user, verify_basic
+from auntiepypi._server._config import _DEFAULT_MAX_UPLOAD_BYTES
+from auntiepypi._server._multipart import MultipartError, parse_multipart_upload
+from auntiepypi._server._publish import write_upload
+from auntiepypi._server._wheelhouse import list_projects, normalize, parse_filename
 
 _SIMPLE_PREFIX = "/simple/"
 _FILES_PREFIX = "/files/"
@@ -53,12 +59,22 @@ def make_handler(
     root: Path,
     *,
     htpasswd_map: dict[str, bytes] | None = None,
+    publish_users: tuple[str, ...] = (),
+    max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES,
 ) -> type[BaseHTTPRequestHandler]:
     """Return a request-handler class bound to ``root``.
 
-    When ``htpasswd_map`` is non-None, every request is gated through
-    HTTP Basic auth against the map; missing/invalid creds → 401.
-    When None, the handler is unauthenticated (v0.6.0 behavior).
+    When ``htpasswd_map`` is non-None, every GET request is gated
+    through HTTP Basic auth against the map; missing/invalid creds →
+    401. When None, the GET handler is unauthenticated (v0.6.0
+    behavior).
+
+    POST always requires auth: with ``htpasswd_map=None`` the handler
+    returns 405. The authenticated user must additionally be in
+    ``publish_users`` (403 otherwise). Empty ``publish_users`` ⇒ no
+    one can publish (read-only mode preserved with 403 "publish
+    disabled"). ``max_upload_bytes`` is enforced both pre-read
+    (Content-Length) and during-read (counted reader).
     """
     resolved_root = root.resolve()
 
@@ -205,5 +221,110 @@ def make_handler(
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+
+        def _send_text(self, status: int, text: str) -> None:
+            body = f"{text}\n".encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_json(self, status: int, payload: dict) -> None:
+            body = _json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        # --- publish (v0.8.0) ----------------------------------------------
+
+        def do_POST(self) -> None:  # noqa: N802 — stdlib name
+            """Twine-shape upload at ``POST /``.
+
+            Auth must be configured (htpasswd_map non-None) — otherwise
+            405. Caller must authenticate AND be in publish_users —
+            otherwise 401 / 403. Path must be exactly ``/`` — anything
+            else is 404 (we don't leak alternate routes via 405).
+            """
+            if htpasswd_map is None:
+                return self._send_text(405, "405 Method Not Allowed")
+            user = authenticate_user(
+                self.headers.get("Authorization", ""), htpasswd_map
+            )
+            if user is None:
+                return self._send_401()
+            if not publish_users:
+                return self._send_text(403, "publish disabled")
+            if user not in publish_users:
+                return self._send_text(403, f"user {user!r} cannot publish")
+            if self.path != "/":
+                return self._send_text(404, "404 Not Found")
+            return self._handle_upload()
+
+        def _handle_upload(self) -> None:
+            ctype = self.headers.get("Content-Type", "")
+            if not ctype.lower().startswith("multipart/form-data"):
+                return self._send_text(
+                    400, "expected Content-Type: multipart/form-data"
+                )
+            length = self._content_length_or_zero()
+            if length > max_upload_bytes:
+                return self._send_text(
+                    413, f"upload too large (max {max_upload_bytes} bytes)"
+                )
+            # Counted read defends against missing/lying Content-Length:
+            # we never read more than the cap regardless of what the
+            # client claims.
+            try:
+                body = self.rfile.read(min(length, max_upload_bytes)) if length else b""
+            except OSError as err:
+                return self._send_text(400, f"read error: {err}")
+            if length and len(body) != length:
+                return self._send_text(
+                    400, "incomplete body (Content-Length mismatch)"
+                )
+            try:
+                fields = parse_multipart_upload(ctype, body, max_upload_bytes)
+            except MultipartError as err:
+                return self._send_text(400, str(err))
+            if fields.action != "file_upload":
+                return self._send_text(
+                    400, f"expected :action=file_upload, got {fields.action!r}"
+                )
+            if not _SAFE_FILENAME.match(fields.filename):
+                return self._send_text(400, f"invalid filename: {fields.filename!r}")
+            parsed = parse_filename(fields.filename)
+            if parsed is None:
+                return self._send_text(
+                    400, f"unrecognized distribution filename: {fields.filename!r}"
+                )
+            project, _version = parsed
+            if normalize(fields.name) != normalize(project):
+                return self._send_text(
+                    400,
+                    f"name field {fields.name!r} does not match filename "
+                    f"project {project!r}",
+                )
+            result = write_upload(resolved_root, fields.filename, fields.content)
+            if result.status == 201:
+                return self._send_json(
+                    201,
+                    {
+                        "ok": True,
+                        "filename": fields.filename,
+                        "url": f"/files/{fields.filename}",
+                        "written": result.written,
+                    },
+                )
+            return self._send_text(result.status, result.detail or str(result.status))
+
+        def _content_length_or_zero(self) -> int:
+            raw = self.headers.get("Content-Length", "")
+            try:
+                return max(int(raw), 0)
+            except ValueError:
+                return 0
 
     return _Handler

--- a/auntiepypi/_server/_app.py
+++ b/auntiepypi/_server/_app.py
@@ -250,9 +250,7 @@ def make_handler(
             """
             if htpasswd_map is None:
                 return self._send_text(405, "405 Method Not Allowed")
-            user = authenticate_user(
-                self.headers.get("Authorization", ""), htpasswd_map
-            )
+            user = authenticate_user(self.headers.get("Authorization", ""), htpasswd_map)
             if user is None:
                 return self._send_401()
             if not publish_users:
@@ -266,14 +264,10 @@ def make_handler(
         def _handle_upload(self) -> None:
             ctype = self.headers.get("Content-Type", "")
             if not ctype.lower().startswith("multipart/form-data"):
-                return self._send_text(
-                    400, "expected Content-Type: multipart/form-data"
-                )
+                return self._send_text(400, "expected Content-Type: multipart/form-data")
             length = self._content_length_or_zero()
             if length > max_upload_bytes:
-                return self._send_text(
-                    413, f"upload too large (max {max_upload_bytes} bytes)"
-                )
+                return self._send_text(413, f"upload too large (max {max_upload_bytes} bytes)")
             # Counted read defends against missing/lying Content-Length:
             # we never read more than the cap regardless of what the
             # client claims.
@@ -282,17 +276,13 @@ def make_handler(
             except OSError as err:
                 return self._send_text(400, f"read error: {err}")
             if length and len(body) != length:
-                return self._send_text(
-                    400, "incomplete body (Content-Length mismatch)"
-                )
+                return self._send_text(400, "incomplete body (Content-Length mismatch)")
             try:
                 fields = parse_multipart_upload(ctype, body, max_upload_bytes)
             except MultipartError as err:
                 return self._send_text(400, str(err))
             if fields.action != "file_upload":
-                return self._send_text(
-                    400, f"expected :action=file_upload, got {fields.action!r}"
-                )
+                return self._send_text(400, f"expected :action=file_upload, got {fields.action!r}")
             if not _SAFE_FILENAME.match(fields.filename):
                 return self._send_text(400, f"invalid filename: {fields.filename!r}")
             parsed = parse_filename(fields.filename)
@@ -304,8 +294,7 @@ def make_handler(
             if normalize(fields.name) != normalize(project):
                 return self._send_text(
                     400,
-                    f"name field {fields.name!r} does not match filename "
-                    f"project {project!r}",
+                    f"name field {fields.name!r} does not match filename " f"project {project!r}",
                 )
             result = write_upload(resolved_root, fields.filename, fields.content)
             if result.status == 201:

--- a/auntiepypi/_server/_auth.py
+++ b/auntiepypi/_server/_auth.py
@@ -13,12 +13,16 @@ Three pieces:
    ``pip install`` (which opens many connections) snappy without
    weakening the per-credential check.
 
-3. :func:`verify_basic` — parse ``Authorization: Basic <b64>``,
+3. :func:`authenticate_user` — parse ``Authorization: Basic <b64>``,
    bcrypt-verify against the htpasswd map, and write to the cache on
-   success. Returns ``False`` for any failure mode (missing header,
-   wrong scheme, malformed base64, unknown user, password mismatch).
-   Never raises on malformed input — auth bypass via 500 is its own
-   bug class.
+   success. Returns the authenticated **username** on success, or
+   ``None`` for any failure mode (missing header, wrong scheme,
+   malformed base64, unknown user, password mismatch). Never raises
+   on malformed input — auth bypass via 500 is its own bug class.
+
+4. :func:`verify_basic` — bool adapter over :func:`authenticate_user`
+   for read-side callers that only care whether the request is
+   authenticated, not who it is. Kept for v0.7.0 call-site stability.
 
 The cache is a module-level singleton because the handler factory
 re-binds htpasswd_map per server instance but verify_basic is called
@@ -42,6 +46,7 @@ import bcrypt
 
 __all__ = [
     "HtpasswdError",
+    "authenticate_user",
     "parse_htpasswd",
     "verify_basic",
 ]
@@ -132,23 +137,28 @@ class _AuthCache:
 _cache = _AuthCache()
 
 
-def verify_basic(raw_header: str, htpasswd_map: dict[str, bytes]) -> bool:
+def authenticate_user(raw_header: str, htpasswd_map: dict[str, bytes]) -> str | None:
     """Verify ``Authorization: Basic <b64>`` against ``htpasswd_map``.
 
-    Returns ``True`` only when the header is well-formed Basic auth
-    and the credentials bcrypt-match an entry in the map. Returns
-    ``False`` for every other case — never raises.
+    Returns the authenticated **username** when the header is
+    well-formed Basic auth and the credentials bcrypt-match an entry
+    in the map. Returns ``None`` for every other case — never raises.
+
+    This is the v0.8.0 primitive: publish authz needs to know *which*
+    user uploaded, so the bool-only :func:`verify_basic` from v0.7.0
+    delegates here and adapts to bool for read-side callers that don't
+    care about identity.
     """
     if not raw_header or not raw_header.startswith(_BASIC_PREFIX):
-        return False
+        return None
     cache_hit = _cache.get(raw_header)
     if cache_hit is not None:
         cached_user, cached_hash = cache_hit
-        # Honor the cached True only if the map still has the same
+        # Honor the cached hit only if the map still has the same
         # (user → expected_hash) binding. Rotation / user removal /
         # fresh map all invalidate naturally.
         if htpasswd_map.get(cached_user) == cached_hash:
-            return True
+            return cached_user
         # Fall through to re-verify under the current map.
     payload = raw_header[len(_BASIC_PREFIX) :].strip()
     try:
@@ -156,21 +166,31 @@ def verify_basic(raw_header: str, htpasswd_map: dict[str, bytes]) -> bool:
     except binascii.Error:
         # binascii.Error is a subclass of ValueError; catching the more
         # specific exception is sufficient and clearer.
-        return False
+        return None
     sep = decoded.find(b":")
     if sep < 0:
-        return False
+        return None
     user = decoded[:sep].decode("utf-8", errors="replace")
     password = decoded[sep + 1 :]
     expected = htpasswd_map.get(user)
     if expected is None:
-        return False
+        return None
     try:
         ok = bcrypt.checkpw(password, expected)
     except ValueError:
         # bcrypt raises on malformed hash, but parse_htpasswd already
         # screened the prefixes; this is defence-in-depth.
-        return False
-    if ok:
-        _cache.put(raw_header, user, expected)
-    return ok
+        return None
+    if not ok:
+        return None
+    _cache.put(raw_header, user, expected)
+    return user
+
+
+def verify_basic(raw_header: str, htpasswd_map: dict[str, bytes]) -> bool:
+    """Bool adapter over :func:`authenticate_user`.
+
+    Read-side callers (``do_GET``) don't need the username; this
+    keeps the v0.7.0 call sites unchanged.
+    """
+    return authenticate_user(raw_header, htpasswd_map) is not None

--- a/auntiepypi/_server/_auth.py
+++ b/auntiepypi/_server/_auth.py
@@ -46,10 +46,48 @@ import bcrypt
 
 __all__ = [
     "HtpasswdError",
+    "PublishAuthzError",
+    "assert_publish_users_in_htpasswd",
     "authenticate_user",
     "parse_htpasswd",
     "verify_basic",
 ]
+
+
+class PublishAuthzError(Exception):
+    """``publish_users`` references a name not in the htpasswd file."""
+
+
+def assert_publish_users_in_htpasswd(htpasswd: Path | None, publish_users: tuple[str, ...]) -> None:
+    """Verify every ``publish_users`` name has a real htpasswd entry.
+
+    Called at **server-start** time (not detection time) — typos and
+    stale rotations surface before the listener binds. No-ops when
+    either field is empty / unset.
+
+    The credential file IS read here, deliberately: this is server
+    code, not a probe. Detection paths
+    (:mod:`auntiepypi._detect._local`, ``_declared``, ``_port``,
+    ``_proc``) MUST NOT call this — that would re-introduce the
+    "probe parses htpasswd" anti-pattern that v0.7.0 / v0.8.0 are
+    careful to avoid.
+    """
+    if not publish_users or htpasswd is None:
+        return
+    try:
+        table = parse_htpasswd(htpasswd)
+    except (OSError, HtpasswdError):
+        # Caller's readability check (e.g. _verify_tls_auth_paths)
+        # will surface a clearer error; don't double-report.
+        return
+    missing = [name for name in publish_users if name not in table]
+    if missing:
+        raise PublishAuthzError(
+            f"[tool.auntiepypi.local] publish_users contains name(s) not in "
+            f"{htpasswd}: {missing}. Either remove from publish_users or re-add "
+            "to htpasswd."
+        )
+
 
 _BCRYPT_PREFIXES = (b"$2y$", b"$2b$", b"$2a$")
 _BASIC_PREFIX = "Basic "

--- a/auntiepypi/_server/_config.py
+++ b/auntiepypi/_server/_config.py
@@ -1,7 +1,8 @@
 """Configuration for the first-party PEP 503 simple-index server.
 
-``LocalConfig`` is a frozen dataclass with three core fields and three
-optional v0.7.0 fields, all defaulted:
+``LocalConfig`` is a frozen dataclass with three core fields plus
+optional v0.7.0 (TLS + auth) and v0.8.0 (publish authz) fields, all
+defaulted:
 
 - ``host``: bind address. Loopback is always allowed; non-loopback
   binds require both TLS (``cert`` + ``key``) AND auth (``htpasswd``).
@@ -17,6 +18,12 @@ optional v0.7.0 fields, all defaulted:
   Operator-supplied; auntie does not auto-generate.
 - ``htpasswd`` (v0.7.0): Apache htpasswd file (bcrypt-only entries) for
   HTTP Basic auth.
+- ``publish_users`` (v0.8.0): allowlist of htpasswd usernames permitted
+  to POST uploads. Empty / unset → no one can publish (read-only mode
+  preserved). Set with names → only those users can POST. Requires
+  ``htpasswd`` (you can't authorize anonymous users).
+- ``max_upload_bytes`` (v0.8.0): per-request upload size cap.
+  Default 100 MiB. Operators with multi-GiB ML wheels override.
 
 The loader (``auntiepypi._detect._config.load_local_config``) reads
 ``[tool.auntiepypi.local]`` from ``pyproject.toml`` if present and
@@ -32,6 +39,7 @@ from pathlib import Path
 
 _DEFAULT_PORT = 3141
 _DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MiB
 
 
 def default_root() -> Path:
@@ -50,6 +58,8 @@ class LocalConfig:
     cert: Path | None = None
     key: Path | None = None
     htpasswd: Path | None = None
+    publish_users: tuple[str, ...] = ()
+    max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES
 
     @property
     def tls_enabled(self) -> bool:
@@ -64,3 +74,13 @@ class LocalConfig:
     def auth_enabled(self) -> bool:
         """True iff ``htpasswd`` is set."""
         return self.htpasswd is not None
+
+    @property
+    def publish_enabled(self) -> bool:
+        """True iff ``publish_users`` is non-empty AND auth is on.
+
+        Empty allowlist means read-only mode (no one publishes, even
+        with valid credentials). The config-load validator rejects a
+        non-empty allowlist without auth before this property runs.
+        """
+        return bool(self.publish_users) and self.auth_enabled

--- a/auntiepypi/_server/_multipart.py
+++ b/auntiepypi/_server/_multipart.py
@@ -1,0 +1,135 @@
+"""Twine-style ``multipart/form-data`` parser for the v0.8.0 upload endpoint.
+
+The legacy PyPI upload API sends a multipart body with one part per
+field. We only consume three:
+
+- ``:action`` (must be ``file_upload``)
+- ``name`` (canonical project name; cross-checked against the filename)
+- ``content`` (the distribution bytes; ``filename=…`` parameter required)
+
+PyPI sends another ~17 fields (``version``, ``pyversion``, ``summary``,
+``metadata_version``, ``sha256_digest``, ``gpg_signature``, …) — we
+silently ignore them. The wheel/sdist itself is the source of truth
+for metadata; we just need to write the right bytes to the right
+filename.
+
+Implementation: stdlib ``email.parser.BytesParser`` with
+``policy.compat32``. ``cgi`` would have been a closer fit, but it
+was removed in Python 3.13. Third-party ``multipart`` / ``werkzeug``
+would break the "stdlib + bcrypt only" runtime-dep invariant.
+
+v0.8.0 buffers the whole upload in memory before parsing. With
+``max_upload_bytes`` capped (100 MiB default) and a single-host LAN
+footprint, this is acceptable. Streaming parser → v0.9.0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from email import policy
+from email.parser import BytesParser
+
+__all__ = [
+    "MultipartError",
+    "UploadFields",
+    "parse_multipart_upload",
+]
+
+
+class MultipartError(Exception):
+    """Malformed multipart upload body."""
+
+
+@dataclass(frozen=True)
+class UploadFields:
+    """The three fields the upload endpoint cares about."""
+
+    action: str
+    name: str
+    filename: str
+    content: bytes
+
+
+def parse_multipart_upload(
+    content_type: str, raw_body: bytes, max_bytes: int
+) -> UploadFields:
+    """Parse a twine-style upload body.
+
+    :param content_type: the request's ``Content-Type`` header value
+        (must start with ``multipart/form-data``; boundary= required).
+    :param raw_body: the full request body as bytes.
+    :param max_bytes: per-request body cap. Already enforced by the
+        counted reader before this function runs; checked again here
+        so the parser is safe to call directly from tests.
+
+    :raises MultipartError: on malformed Content-Type, missing
+        boundary, missing required parts, missing content filename, or
+        body exceeding ``max_bytes``.
+    """
+    if not content_type or not content_type.lower().startswith("multipart/form-data"):
+        raise MultipartError(
+            f"expected multipart/form-data Content-Type, got {content_type!r}"
+        )
+    if "boundary=" not in content_type.lower():
+        raise MultipartError("multipart Content-Type missing boundary parameter")
+    if len(raw_body) > max_bytes:
+        raise MultipartError(
+            f"body too large ({len(raw_body)} > max_upload_bytes {max_bytes})"
+        )
+
+    # email.parser needs a header block on top of the body — synthesize one.
+    synthetic = f"Content-Type: {content_type}\r\n\r\n".encode("utf-8") + raw_body
+    try:
+        msg = BytesParser(policy=policy.compat32).parsebytes(synthetic)
+    except (ValueError, TypeError) as err:
+        raise MultipartError(f"failed to parse multipart body: {err}") from err
+
+    if not msg.is_multipart():
+        raise MultipartError("body is not multipart (no parts found)")
+
+    fields: dict[str, bytes] = {}
+    filename: str | None = None
+    for part in msg.walk():
+        if part is msg or part.is_multipart():
+            continue
+        name = part.get_param("name", header="content-disposition")
+        if not name:
+            continue
+        payload = part.get_payload(decode=True) or b""
+        fields[name] = payload
+        if name == "content":
+            # Filename is a Content-Disposition parameter on the
+            # content part. Twine sends it; we reject the upload
+            # without it because there's no other way to determine
+            # the on-disk wheel name.
+            filename = part.get_param("filename", header="content-disposition")
+
+    return _build_fields(fields, filename)
+
+
+def _build_fields(fields: dict[str, bytes], filename: str | None) -> UploadFields:
+    """Assemble :class:`UploadFields`, raising on missing requirements."""
+    action_b = fields.get(":action")
+    if action_b is None:
+        raise MultipartError("missing required part: ':action'")
+    name_b = fields.get("name")
+    if name_b is None:
+        raise MultipartError("missing required part: 'name'")
+    content_b = fields.get("content")
+    if content_b is None:
+        raise MultipartError("missing required part: 'content'")
+    if not filename:
+        raise MultipartError(
+            "'content' part is missing filename= in Content-Disposition"
+        )
+    try:
+        action = action_b.decode("utf-8")
+        name = name_b.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise MultipartError(f"non-utf8 metadata field: {err}") from err
+    return UploadFields(
+        action=action.strip(),
+        name=name.strip(),
+        filename=filename,
+        content=content_b,
+    )

--- a/auntiepypi/_server/_multipart.py
+++ b/auntiepypi/_server/_multipart.py
@@ -50,9 +50,7 @@ class UploadFields:
     content: bytes
 
 
-def parse_multipart_upload(
-    content_type: str, raw_body: bytes, max_bytes: int
-) -> UploadFields:
+def parse_multipart_upload(content_type: str, raw_body: bytes, max_bytes: int) -> UploadFields:
     """Parse a twine-style upload body.
 
     :param content_type: the request's ``Content-Type`` header value
@@ -67,15 +65,11 @@ def parse_multipart_upload(
         body exceeding ``max_bytes``.
     """
     if not content_type or not content_type.lower().startswith("multipart/form-data"):
-        raise MultipartError(
-            f"expected multipart/form-data Content-Type, got {content_type!r}"
-        )
+        raise MultipartError(f"expected multipart/form-data Content-Type, got {content_type!r}")
     if "boundary=" not in content_type.lower():
         raise MultipartError("multipart Content-Type missing boundary parameter")
     if len(raw_body) > max_bytes:
-        raise MultipartError(
-            f"body too large ({len(raw_body)} > max_upload_bytes {max_bytes})"
-        )
+        raise MultipartError(f"body too large ({len(raw_body)} > max_upload_bytes {max_bytes})")
 
     # email.parser needs a header block on top of the body — synthesize one.
     synthetic = f"Content-Type: {content_type}\r\n\r\n".encode("utf-8") + raw_body
@@ -119,9 +113,7 @@ def _build_fields(fields: dict[str, bytes], filename: str | None) -> UploadField
     if content_b is None:
         raise MultipartError("missing required part: 'content'")
     if not filename:
-        raise MultipartError(
-            "'content' part is missing filename= in Content-Disposition"
-        )
+        raise MultipartError("'content' part is missing filename= in Content-Disposition")
     try:
         action = action_b.decode("utf-8")
         name = name_b.decode("utf-8")

--- a/auntiepypi/_server/_publish.py
+++ b/auntiepypi/_server/_publish.py
@@ -1,0 +1,80 @@
+"""Atomic upload writer for the v0.8.0 publish endpoint.
+
+One function: :func:`write_upload`. Writes the distribution bytes to a
+hidden temp file in ``cfg.root``, fsyncs, then ``os.rename`` to the
+final filename. Same-filesystem rename is atomic on POSIX, so the
+final file either exists fully or doesn't exist — no half-uploaded
+wheels left lying around when the server crashes mid-write.
+
+Existing-file collisions return :class:`WriteResult` with status 409,
+not 500: a name collision is a client error (pick a new version), not
+a server problem. No overwrite, ever — yank/delete is out of scope for
+v0.8.0 (operators delete the file from ``cfg.root`` directly to
+retract).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["WriteResult", "write_upload"]
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """Outcome of a single upload write.
+
+    ``status`` mirrors the HTTP status the handler will return:
+    201 (created), 409 (existing file), or 500 (write failure).
+    ``written`` is the byte count on success, 0 otherwise.
+    """
+
+    status: int
+    detail: str = ""
+    written: int = 0
+
+
+def write_upload(root: Path, filename: str, content: bytes) -> WriteResult:
+    """Atomically write ``content`` to ``root/filename``.
+
+    :returns: :class:`WriteResult` with status 201 on success, 409 if
+        the target already exists, 500 on filesystem error. The temp
+        file is unlinked on every error path so partial uploads never
+        litter ``root``.
+    """
+    target = root / filename
+    if target.exists():
+        return WriteResult(status=409, detail="file already exists")
+
+    # NamedTemporaryFile in `dir=root` keeps the rename on the same
+    # filesystem (atomic). Sonar S5443 fires on /tmp use; here `dir`
+    # is operator-controlled cfg.root, not /tmp, so the warning is
+    # spurious — see _publish docstring above.
+    tmp = tempfile.NamedTemporaryFile(  # noqa: S108  # NOSONAR python:S5443
+        dir=root, delete=False, prefix=".upload-", suffix=".part"
+    )
+    tmp_path = Path(tmp.name)
+    try:
+        tmp.write(content)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.rename(tmp_path, target)
+        return WriteResult(status=201, written=len(content))
+    except OSError as err:
+        # Filesystem failure (ENOSPC, EROFS, EACCES). Always clean up
+        # the temp before returning so we don't leave .upload-*.part
+        # files behind.
+        return WriteResult(status=500, detail=str(err))
+    finally:
+        # Best-effort cleanup. After a successful rename the temp
+        # path no longer exists, so unlink with missing_ok=True is
+        # cheap and safe.
+        try:
+            tmp.close()
+        except OSError:
+            pass
+        tmp_path.unlink(missing_ok=True)

--- a/auntiepypi/_server/_publish.py
+++ b/auntiepypi/_server/_publish.py
@@ -1,10 +1,13 @@
 """Atomic upload writer for the v0.8.0 publish endpoint.
 
 One function: :func:`write_upload`. Writes the distribution bytes to a
-hidden temp file in ``cfg.root``, fsyncs, then ``os.rename`` to the
-final filename. Same-filesystem rename is atomic on POSIX, so the
-final file either exists fully or doesn't exist — no half-uploaded
-wheels left lying around when the server crashes mid-write.
+hidden temp file in ``cfg.root``, fsyncs, then atomically commits to
+the final filename via :func:`os.link` — which **fails with
+FileExistsError** if the target already exists. The pre-check
+``target.exists()`` was a TOCTOU: on POSIX, ``os.rename`` would
+silently overwrite if a competing writer materialised the file in the
+window between the check and the rename. ``os.link`` is the no-clobber
+primitive for "create only if absent" on POSIX.
 
 Existing-file collisions return :class:`WriteResult` with status 409,
 not 500: a name collision is a client error (pick a new version), not
@@ -19,6 +22,7 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import IO
 
 __all__ = ["WriteResult", "write_upload"]
 
@@ -37,44 +41,56 @@ class WriteResult:
     written: int = 0
 
 
+def _open_temp(root: Path) -> IO[bytes]:
+    """``NamedTemporaryFile`` in the wheelhouse, hidden prefix.
+
+    Hidden ``.upload-*`` keeps partial uploads invisible to the
+    PEP 503 listing scanner. ``dir=root`` keeps the link/rename on the
+    same filesystem (link is atomic only same-FS).
+    """
+    # `dir` is operator-controlled cfg.root, not /tmp; Sonar S5443
+    # warning is spurious. Pre-check for `root` existence + writability
+    # is implicit — a bad `root` raises OSError here, which the caller
+    # catches and reports as 500.
+    return tempfile.NamedTemporaryFile(  # noqa: S108  # NOSONAR python:S5443
+        dir=root, delete=False, prefix=".upload-", suffix=".part"
+    )
+
+
 def write_upload(root: Path, filename: str, content: bytes) -> WriteResult:
     """Atomically write ``content`` to ``root/filename``.
 
     :returns: :class:`WriteResult` with status 201 on success, 409 if
-        the target already exists, 500 on filesystem error. The temp
-        file is unlinked on every error path so partial uploads never
-        litter ``root``.
+        the target already exists, 500 on any filesystem error. The
+        temp file is unlinked on every exit path so partial uploads
+        never litter ``root``.
+
+    Concurrency: ``os.link(tmp, target)`` is atomic and
+    no-clobber on POSIX — concurrent writers of the same filename
+    cannot race past the existence check, the way ``rename`` would.
     """
     target = root / filename
-    if target.exists():
-        return WriteResult(status=409, detail="file already exists")
-
-    # NamedTemporaryFile in `dir=root` keeps the rename on the same
-    # filesystem (atomic). Sonar S5443 fires on /tmp use; here `dir`
-    # is operator-controlled cfg.root, not /tmp, so the warning is
-    # spurious — see _publish docstring above.
-    tmp = tempfile.NamedTemporaryFile(  # noqa: S108  # NOSONAR python:S5443
-        dir=root, delete=False, prefix=".upload-", suffix=".part"
-    )
-    tmp_path = Path(tmp.name)
+    tmp_path: Path | None = None
     try:
-        tmp.write(content)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-        os.rename(tmp_path, target)
+        tmp = _open_temp(root)
+        tmp_path = Path(tmp.name)
+        try:
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        finally:
+            tmp.close()
+        # No-clobber atomic commit: link the temp into the final name.
+        # ``os.link`` raises FileExistsError if `target` already
+        # exists — the contracted 409 path with no TOCTOU window.
+        try:
+            os.link(tmp_path, target)
+        except FileExistsError:
+            return WriteResult(status=409, detail="file already exists")
         return WriteResult(status=201, written=len(content))
     except OSError as err:
-        # Filesystem failure (ENOSPC, EROFS, EACCES). Always clean up
-        # the temp before returning so we don't leave .upload-*.part
-        # files behind.
+        # ENOSPC / EROFS / EACCES / temp-create failure on bad root.
         return WriteResult(status=500, detail=str(err))
     finally:
-        # Best-effort cleanup. After a successful rename the temp
-        # path no longer exists, so unlink with missing_ok=True is
-        # cheap and safe.
-        try:
-            tmp.close()
-        except OSError:
-            pass
-        tmp_path.unlink(missing_ok=True)
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)

--- a/auntiepypi/cli/__init__.py
+++ b/auntiepypi/cli/__init__.py
@@ -21,6 +21,7 @@ from auntiepypi.cli._commands import down as _down_cmd
 from auntiepypi.cli._commands import explain as _explain_cmd
 from auntiepypi.cli._commands import learn as _learn_cmd
 from auntiepypi.cli._commands import overview as _overview_cmd
+from auntiepypi.cli._commands import publish as _publish_cmd
 from auntiepypi.cli._commands import restart as _restart_cmd
 from auntiepypi.cli._commands import up as _up_cmd
 from auntiepypi.cli._commands import whoami as _whoami_cmd
@@ -61,6 +62,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _up_cmd.register(sub)
     _down_cmd.register(sub)
     _restart_cmd.register(sub)
+    _publish_cmd.register(sub)
     _whoami_cmd.register(sub)
 
     return parser

--- a/auntiepypi/cli/_commands/_publish_client.py
+++ b/auntiepypi/cli/_commands/_publish_client.py
@@ -43,9 +43,12 @@ def _new_boundary() -> str:
 
 def _text_part(boundary: str, name: str, value: bytes) -> bytes:
     return (
-        f"--{boundary}\r\n"
-        f'Content-Disposition: form-data; name="{name}"\r\n\r\n'
-    ).encode("utf-8") + value + b"\r\n"
+        (f"--{boundary}\r\n" f'Content-Disposition: form-data; name="{name}"\r\n\r\n').encode(
+            "utf-8"
+        )
+        + value
+        + b"\r\n"
+    )
 
 
 def _file_part(boundary: str, name: str, filename: str, value: bytes) -> bytes:
@@ -90,6 +93,20 @@ def insecure_skip_verify_enabled() -> bool:
     return os.environ.get("AUNTIE_INSECURE_SKIP_VERIFY", "") not in ("", "0", "false", "False")
 
 
+def _build_client_ssl_context(url: str, *, verify: bool) -> ssl.SSLContext | None:
+    """Pick an SSL context for the upload POST.
+
+    HTTPS + verify=True → CA-verifying default context.
+    HTTPS + verify=False → unverified context (operator opt-in via
+    AUNTIE_INSECURE_SKIP_VERIFY=1 only). HTTP → None.
+    """
+    if not url.startswith("https://"):
+        return None
+    if verify:
+        return ssl.create_default_context()
+    return ssl._create_unverified_context()  # noqa: S323  # nosec B323  # NOSONAR python:S4830
+
+
 def post(
     url: str,
     body: bytes,
@@ -123,16 +140,11 @@ def post(
             "Content-Length": str(len(body)),
         },
     )
-    ctx: ssl.SSLContext | None = None
-    if url.startswith("https://"):
-        if verify:
-            ctx = ssl.create_default_context()
-        else:
-            # Opt-in via AUNTIE_INSECURE_SKIP_VERIFY for self-signed
-            # operators; never silent.
-            ctx = ssl._create_unverified_context()  # noqa: S323  # nosec B323  # NOSONAR python:S4830
+    ctx = _build_client_ssl_context(url, verify=verify)
     try:
-        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:  # noqa: S310
+        with urllib.request.urlopen(  # noqa: S310  # nosec B310 - http/https only
+            req, timeout=timeout, context=ctx
+        ) as resp:
             return resp.status, resp.read()
     except urllib.error.HTTPError as err:
         # 4xx/5xx responses come through HTTPError — read the body

--- a/auntiepypi/cli/_commands/_publish_client.py
+++ b/auntiepypi/cli/_commands/_publish_client.py
@@ -1,0 +1,140 @@
+"""Stdlib HTTP client for ``auntie publish``.
+
+Two helpers, kept in their own module so unit tests can import them
+without going through argparse:
+
+- :func:`build_multipart` — assemble a twine-shape multipart body by
+  hand. Returns ``(body_bytes, content_type_header)``.
+- :func:`post` — send the body to the local index with
+  ``Authorization: Basic …`` over ``urllib.request``. Returns
+  ``(status, response_body_bytes)`` for any HTTP response (including
+  4xx via :class:`urllib.error.HTTPError`); raises
+  :class:`urllib.error.URLError` on transport-layer failures so the
+  caller can map to a distinct exit code.
+
+We construct the multipart body manually rather than use
+``email.message.EmailMessage``: the email API is geared toward
+``multipart/mixed`` and converting it to ``multipart/form-data`` with
+the right Content-Disposition headers is more boilerplate than just
+emitting the bytes directly. The shape is small and stable.
+
+HTTPS verification is on by default; operators with self-signed certs
+set ``AUNTIE_INSECURE_SKIP_VERIFY=1``. The unverified context is used
+*only* on this opt-in path; the production client never silently
+skips verification.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import secrets
+import ssl
+import urllib.error
+import urllib.request
+
+__all__ = ["build_multipart", "post", "insecure_skip_verify_enabled"]
+
+
+def _new_boundary() -> str:
+    """Random boundary: 16 hex chars on a stable prefix."""
+    return f"----auntie-{secrets.token_hex(16)}"
+
+
+def _text_part(boundary: str, name: str, value: bytes) -> bytes:
+    return (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="{name}"\r\n\r\n'
+    ).encode("utf-8") + value + b"\r\n"
+
+
+def _file_part(boundary: str, name: str, filename: str, value: bytes) -> bytes:
+    header = (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="{name}"; '
+        f'filename="{filename}"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n"
+    ).encode("utf-8")
+    return header + value + b"\r\n"
+
+
+def build_multipart(
+    file_bytes: bytes, filename: str, project: str, version: str
+) -> tuple[bytes, str]:
+    """Build a twine-shape ``multipart/form-data`` body.
+
+    Four parts: ``:action`` (``file_upload``), ``name`` (canonical
+    project name), ``version``, and ``content`` (the raw distribution
+    bytes with ``filename=…``). Twine sends additional metadata
+    fields; the auntiepypi server ignores them so we don't bother.
+
+    The ``:action`` field name is what the legacy PyPI upload API
+    requires — note the leading colon. Stable random boundary uses
+    ``secrets.token_hex`` to keep the chance of accidental collision
+    with the file bytes vanishingly small.
+    """
+    boundary = _new_boundary()
+    body = (
+        _text_part(boundary, ":action", b"file_upload")
+        + _text_part(boundary, "name", project.encode("utf-8"))
+        + _text_part(boundary, "version", version.encode("utf-8"))
+        + _file_part(boundary, "content", filename, file_bytes)
+        + f"--{boundary}--\r\n".encode("utf-8")
+    )
+    ctype = f"multipart/form-data; boundary={boundary}"
+    return body, ctype
+
+
+def insecure_skip_verify_enabled() -> bool:
+    """True iff ``AUNTIE_INSECURE_SKIP_VERIFY`` is set to a truthy value."""
+    return os.environ.get("AUNTIE_INSECURE_SKIP_VERIFY", "") not in ("", "0", "false", "False")
+
+
+def post(
+    url: str,
+    body: bytes,
+    content_type: str,
+    user: str,
+    password: str,
+    *,
+    verify: bool = True,
+    timeout: float = 60.0,
+) -> tuple[int, bytes]:
+    """POST ``body`` to ``url`` with HTTP Basic auth.
+
+    Returns ``(status, response_body_bytes)`` on any HTTP response —
+    including 4xx (we read ``HTTPError`` and surface it as a status
+    rather than re-raising). Raises :class:`urllib.error.URLError` on
+    transport-layer failures (DNS/connect/TLS) so the caller can map
+    to a distinct exit code.
+
+    ``verify`` controls TLS hostname/CA verification; when False, an
+    unverified context is used (operators with self-signed certs
+    opt in via ``AUNTIE_INSECURE_SKIP_VERIFY=1``).
+    """
+    creds = base64.b64encode(f"{user}:{password}".encode("utf-8")).decode("ascii")
+    req = urllib.request.Request(  # noqa: S310 - URL comes from cfg.host/port
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": content_type,
+            "Authorization": f"Basic {creds}",
+            "Content-Length": str(len(body)),
+        },
+    )
+    ctx: ssl.SSLContext | None = None
+    if url.startswith("https://"):
+        if verify:
+            ctx = ssl.create_default_context()
+        else:
+            # Opt-in via AUNTIE_INSECURE_SKIP_VERIFY for self-signed
+            # operators; never silent.
+            ctx = ssl._create_unverified_context()  # noqa: S323  # nosec B323  # NOSONAR python:S4830
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:  # noqa: S310
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as err:
+        # 4xx/5xx responses come through HTTPError — read the body
+        # and surface as a status. Caller maps to exit codes.
+        return err.code, err.read() or b""

--- a/auntiepypi/cli/_commands/_publish_client.py
+++ b/auntiepypi/cli/_commands/_publish_client.py
@@ -37,7 +37,11 @@ __all__ = ["build_multipart", "post", "insecure_skip_verify_enabled"]
 
 
 def _new_boundary() -> str:
-    """Random boundary: 16 hex chars on a stable prefix."""
+    """Random boundary: 32 hex chars (16 random bytes) on a stable prefix.
+
+    ``secrets.token_hex(16)`` returns a 32-char hex string. Collision
+    probability with the file payload is ~2^-128.
+    """
     return f"----auntie-{secrets.token_hex(16)}"
 
 
@@ -88,9 +92,19 @@ def build_multipart(
     return body, ctype
 
 
+_TRUTHY_ENV = frozenset({"1", "true", "yes", "on"})
+
+
 def insecure_skip_verify_enabled() -> bool:
-    """True iff ``AUNTIE_INSECURE_SKIP_VERIFY`` is set to a truthy value."""
-    return os.environ.get("AUNTIE_INSECURE_SKIP_VERIFY", "") not in ("", "0", "false", "False")
+    """True iff ``AUNTIE_INSECURE_SKIP_VERIFY`` is a truthy value.
+
+    Case-insensitive: ``1`` / ``true`` / ``yes`` / ``on`` (any case)
+    enable the bypass; everything else (including unset, empty,
+    ``0``, ``false``, ``no``, ``off``, ``FALSE``) leaves verification
+    on. Allowlist semantics — defaulting to "on" for a security knob
+    is the safer side when the env value is ambiguous (e.g. typos).
+    """
+    return os.environ.get("AUNTIE_INSECURE_SKIP_VERIFY", "").strip().lower() in _TRUTHY_ENV
 
 
 def _build_client_ssl_context(url: str, *, verify: bool) -> ssl.SSLContext | None:

--- a/auntiepypi/cli/_commands/_publish_client.py
+++ b/auntiepypi/cli/_commands/_publish_client.py
@@ -110,14 +110,20 @@ def insecure_skip_verify_enabled() -> bool:
 def _build_client_ssl_context(url: str, *, verify: bool) -> ssl.SSLContext | None:
     """Pick an SSL context for the upload POST.
 
-    HTTPS + verify=True → CA-verifying default context.
+    HTTPS + verify=True → CA-verifying default context with TLS 1.2
+    floor (matches the server-side pin in
+    :mod:`auntiepypi._server._tls`).
     HTTPS + verify=False → unverified context (operator opt-in via
-    AUNTIE_INSECURE_SKIP_VERIFY=1 only). HTTP → None.
+    ``AUNTIE_INSECURE_SKIP_VERIFY=1`` only). HTTP → None.
     """
     if not url.startswith("https://"):
         return None
     if verify:
-        return ssl.create_default_context()
+        ctx = ssl.create_default_context()
+        # Pin TLS 1.2 floor explicitly so older protocols stay out of
+        # band even on operating systems with permissive defaults.
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+        return ctx
     return ssl._create_unverified_context()  # noqa: S323  # nosec B323  # NOSONAR python:S4830
 
 

--- a/auntiepypi/cli/_commands/learn.py
+++ b/auntiepypi/cli/_commands/learn.py
@@ -52,6 +52,11 @@ Commands
   auntie restart [name|--all]  Restart a server (atomic for systemd-user;
                                stop+start for command and the first-party
                                server). Supports --json.
+  auntie publish <path>        Upload a wheel/sdist to the configured local
+                               index ([tool.auntiepypi.local]). Requires
+                               htpasswd + publish_users allowlist; reads
+                               $AUNTIE_PUBLISH_USER / _PASSWORD or prompts.
+                               Supports --json.
   auntie whoami                Auth/env probe — which PyPI / TestPyPI /
                                local index is the active environment
                                pointing at? Supports --json.
@@ -70,6 +75,8 @@ Configuration
     cert = "/etc/ssl/auntie.pem"          # v0.7.0: HTTPS termination
     key  = "/etc/ssl/auntie.key"          # v0.7.0: paired with cert
     htpasswd = "/etc/auntie/htpasswd"     # v0.7.0: Basic-auth, bcrypt-only
+    publish_users = ["alice"]             # v0.8.0: who can POST uploads
+    max_upload_bytes = 104857600          # v0.8.0: per-request size cap
 
   pyproject.toml [[tool.auntiepypi.servers]]   # one block per declared server
     name = "main"                         # "auntie" is reserved
@@ -152,6 +159,14 @@ def _as_json_payload() -> dict[str, object]:
                     "Restart a server. Atomic for systemd-user; stop+start for "
                     "command and the first-party server. Re-spawn uses current "
                     "pyproject config."
+                ),
+            },
+            {
+                "path": ["publish"],
+                "summary": (
+                    "Upload a wheel/sdist to the configured local index. "
+                    "Requires publish_users allowlist; reads "
+                    "$AUNTIE_PUBLISH_USER / _PASSWORD or prompts."
                 ),
             },
             {

--- a/auntiepypi/cli/_commands/publish.py
+++ b/auntiepypi/cli/_commands/publish.py
@@ -1,0 +1,162 @@
+"""``auntie publish <path>`` — upload a wheel/sdist to the local index.
+
+Reads ``[tool.auntiepypi.local]`` for ``host``/``port``/``tls_enabled``
+and POSTs the file via the twine-shape upload protocol that the v0.8.0
+server accepts. Credentials come from ``$AUNTIE_PUBLISH_USER`` /
+``$AUNTIE_PUBLISH_PASSWORD`` or interactive prompt; keyring/netrc
+support is deferred to v0.8.1.
+
+Exit codes:
+
+- 0 on 2xx (server accepted the upload)
+- 1 on any 4xx/5xx (auth failure, authz miss, conflict, size cap)
+- 2 on transport error (DNS / TCP / TLS failure, missing file path)
+
+Exit-code mapping is deliberate: a server-side 409 ("file already
+exists") is a script-author error (pick a new version), distinct from
+a network or config error which is an environment problem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+
+from auntiepypi._detect._config import load_local_config
+from auntiepypi._server._wheelhouse import parse_filename
+from auntiepypi.cli._commands._publish_client import (
+    build_multipart,
+    insecure_skip_verify_enabled,
+    post,
+)
+from auntiepypi.cli._output import emit_result
+
+__all__ = ["cmd_publish", "register"]
+
+
+def _resolve_creds(args: argparse.Namespace) -> tuple[str, str]:
+    """Return ``(user, password)`` from env or prompts.
+
+    Uses ``getpass`` for the password so it doesn't echo. In non-TTY
+    environments without env vars set, exits 2 rather than blocking
+    on a hidden read.
+    """
+    user = os.environ.get("AUNTIE_PUBLISH_USER")
+    password = os.environ.get("AUNTIE_PUBLISH_PASSWORD")
+    if user and password:
+        return user, password
+    if not sys.stdin.isatty():
+        print(
+            "auntie publish: missing credentials. Set "
+            "AUNTIE_PUBLISH_USER and AUNTIE_PUBLISH_PASSWORD, or "
+            "run interactively.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if not user:
+        user = input("user: ")
+    if not password:
+        password = getpass.getpass("password: ")
+    return user, password
+
+
+def _build_url(host: str, port: int, *, tls: bool) -> str:
+    scheme = "https" if tls else "http"
+    bracketed = f"[{host}]" if ":" in host else host
+    return f"{scheme}://{bracketed}:{port}/"
+
+
+def _emit_failure(status: int, body: bytes, json_mode: bool) -> int:
+    detail = body.decode("utf-8", errors="replace").strip()
+    payload = {"ok": False, "status": status, "detail": detail}
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        print(f"HTTP {status}: {detail}", file=sys.stderr)
+    return 1
+
+
+def _emit_success(body: bytes, json_mode: bool) -> int:
+    try:
+        decoded = json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        decoded = {"ok": True, "raw": body.decode("utf-8", errors="replace")}
+    if json_mode:
+        emit_result(decoded, json_mode=True)
+    else:
+        filename = decoded.get("filename") or "<unknown>"
+        url = decoded.get("url") or ""
+        print(f"published {filename} → {url}")
+    return 0
+
+
+def cmd_publish(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    path: Path = args.path
+    if not path.exists() or not path.is_file():
+        print(f"auntie publish: file not found: {path}", file=sys.stderr)
+        return 2
+    parsed = parse_filename(path.name)
+    if parsed is None:
+        print(
+            f"auntie publish: not a recognized distribution filename: {path.name}",
+            file=sys.stderr,
+        )
+        return 2
+    project, version = parsed
+
+    cfg = load_local_config()
+    user, password = _resolve_creds(args)
+
+    file_bytes = path.read_bytes()
+    body, ctype = build_multipart(file_bytes, path.name, project, version)
+    url = _build_url(cfg.host, cfg.port, tls=cfg.tls_enabled)
+
+    if cfg.tls_enabled and insecure_skip_verify_enabled():
+        print(
+            "auntie publish: AUNTIE_INSECURE_SKIP_VERIFY=1 — TLS "
+            "verification disabled for this upload",
+            file=sys.stderr,
+        )
+
+    try:
+        status, resp_body = post(
+            url,
+            body,
+            ctype,
+            user,
+            password,
+            verify=not insecure_skip_verify_enabled(),
+        )
+    except urllib.error.URLError as err:
+        print(f"auntie publish: transport error: {err.reason}", file=sys.stderr)
+        return 2
+
+    if 200 <= status < 300:
+        return _emit_success(resp_body, json_mode)
+    return _emit_failure(status, resp_body, json_mode)
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "publish",
+        help="Upload a wheel or sdist to the configured local index.",
+        description=(
+            "Upload a wheel/sdist to [tool.auntiepypi.local] via the "
+            "twine-shape POST protocol. Credentials come from "
+            "$AUNTIE_PUBLISH_USER / $AUNTIE_PUBLISH_PASSWORD or "
+            "interactive prompt."
+        ),
+    )
+    p.add_argument(
+        "path",
+        type=Path,
+        help="path to the wheel (.whl) or sdist (.tar.gz / .zip) to upload",
+    )
+    p.add_argument("--json", action="store_true", help="emit structured JSON")
+    p.set_defaults(func=cmd_publish)

--- a/auntiepypi/cli/_commands/publish.py
+++ b/auntiepypi/cli/_commands/publish.py
@@ -39,7 +39,7 @@ from auntiepypi.cli._output import emit_result
 __all__ = ["cmd_publish", "register"]
 
 
-def _resolve_creds(args: argparse.Namespace) -> tuple[str, str]:
+def _resolve_creds() -> tuple[str, str]:
     """Return ``(user, password)`` from env or prompts.
 
     Uses ``getpass`` for the password so it doesn't echo. In non-TTY
@@ -111,7 +111,7 @@ def cmd_publish(args: argparse.Namespace) -> int:
     project, version = parsed
 
     cfg = load_local_config()
-    user, password = _resolve_creds(args)
+    user, password = _resolve_creds()
 
     file_bytes = path.read_bytes()
     body, ctype = build_multipart(file_bytes, path.name, project, version)

--- a/auntiepypi/explain/catalog.py
+++ b/auntiepypi/explain/catalog.py
@@ -40,6 +40,9 @@ locally. Informational, not gating.
   stop+start for `command`. Always re-spawns from the current
   `pyproject.toml` argv (or `[tool.auntiepypi.local]` for the bare
   form).
+- `auntie publish <path>` — upload a wheel/sdist to the configured
+  local index. Requires `publish_users` allowlist + htpasswd creds
+  via `$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD`.
 - `auntie whoami` — auth/env probe; reports configured indexes.
 
 ## Console scripts
@@ -65,6 +68,7 @@ The package installs two scripts that point at the same entry point:
 - `auntie explain up`
 - `auntie explain down`
 - `auntie explain restart`
+- `auntie explain publish`
 - `auntie explain whoami`
 """
 
@@ -373,6 +377,63 @@ probe machinery `overview` uses to flag local indexes that are
 Read-only.
 """
 
+_PUBLISH = """\
+# auntie publish
+
+Upload a wheel or sdist to the configured local index
+(`[tool.auntiepypi.local]`).
+
+Uses the legacy PyPI upload protocol (`POST /` with
+`multipart/form-data`, `:action=file_upload`) — twine, flit, hatch,
+and the v0.8.0 first-party server all speak it.
+
+## Authorization
+
+The server requires both authentication AND an authz allowlist:
+
+    [tool.auntiepypi.local]
+    htpasswd      = "/etc/auntie/htpasswd"
+    publish_users = ["alice", "bob"]
+
+`publish_users` empty / unset → no one publishes (read-only mode
+preserved). `publish_users` set + caller in the list → upload
+accepted.
+
+## Credentials
+
+Read from environment, then prompt:
+
+- `$AUNTIE_PUBLISH_USER` (or `input("user: ")`)
+- `$AUNTIE_PUBLISH_PASSWORD` (or `getpass.getpass()`)
+
+Non-TTY environments without env vars set exit 2 (no silent block).
+
+## Usage
+
+    auntie publish dist/mypkg-1.0-py3-none-any.whl
+    auntie publish dist/mypkg-1.0.tar.gz --json
+
+## TLS
+
+When `[tool.auntiepypi.local].cert` and `.key` are set, the URL
+becomes `https://...`. Verification is on by default; for self-signed
+certs, set `AUNTIE_INSECURE_SKIP_VERIFY=1` (a stderr warning fires
+each invocation).
+
+## Exit codes
+
+- 0 — server accepted (HTTP 2xx).
+- 1 — server rejected (HTTP 4xx / 5xx).
+  Common: 401 (bad creds), 403 (user not in `publish_users`,
+  or `publish_users` empty), 409 (file already exists — pick a new
+  version), 413 (over `max_upload_bytes`).
+- 2 — transport error (DNS / connect / TLS) or local file problem
+  (path missing, unrecognized distribution filename).
+
+No yank/delete: to retract a wheel, the operator deletes the file
+from `cfg.root` directly. v0.8.0 does not provide a delete API.
+"""
+
 ENTRIES: dict[tuple[str, ...], str] = {
     (): _ROOT,
     ("auntiepypi",): _ROOT,
@@ -384,5 +445,6 @@ ENTRIES: dict[tuple[str, ...], str] = {
     ("up",): _UP,
     ("down",): _DOWN,
     ("restart",): _RESTART,
+    ("publish",): _PUBLISH,
     ("whoami",): _WHOAMI,
 }

--- a/docs/superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md
+++ b/docs/superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md
@@ -1,0 +1,369 @@
+# auntiepypi v0.8.0 — `auntie publish` (write side)
+
+**Status:** approved 2026-05-03
+**Implements:** the v0.8.0 entry from CLAUDE.md's roadmap (POST upload
+path with v0.7.0 trust model + per-user publish authz).
+**Related specs:**
+[v0.7.0 TLS + basic-auth](2026-05-02-auntiepypi-v0.7.0-tls-auth-design.md),
+[v0.6.0 local server](2026-05-01-auntiepypi-v0.6.0-local-server-design.md)
+
+## Context
+
+v0.7.0 shipped HTTPS termination and HTTP Basic auth on the existing
+read-only routes (`/`, `/simple/`, `/simple/<pkg>/`,
+`/files/<filename>`) and lifted the loopback restriction when both TLS
+and auth are configured. The v0.7.0 spec explicitly defers the write
+side to this milestone:
+
+> `auntie publish` write side → v0.8.0. Same trust model as v0.7.0
+> (TLS + basic-auth) plus an authorization step (which users can
+> publish).
+
+v0.8.0 fills that pointer. The first-party server gains:
+
+- **A twine-compatible POST upload endpoint at `/`** — the legacy PyPI
+  upload API: `multipart/form-data` with `:action=file_upload`. Existing
+  Python publishing tools (`twine`, `flit publish`, `hatch publish`)
+  work unchanged.
+- **A `publish_users` allowlist** in `[tool.auntiepypi.local]`. Empty
+  / unset → no one can publish (read-only mode preserved). Set with
+  names → only those htpasswd users can POST. A strict superset of
+  authentication: every publisher must already authenticate.
+- **An `auntie publish <wheel>` CLI verb** that uploads via stdlib
+  `urllib.request` to the configured local server. Mirrors the
+  small-landable-PR cadence used for v0.5.0 / v0.6.0 / v0.7.0.
+
+The write side narrows the v0.7.0 trust surface ("single-host LAN with
+auth + TLS") to "single-host LAN with auth + TLS + per-user authz."
+
+The "stdlib-only except crypto primitives" invariant holds: multipart
+parsing uses `email.parser.BytesParser`. The `cgi` module would have
+been a closer fit but it's removed in Python 3.13; we're on 3.12+.
+`bcrypt>=4.0,<5` (added in v0.7.0) remains the only runtime dep.
+
+## Locked design decisions
+
+### D1. Twine-compatible POST upload at `/`
+
+Endpoint: `POST /` with `Content-Type: multipart/form-data; boundary=…`.
+The body must contain at least:
+
+- A part named `:action` with value `file_upload`. Anything else → 400.
+- A part named `name` with the canonical project name.
+- A part named `content` with `filename=…` and the raw distribution
+  bytes.
+
+PyPI's legacy upload API sends ~20 metadata fields (`version`,
+`pyversion`, `metadata_version`, `summary`, `sha256_digest`, …); the
+server **ignores** all but the three above. The wheel/sdist itself is
+the source of truth for metadata.
+
+**Why POST `/` and not POST `/simple/`?** Twine hardcodes the upload
+URL as the index URL with `/legacy/` appended (or the bare URL for
+non-PyPI). The conventional shape is "POST to the URL twine was given."
+For our index, that's `/`. (`pypiserver` uses POST `/`; `devpi` uses
+per-user URLs. We follow `pypiserver`.)
+
+### D2. `publish_users` allowlist field
+
+```toml
+[tool.auntiepypi.local]
+publish_users = ["alice", "bob"]
+```
+
+- Type: `list[str]` of htpasswd usernames. Stored on `LocalConfig` as
+  `publish_users: tuple[str, ...]` (frozen-dataclass-friendly).
+- **Empty / unset → no one can publish.** Read-only mode is preserved
+  when an operator just wants a private mirror. POST → 403 with body
+  `"publish disabled"`.
+- **Set with names → only those users can POST.** Authenticated user
+  not in the list → 403.
+- Names must reference actual htpasswd entries; loader cross-checks
+  at config-load time and raises `ServerConfigError` on dangling
+  references (mirrors the v0.7.0 truth-table validators).
+- Requires `auth_enabled` — `publish_users` set without `htpasswd` →
+  `ServerConfigError`. (You can't authorize anonymous users.)
+
+Per-package ownership (`{"alice": ["mypkg-*"]}`) is deferred to v1.0.0.
+
+### D3. `verify_basic` widens to return `str | None`
+
+The v0.7.0 `verify_basic(header, map) -> bool` discards the
+authenticated username. Publish authz needs it. We refactor:
+
+```python
+def authenticate_user(raw_header: str, htpasswd_map) -> str | None:
+    """Same checks as v0.7.0 verify_basic; returns username on
+    success, None on any failure mode."""
+
+def verify_basic(raw_header: str, htpasswd_map) -> bool:
+    return authenticate_user(raw_header, htpasswd_map) is not None
+```
+
+`authenticate_user` is the new primitive; `verify_basic` becomes a
+thin bool adapter for read-side callers that don't care which user.
+Cache shape unchanged — the v0.7.0 cache already stores
+`(timestamp, user, expected_hash)`; `authenticate_user` returns
+`cached_user` on a fresh hit. No behaviour change for v0.7.0 callers.
+
+### D4. Existing-file POST returns 409 Conflict
+
+PyPI returns 400 with body "File already exists." We return **409
+Conflict** because it's the semantically correct status for a name
+collision and gives clients a clear retry signal (don't retry; pick a
+new version). No overwrite, ever. Yank/delete is out of scope.
+
+### D5. Body size cap via `max_upload_bytes`
+
+```toml
+[tool.auntiepypi.local]
+max_upload_bytes = 104857600   # default: 100 MiB
+```
+
+Enforced two ways:
+
+1. **Pre-read** via `Content-Length` — reject before reading body.
+2. **During-read** via a counted reader that aborts after the cap.
+   Defends against missing/lying `Content-Length`.
+
+Default 100 MiB; operators with multi-GiB ML wheels override. The cap
+is per-request, not per-day. No rate limiting in v0.8.0.
+
+### D6. Atomic write: `tempfile` + `os.rename` in the same dir
+
+Storage is flat (all wheels at `cfg.root` directly). Upload flow:
+
+1. Validate filename via `parse_filename()` + `_SAFE_FILENAME` regex.
+2. Validate the multipart `name` field normalizes to the same project
+   name as `parse_filename()` reports (prevents cross-project
+   overwrites by an authorized user).
+3. Refuse if `cfg.root / filename` already exists → 409.
+4. `tempfile.NamedTemporaryFile(dir=cfg.root, delete=False, prefix=".upload-")`
+   — same filesystem guarantees atomic `os.rename`.
+5. Write the bytes to the temp file.
+6. `os.fsync()` the file, close, then `os.rename(tmp, final)`.
+7. Unlink the temp path on any error path (no-op after successful
+   rename). Errors return 500 only after cleanup.
+
+### D7. CLI: `auntie publish <path>`
+
+```text
+auntie publish dist/mypkg-1.0-py3-none-any.whl
+```
+
+- Reads `[tool.auntiepypi.local]` for `host`, `port`, `tls_enabled`.
+- Username from `$AUNTIE_PUBLISH_USER` or interactive prompt.
+- Password from `$AUNTIE_PUBLISH_PASSWORD` or `getpass.getpass()`.
+- Builds a multipart body via `email.message.EmailMessage` (stdlib),
+  sends via `urllib.request.Request(method="POST")` with
+  `Authorization: Basic …` header.
+- HTTPS verification: when `cfg.tls_enabled`, uses
+  `ssl.create_default_context()` (verifying). Self-signed cert? The
+  operator either trusts it via system CA store or sets
+  `AUNTIE_INSECURE_SKIP_VERIFY=1`. We prefer secure-by-default; the
+  detector's `_create_unverified_context` is for self-probing only,
+  not for clients.
+- Output: `{"ok": true, "filename": "…", "url": "…"}` with `--json`,
+  human-readable text otherwise. Exit 0 on 2xx, 1 on 4xx/5xx, 2 on
+  network/TLS errors.
+- Keyring/netrc support deferred to v0.8.1.
+
+## Architecture
+
+### `[tool.auntiepypi.local]` config block (full)
+
+```toml
+[tool.auntiepypi.local]
+host = "0.0.0.0"
+port = 3141
+root = "~/.local/share/auntiepypi/wheels"
+cert = "/etc/ssl/private/auntie.pem"
+key  = "/etc/ssl/private/auntie.key"
+htpasswd = "/etc/auntie/htpasswd"
+publish_users = ["alice", "bob"]      # NEW
+max_upload_bytes = 104857600          # NEW (optional; default 100 MiB)
+```
+
+### `LocalConfig` extension
+
+```python
+_DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+@dataclass(frozen=True)
+class LocalConfig:
+    host: str = _DEFAULT_HOST
+    port: int = _DEFAULT_PORT
+    root: Path = field(default_factory=default_root)
+    cert: Path | None = None
+    key: Path | None = None
+    htpasswd: Path | None = None
+    publish_users: tuple[str, ...] = ()                # NEW
+    max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES  # NEW
+
+    @property
+    def publish_enabled(self) -> bool:
+        return bool(self.publish_users) and self.auth_enabled
+```
+
+Defaulting `publish_users` to `()` is friendlier than `None` for
+downstream callers — `if user in cfg.publish_users` works either way.
+Empty tuple = read-only. The validator still raises if the field is
+set but `htpasswd` isn't.
+
+### Auth + authz flow (POST handler)
+
+```python
+def do_POST(self) -> None:
+    if htpasswd_map is None:
+        return self._send_status(405)              # auth not configured
+    user = authenticate_user(
+        self.headers.get("Authorization", ""), htpasswd_map
+    )
+    if user is None:
+        return self._send_401()
+    if not publish_users or user not in publish_users:
+        return self._send_status(
+            403,
+            "publish disabled" if not publish_users
+            else f"user {user!r} cannot publish",
+        )
+    if self.path != "/":
+        return self._send_status(404)
+    return self._handle_upload(user)
+```
+
+`_handle_upload` parses the body, validates the filename, runs
+`write_upload`, and returns 201 on success.
+
+### Threat model (v0.8.0)
+
+Read surface still "single-host LAN with auth + TLS." Write narrows
+that to "single-host LAN with auth + TLS + per-user authz."
+
+| Threat                                | Mitigation                              |
+|---------------------------------------|-----------------------------------------|
+| Anonymous publish                     | 401 unless authenticated                |
+| Reader can publish                    | 403 unless in publish_users             |
+| Disk fill via huge upload             | max_upload_bytes (Content-Length + counted reader) |
+| Wheel name collision                  | 409 Conflict; no overwrite              |
+| Path traversal via filename           | _SAFE_FILENAME regex (no `/`, no `..`)  |
+| Cross-project overwrite               | normalize(name) == normalize(parsed)    |
+| Partial-file litter on crash          | tempfile + atomic rename + finally cleanup |
+| Memory exhaustion via giant body      | Same as disk-fill: cap + counted reader |
+| Plaintext creds on POST wire          | TLS 1.2 floor (v0.7.0 carryover)        |
+| Stolen htpasswd → silent publish      | Operator rotates with `htpasswd -B`;    |
+|                                       | cache TTL 60s ⇒ rotation visible fast   |
+
+Out of scope (deferred or never):
+
+- **Yank/delete** → never as an API. Operators retract a wheel by
+  deleting the file from `cfg.root` directly. Document this rather
+  than ship a half-baked yank API.
+- **Per-package ownership maps** → v1.0.0. The
+  `{"alice": ["mypkg-*"]}` shape is on the roadmap but quadruples the
+  validator and test surface; out of scope for a small landable PR.
+- **Keyring / netrc** → v0.8.1. v0.8.0 reads `$AUNTIE_PUBLISH_USER` /
+  `$AUNTIE_PUBLISH_PASSWORD` or prompts. Keyring lookup is a separate
+  PR with its own dep choice (system keyring vs. `keyring` package).
+- **Streaming multipart parse** → v0.9.0. v0.8.0 buffers the whole
+  upload in memory before parsing. With `max_upload_bytes` capped at
+  100 MiB, this is acceptable for the LAN-scale use case.
+- **Rate limiting** → never in v0.8.0. TLS termination + bcrypt KDF
+  cost + LAN scope is adequate for the threat model.
+- **Detached signature uploads** (`gpg_signature` part) → twine sends
+  them but PyPI deprecated signature uploads. We 200 and silently
+  discard. Document so users don't expect signature storage.
+- **`sha256_digest` echo** → twine optionally validates the server's
+  echoed SHA256. We don't compute or echo. Twine treats absence as
+  "didn't ask" and doesn't fail.
+
+## Compat notes
+
+- `LocalConfig` gains two optional fields; v0.7.0 default tables still
+  parse identically. Existing pyprojects with `[tool.auntiepypi.local]`
+  keep working.
+- `_actions/auntie._argv()` adds flags conditionally; pyprojects
+  without `publish_users` / `max_upload_bytes` get the same argv as in
+  v0.7.0.
+- `verify_basic` keeps its bool signature; read-side callers
+  (`_app.do_GET` v0.7.0) need no change. Internally it delegates to
+  the new `authenticate_user`.
+- No new runtime dependencies. `bcrypt` (added in v0.7.0) is reused
+  by the new `authenticate_user` primitive.
+
+## Remediation example: "I forgot publish_users"
+
+Operator wants to publish but only configured TLS + auth:
+
+```toml
+[tool.auntiepypi.local]
+host = "0.0.0.0"
+cert = "/etc/ssl/private/auntie.pem"
+key  = "/etc/ssl/private/auntie.key"
+htpasswd = "/etc/auntie/htpasswd"
+```
+
+…runs `auntie up`, then `auntie publish dist/mypkg-1.0.whl`. Result:
+
+```text
+$ auntie publish dist/mypkg-1.0.whl
+HTTP 403: publish disabled
+```
+
+Fix: add the allowlist.
+
+```toml
+[tool.auntiepypi.local]
+host = "0.0.0.0"
+cert = "/etc/ssl/private/auntie.pem"
+key  = "/etc/ssl/private/auntie.key"
+htpasswd = "/etc/auntie/htpasswd"
+publish_users = ["alice"]
+```
+
+Then `auntie restart` (publish_users is read at server-start time, so
+the running server doesn't pick up the change otherwise). Now
+`auntie publish` succeeds.
+
+## Remediation example: "I rotated a user out of htpasswd"
+
+Operator removes `alice` from htpasswd but leaves `publish_users` as
+`["alice"]`:
+
+```text
+$ auntie up
+ServerConfigError:
+  [tool.auntiepypi.local] publish_users[0] = 'alice' is not present in
+  /etc/auntie/htpasswd. Either remove from publish_users or re-add to
+  htpasswd.
+```
+
+This is the cross-validator's job. The error fires at config-load
+time so misconfigurations don't get silently shipped.
+
+## Verification
+
+The v0.8.0 plan's verification gauntlet (TLS + auth + publish smoke,
+twine-compat smoke, idempotence check, authz failure path) lives in
+the plan file at `~/.claude/plans/dazzling-snacking-kay.md`.
+
+Quality pipeline (same as v0.7.0):
+
+- `pytest -n auto --cov=auntiepypi`, coverage ≥ 94%
+- `black`, `isort`, `flake8`, `pylint --errors-only`, `bandit`
+- `markdownlint-cli2`
+- `bash .claude/skills/pr-review/scripts/portability-lint.sh`
+
+Expected SonarCloud findings (and resolutions):
+
+- `python:S5443` (`tempfile.NamedTemporaryFile(dir=...)`) on
+  `_publish.write_upload`. NOSONAR with rationale: `dir` is
+  operator-controlled `cfg.root`, not `/tmp`; operating-system temp
+  dir would defeat the same-filesystem-rename invariant.
+- `python:S2068` (hardcoded password) on test fixtures using `secret`
+  / `fixture-pw`. NOSONAR; test-only, never deployed.
+- `python:S5332` (HTTP-without-TLS) on test fixtures — carryover
+  pattern from v0.7.0; NOSONAR with rationale.
+- No new code smells expected; the upload flow is a sequence of small
+  helpers (parse, validate, write) each well under cognitive-complexity
+  budget.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auntiepypi"
-version = "0.7.0"
+version = "0.8.0"
 description = "auntiepypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_actions_auntie.py
+++ b/tests/test_actions_auntie.py
@@ -124,6 +124,74 @@ def test_argv_full_bundle(tmp_path):
     assert "--htpasswd" in argv
 
 
+def test_argv_omits_publish_flags_when_unconfigured(tmp_path):
+    """v0.7.0 pyprojects (no publish_users / no max_upload_bytes
+    override) get the same argv as before — no new flags appended."""
+    cfg = LocalConfig(host="127.0.0.1", root=tmp_path / "wheels")
+    argv = _auntie._argv(cfg)
+    assert "--publish-user" not in argv
+    assert "--max-upload-bytes" not in argv
+
+
+def test_argv_appends_publish_users_one_flag_per_name(tmp_path):
+    """argparse `action="append"` requires --publish-user repeated."""
+    htp = tmp_path / "htp"
+    cfg = LocalConfig(
+        root=tmp_path / "wheels",
+        htpasswd=htp,
+        publish_users=("alice", "bob"),
+    )
+    argv = _auntie._argv(cfg)
+    # The flag appears twice, each followed by a name in order.
+    assert argv.count("--publish-user") == 2
+    idx_alice = argv.index("alice")
+    idx_bob = argv.index("bob")
+    # Each --publish-user precedes its name.
+    assert argv[idx_alice - 1] == "--publish-user"
+    assert argv[idx_bob - 1] == "--publish-user"
+
+
+def test_argv_appends_max_upload_bytes_when_overridden(tmp_path):
+    cfg = LocalConfig(
+        root=tmp_path / "wheels",
+        max_upload_bytes=2 * 1024 * 1024 * 1024,
+    )
+    argv = _auntie._argv(cfg)
+    assert "--max-upload-bytes" in argv
+    idx = argv.index("--max-upload-bytes")
+    assert argv[idx + 1] == str(2 * 1024 * 1024 * 1024)
+
+
+def test_argv_omits_max_upload_bytes_at_default(tmp_path):
+    """The default cap doesn't need an explicit flag — argv stays terse."""
+    cfg = LocalConfig(
+        root=tmp_path / "wheels",
+        max_upload_bytes=100 * 1024 * 1024,  # the default
+    )
+    argv = _auntie._argv(cfg)
+    assert "--max-upload-bytes" not in argv
+
+
+def test_argv_full_v8_bundle(tmp_path):
+    cert = tmp_path / "c.pem"
+    key = tmp_path / "k.pem"
+    htp = tmp_path / "htp"
+    cfg = LocalConfig(
+        host="127.0.0.1",
+        port=3141,
+        root=tmp_path / "wheels",
+        cert=cert,
+        key=key,
+        htpasswd=htp,
+        publish_users=("alice",),
+        max_upload_bytes=42 * 1024 * 1024,
+    )
+    argv = _auntie._argv(cfg)
+    for flag in ("--cert", "--key", "--htpasswd", "--publish-user", "--max-upload-bytes"):
+        assert flag in argv, f"missing {flag} in {argv}"
+    assert argv[argv.index("--publish-user") + 1] == "alice"
+
+
 # --------- ACTIONS registration ---------
 
 

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -127,14 +127,16 @@ def test_insecure_skip_verify_default_off(monkeypatch):
 
 
 def test_insecure_skip_verify_recognises_truthy(monkeypatch):
-    monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", "1")
-    assert insecure_skip_verify_enabled() is True
-    monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", "yes")
-    assert insecure_skip_verify_enabled() is True
+    for truthy in ("1", "true", "TRUE", "True", "yes", "YES", "on", "ON", "  yes  "):
+        monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", truthy)
+        assert insecure_skip_verify_enabled() is True, truthy
 
 
 def test_insecure_skip_verify_recognises_falsy(monkeypatch):
-    for falsy in ("", "0", "false", "False"):
+    """All non-allowlisted values (including FALSE/No/off/typos) leave
+    verification on. Defaulting to 'verify' is the safer side for a
+    security knob."""
+    for falsy in ("", "0", "false", "False", "FALSE", "no", "No", "off", "OFF", "anything"):
         monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", falsy)
         assert insecure_skip_verify_enabled() is False, falsy
 
@@ -345,9 +347,9 @@ def test_publish_verb_registered_in_main_parser():
     parser = _build_parser()
     # Smoke test — ensure `publish` parses without error.
     with mock.patch.object(publish_cmd, "cmd_publish", return_value=0):
-        args = parser.parse_args(["publish", "/tmp/x.whl"])  # noqa: S108
+        args = parser.parse_args(["publish", "/tmp/x.whl"])  # noqa: S108  # NOSONAR python:S5443
         assert args.command == "publish"
-        assert args.path == Path("/tmp/x.whl")  # noqa: S108
+        assert args.path == Path("/tmp/x.whl")  # noqa: S108  # NOSONAR python:S5443
 
 
 # --------- coverage closeouts ---------

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -17,7 +17,6 @@ from auntiepypi.cli._commands._publish_client import (
     post,
 )
 
-
 # --------- build_multipart cross-check via the server-side parser ---------
 
 
@@ -41,9 +40,7 @@ def test_build_multipart_roundtrips_through_server_parser():
 
 def test_build_multipart_handles_arbitrary_bytes():
     binary = bytes(range(256))
-    body, ctype = build_multipart(
-        binary, "mypkg-1.0-py3-none-any.whl", "mypkg", "1.0"
-    )
+    body, ctype = build_multipart(binary, "mypkg-1.0-py3-none-any.whl", "mypkg", "1.0")
     from auntiepypi._server._multipart import parse_multipart_upload
 
     fields = parse_multipart_upload(ctype, body, max_bytes=10 * 1024 * 1024)
@@ -66,9 +63,7 @@ def test_post_returns_status_and_body_on_2xx(monkeypatch):
         def read(self):
             return b'{"ok": true}'
 
-    monkeypatch.setattr(
-        "urllib.request.urlopen", lambda *a, **kw: _FakeResp()
-    )
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **kw: _FakeResp())
     status, body = post(
         "http://127.0.0.1:3141/",  # noqa: S104  # NOSONAR python:S5332
         b"body",
@@ -158,9 +153,7 @@ def wheel_file(tmp_path: Path) -> Path:
 def loopback_pyproject(tmp_path: Path, monkeypatch) -> Path:
     """Set CWD to a tmp project with a loopback [tool.auntiepypi.local]."""
     (tmp_path / "pyproject.toml").write_text(
-        "[tool.auntiepypi.local]\n"
-        'host = "127.0.0.1"\n'
-        "port = 3141\n"
+        "[tool.auntiepypi.local]\n" 'host = "127.0.0.1"\n' "port = 3141\n"
     )
     monkeypatch.chdir(tmp_path)
     return tmp_path
@@ -170,9 +163,7 @@ def _args_for(path: Path, json_mode: bool = False) -> argparse.Namespace:
     return argparse.Namespace(path=path, json=json_mode, func=publish_cmd.cmd_publish)
 
 
-def test_cmd_publish_201_exits_0(
-    monkeypatch, wheel_file, loopback_pyproject, capsys
-):
+def test_cmd_publish_201_exits_0(monkeypatch, wheel_file, loopback_pyproject, capsys):
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
     monkeypatch.setattr(
@@ -199,9 +190,7 @@ def test_cmd_publish_201_exits_0(
 def test_cmd_publish_409_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
-    monkeypatch.setattr(
-        publish_cmd, "post", lambda *a, **kw: (409, b"file already exists\n")
-    )
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (409, b"file already exists\n"))
     rc = publish_cmd.cmd_publish(_args_for(wheel_file))
     assert rc == 1
     err = capsys.readouterr().err
@@ -221,9 +210,7 @@ def test_cmd_publish_401_exits_1(monkeypatch, wheel_file, loopback_pyproject, ca
 def test_cmd_publish_403_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "bob")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "hunter2")
-    monkeypatch.setattr(
-        publish_cmd, "post", lambda *a, **kw: (403, b"user 'bob' cannot publish\n")
-    )
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (403, b"user 'bob' cannot publish\n"))
     rc = publish_cmd.cmd_publish(_args_for(wheel_file))
     assert rc == 1
     err = capsys.readouterr().err
@@ -234,9 +221,7 @@ def test_cmd_publish_403_exits_1(monkeypatch, wheel_file, loopback_pyproject, ca
 def test_cmd_publish_413_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
-    monkeypatch.setattr(
-        publish_cmd, "post", lambda *a, **kw: (413, b"upload too large\n")
-    )
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (413, b"upload too large\n"))
     rc = publish_cmd.cmd_publish(_args_for(wheel_file))
     assert rc == 1
     assert "413" in capsys.readouterr().err
@@ -290,9 +275,7 @@ def test_cmd_publish_json_mode(monkeypatch, wheel_file, loopback_pyproject, caps
     assert payload["filename"] == "mypkg-1.0-py3-none-any.whl"
 
 
-def test_cmd_publish_env_creds_bypass_prompts(
-    monkeypatch, wheel_file, loopback_pyproject
-):
+def test_cmd_publish_env_creds_bypass_prompts(monkeypatch, wheel_file, loopback_pyproject):
     """When both env vars are set, neither input() nor getpass() is called."""
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
@@ -306,21 +289,17 @@ def test_cmd_publish_env_creds_bypass_prompts(
     assert publish_cmd.cmd_publish(_args_for(wheel_file)) == 0
 
 
-def test_cmd_publish_picks_https_when_tls_configured(
-    monkeypatch, wheel_file, tmp_path: Path
-):
+def test_cmd_publish_picks_https_when_tls_configured(monkeypatch, wheel_file, tmp_path: Path):
     """When pyproject configures cert/key, the URL becomes https://."""
     (tmp_path / "c.pem").write_text("cert")
     (tmp_path / "k.pem").write_text("key")
-    (tmp_path / "pyproject.toml").write_text(
-        f"""
+    (tmp_path / "pyproject.toml").write_text(f"""
         [tool.auntiepypi.local]
         host = "127.0.0.1"
         port = 3141
         cert = "{tmp_path / 'c.pem'}"
         key  = "{tmp_path / 'k.pem'}"
-        """
-    )
+        """)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
@@ -336,21 +315,17 @@ def test_cmd_publish_picks_https_when_tls_configured(
     assert captured["url"].startswith("https://")
 
 
-def test_cmd_publish_warns_on_insecure_skip_verify(
-    monkeypatch, wheel_file, tmp_path: Path, capsys
-):
+def test_cmd_publish_warns_on_insecure_skip_verify(monkeypatch, wheel_file, tmp_path: Path, capsys):
     """Setting AUNTIE_INSECURE_SKIP_VERIFY=1 must emit a stderr warning."""
     (tmp_path / "c.pem").write_text("cert")
     (tmp_path / "k.pem").write_text("key")
-    (tmp_path / "pyproject.toml").write_text(
-        f"""
+    (tmp_path / "pyproject.toml").write_text(f"""
         [tool.auntiepypi.local]
         host = "127.0.0.1"
         port = 3141
         cert = "{tmp_path / 'c.pem'}"
         key  = "{tmp_path / 'k.pem'}"
-        """
-    )
+        """)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
     monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
@@ -373,3 +348,92 @@ def test_publish_verb_registered_in_main_parser():
         args = parser.parse_args(["publish", "/tmp/x.whl"])  # noqa: S108
         assert args.command == "publish"
         assert args.path == Path("/tmp/x.whl")  # noqa: S108
+
+
+# --------- coverage closeouts ---------
+
+
+def test_resolve_creds_non_tty_without_env_exits_2(
+    monkeypatch, wheel_file, loopback_pyproject, capsys
+):
+    """Non-interactive run without env vars must exit 2, not block."""
+    monkeypatch.delenv("AUNTIE_PUBLISH_USER", raising=False)
+    monkeypatch.delenv("AUNTIE_PUBLISH_PASSWORD", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    with pytest.raises(SystemExit) as exc:
+        publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert exc.value.code == 2
+    assert "missing credentials" in capsys.readouterr().err
+
+
+def test_resolve_creds_interactive_prompt_used(monkeypatch, wheel_file, loopback_pyproject):
+    """When env vars are missing but TTY is attached, prompt for both."""
+    monkeypatch.delenv("AUNTIE_PUBLISH_USER", raising=False)
+    monkeypatch.delenv("AUNTIE_PUBLISH_PASSWORD", raising=False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *_: "alice")
+    monkeypatch.setattr("getpass.getpass", lambda *_: "secret")
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (201, b'{"ok": true}'))
+    assert publish_cmd.cmd_publish(_args_for(wheel_file)) == 0
+
+
+def test_emit_success_handles_non_json_body(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    """Server might respond 2xx with plain text; CLI must not crash."""
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (200, b"ok"))
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # No filename in the response → falls back to <unknown>
+    assert "published" in out
+
+
+def test_emit_failure_json_mode(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    """JSON-mode failure prints structured payload, not text."""
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (409, b"file already exists\n"))
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file, json_mode=True))
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["status"] == 409
+
+
+def test_post_uses_default_verifying_context_for_https(monkeypatch):
+    """verify=True on https URL → ssl.create_default_context() in play."""
+    captured: dict[str, object] = {}
+
+    class _FakeResp:
+        status = 201
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def fake_urlopen(req, timeout, context):
+        captured["context"] = context
+        return _FakeResp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    post(
+        "https://127.0.0.1:3141/",
+        b"x",
+        "ct",
+        "alice",
+        "secret",
+        verify=True,
+    )
+    import ssl as _ssl
+
+    # The default verifying context has CERT_REQUIRED + check_hostname=True.
+    ctx = captured["context"]
+    assert isinstance(ctx, _ssl.SSLContext)
+    assert ctx.verify_mode == _ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -1,0 +1,375 @@
+"""Tests for ``auntie publish`` (CLI verb + multipart client)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from auntiepypi.cli._commands import publish as publish_cmd
+from auntiepypi.cli._commands._publish_client import (
+    build_multipart,
+    insecure_skip_verify_enabled,
+    post,
+)
+
+
+# --------- build_multipart cross-check via the server-side parser ---------
+
+
+def test_build_multipart_roundtrips_through_server_parser():
+    """The body build_multipart() emits must parse cleanly with the
+    server-side parse_multipart_upload — same shape, same fields."""
+    from auntiepypi._server._multipart import parse_multipart_upload
+
+    body, ctype = build_multipart(
+        b"WHEEL-BYTES",
+        "mypkg-1.0-py3-none-any.whl",
+        "mypkg",
+        "1.0",
+    )
+    fields = parse_multipart_upload(ctype, body, max_bytes=10 * 1024 * 1024)
+    assert fields.action == "file_upload"
+    assert fields.name == "mypkg"
+    assert fields.filename == "mypkg-1.0-py3-none-any.whl"
+    assert fields.content == b"WHEEL-BYTES"
+
+
+def test_build_multipart_handles_arbitrary_bytes():
+    binary = bytes(range(256))
+    body, ctype = build_multipart(
+        binary, "mypkg-1.0-py3-none-any.whl", "mypkg", "1.0"
+    )
+    from auntiepypi._server._multipart import parse_multipart_upload
+
+    fields = parse_multipart_upload(ctype, body, max_bytes=10 * 1024 * 1024)
+    assert fields.content == binary
+
+
+# --------- post() — error mapping ---------
+
+
+def test_post_returns_status_and_body_on_2xx(monkeypatch):
+    class _FakeResp:
+        status = 201
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def read(self):
+            return b'{"ok": true}'
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *a, **kw: _FakeResp()
+    )
+    status, body = post(
+        "http://127.0.0.1:3141/",  # noqa: S104  # NOSONAR python:S5332
+        b"body",
+        "multipart/form-data; boundary=x",
+        "alice",
+        "secret",
+    )
+    assert status == 201
+    assert body == b'{"ok": true}'
+
+
+def test_post_maps_httperror_to_status_and_body(monkeypatch):
+    import urllib.error
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            urllib.error.HTTPError(
+                "http://127.0.0.1/",  # NOSONAR python:S5332
+                409,
+                "Conflict",
+                hdrs=None,
+                fp=BytesIO(b"file already exists"),
+            )
+        ),
+    )
+    status, body = post(
+        "http://127.0.0.1:3141/",  # noqa: S104  # NOSONAR python:S5332
+        b"x",
+        "ct",
+        "alice",
+        "secret",
+    )
+    assert status == 409
+    assert body == b"file already exists"
+
+
+def test_post_propagates_urlerror(monkeypatch):
+    import urllib.error
+
+    def boom(*a, **kw):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    with pytest.raises(urllib.error.URLError):
+        post(
+            "http://127.0.0.1:3141/",  # noqa: S104  # NOSONAR python:S5332
+            b"x",
+            "ct",
+            "alice",
+            "secret",
+        )
+
+
+# --------- insecure_skip_verify_enabled ---------
+
+
+def test_insecure_skip_verify_default_off(monkeypatch):
+    monkeypatch.delenv("AUNTIE_INSECURE_SKIP_VERIFY", raising=False)
+    assert insecure_skip_verify_enabled() is False
+
+
+def test_insecure_skip_verify_recognises_truthy(monkeypatch):
+    monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", "1")
+    assert insecure_skip_verify_enabled() is True
+    monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", "yes")
+    assert insecure_skip_verify_enabled() is True
+
+
+def test_insecure_skip_verify_recognises_falsy(monkeypatch):
+    for falsy in ("", "0", "false", "False"):
+        monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", falsy)
+        assert insecure_skip_verify_enabled() is False, falsy
+
+
+# --------- cmd_publish — end-to-end with monkey-patched post() ---------
+
+
+@pytest.fixture
+def wheel_file(tmp_path: Path) -> Path:
+    p = tmp_path / "mypkg-1.0-py3-none-any.whl"
+    p.write_bytes(b"PK\x03\x04demo")
+    return p
+
+
+@pytest.fixture
+def loopback_pyproject(tmp_path: Path, monkeypatch) -> Path:
+    """Set CWD to a tmp project with a loopback [tool.auntiepypi.local]."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.auntiepypi.local]\n"
+        'host = "127.0.0.1"\n'
+        "port = 3141\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _args_for(path: Path, json_mode: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(path=path, json=json_mode, func=publish_cmd.cmd_publish)
+
+
+def test_cmd_publish_201_exits_0(
+    monkeypatch, wheel_file, loopback_pyproject, capsys
+):
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(
+        publish_cmd,
+        "post",
+        lambda *a, **kw: (
+            201,
+            json.dumps(
+                {
+                    "ok": True,
+                    "filename": "mypkg-1.0-py3-none-any.whl",
+                    "url": "/files/mypkg-1.0-py3-none-any.whl",
+                }
+            ).encode(),
+        ),
+    )
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "published" in out
+    assert "mypkg-1.0-py3-none-any.whl" in out
+
+
+def test_cmd_publish_409_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(
+        publish_cmd, "post", lambda *a, **kw: (409, b"file already exists\n")
+    )
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "409" in err
+    assert "exists" in err
+
+
+def test_cmd_publish_401_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "wrong")
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (401, b"401 Unauthorized\n"))
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 1
+    assert "401" in capsys.readouterr().err
+
+
+def test_cmd_publish_403_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "bob")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "hunter2")
+    monkeypatch.setattr(
+        publish_cmd, "post", lambda *a, **kw: (403, b"user 'bob' cannot publish\n")
+    )
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "403" in err
+    assert "bob" in err
+
+
+def test_cmd_publish_413_exits_1(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(
+        publish_cmd, "post", lambda *a, **kw: (413, b"upload too large\n")
+    )
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 1
+    assert "413" in capsys.readouterr().err
+
+
+def test_cmd_publish_urlerror_exits_2(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    import urllib.error
+
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+
+    def boom(*a, **kw):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(publish_cmd, "post", boom)
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert rc == 2
+    assert "transport error" in capsys.readouterr().err
+
+
+def test_cmd_publish_missing_file_exits_2(loopback_pyproject, capsys):
+    rc = publish_cmd.cmd_publish(_args_for(loopback_pyproject / "no-such.whl"))
+    assert rc == 2
+    assert "file not found" in capsys.readouterr().err
+
+
+def test_cmd_publish_unparseable_filename_exits_2(loopback_pyproject, capsys):
+    bogus = loopback_pyproject / "not-a-wheel.txt"
+    bogus.write_bytes(b"x")
+    rc = publish_cmd.cmd_publish(_args_for(bogus))
+    assert rc == 2
+    assert "not a recognized" in capsys.readouterr().err
+
+
+def test_cmd_publish_json_mode(monkeypatch, wheel_file, loopback_pyproject, capsys):
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(
+        publish_cmd,
+        "post",
+        lambda *a, **kw: (
+            201,
+            json.dumps({"ok": True, "filename": "mypkg-1.0-py3-none-any.whl"}).encode(),
+        ),
+    )
+    rc = publish_cmd.cmd_publish(_args_for(wheel_file, json_mode=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert payload["filename"] == "mypkg-1.0-py3-none-any.whl"
+
+
+def test_cmd_publish_env_creds_bypass_prompts(
+    monkeypatch, wheel_file, loopback_pyproject
+):
+    """When both env vars are set, neither input() nor getpass() is called."""
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (201, b'{"ok": true}'))
+
+    def fail_input(*a, **kw):
+        raise AssertionError("input() called when env creds were set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+    monkeypatch.setattr("getpass.getpass", fail_input)
+    assert publish_cmd.cmd_publish(_args_for(wheel_file)) == 0
+
+
+def test_cmd_publish_picks_https_when_tls_configured(
+    monkeypatch, wheel_file, tmp_path: Path
+):
+    """When pyproject configures cert/key, the URL becomes https://."""
+    (tmp_path / "c.pem").write_text("cert")
+    (tmp_path / "k.pem").write_text("key")
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+        [tool.auntiepypi.local]
+        host = "127.0.0.1"
+        port = 3141
+        cert = "{tmp_path / 'c.pem'}"
+        key  = "{tmp_path / 'k.pem'}"
+        """
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+
+    captured: dict[str, str] = {}
+
+    def capture(url, body, ctype, user, pw, **kw):  # noqa: ANN001
+        captured["url"] = url
+        return 201, b'{"ok": true}'
+
+    monkeypatch.setattr(publish_cmd, "post", capture)
+    publish_cmd.cmd_publish(_args_for(wheel_file))
+    assert captured["url"].startswith("https://")
+
+
+def test_cmd_publish_warns_on_insecure_skip_verify(
+    monkeypatch, wheel_file, tmp_path: Path, capsys
+):
+    """Setting AUNTIE_INSECURE_SKIP_VERIFY=1 must emit a stderr warning."""
+    (tmp_path / "c.pem").write_text("cert")
+    (tmp_path / "k.pem").write_text("key")
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+        [tool.auntiepypi.local]
+        host = "127.0.0.1"
+        port = 3141
+        cert = "{tmp_path / 'c.pem'}"
+        key  = "{tmp_path / 'k.pem'}"
+        """
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUNTIE_PUBLISH_USER", "alice")
+    monkeypatch.setenv("AUNTIE_PUBLISH_PASSWORD", "secret")
+    monkeypatch.setenv("AUNTIE_INSECURE_SKIP_VERIFY", "1")
+    monkeypatch.setattr(publish_cmd, "post", lambda *a, **kw: (201, b'{"ok": true}'))
+    publish_cmd.cmd_publish(_args_for(wheel_file))
+    err = capsys.readouterr().err
+    assert "INSECURE" in err.upper() or "verification disabled" in err
+
+
+# --------- registration ---------
+
+
+def test_publish_verb_registered_in_main_parser():
+    from auntiepypi.cli import _build_parser
+
+    parser = _build_parser()
+    # Smoke test — ensure `publish` parses without error.
+    with mock.patch.object(publish_cmd, "cmd_publish", return_value=0):
+        args = parser.parse_args(["publish", "/tmp/x.whl"])  # noqa: S108
+        assert args.command == "publish"
+        assert args.path == Path("/tmp/x.whl")  # noqa: S108

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -78,18 +78,16 @@ def test_post_returns_status_and_body_on_2xx(monkeypatch):
 def test_post_maps_httperror_to_status_and_body(monkeypatch):
     import urllib.error
 
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *a, **kw: (_ for _ in ()).throw(
-            urllib.error.HTTPError(
-                "http://127.0.0.1/",  # NOSONAR python:S5332
-                409,
-                "Conflict",
-                hdrs=None,
-                fp=BytesIO(b"file already exists"),
-            )
-        ),
-    )
+    def raise_http_409(*_a, **_kw):
+        raise urllib.error.HTTPError(
+            "http://127.0.0.1/",  # NOSONAR python:S5332
+            409,
+            "Conflict",
+            hdrs=None,
+            fp=BytesIO(b"file already exists"),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", raise_http_409)
     status, body = post(
         "http://127.0.0.1:3141/",  # noqa: S104  # NOSONAR python:S5332
         b"x",

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -623,14 +623,21 @@ def test_load_local_config_rejects_publish_users_without_htpasswd(tmp_path):
         load_local_config(tmp_path)
 
 
-def test_load_local_config_rejects_publish_user_not_in_htpasswd(tmp_path, monkeypatch):
-    """Cross-validator catches a publish_users name that isn't an htpasswd entry."""
+def test_load_local_config_does_not_read_htpasswd(tmp_path, monkeypatch):
+    """``load_local_config`` MUST NOT parse the htpasswd file.
+
+    Detection paths call ``load_local_config`` to discover host/port —
+    teaching the loader to read credential stores would leak that
+    parsing into every probe. The publish_users / htpasswd
+    cross-check moved to the server-start path
+    (``_actions.auntie._verify_tls_auth_paths`` and
+    ``_server.__main__.main``) precisely because of this rule.
+    """
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     htp = tmp_path / "htpasswd"
     import bcrypt
 
     h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
-    # Only alice in htpasswd, but publish_users names eve.
     htp.write_bytes(b"alice:" + h + b"\n")
     _write_pyproject(
         tmp_path,
@@ -640,16 +647,14 @@ def test_load_local_config_rejects_publish_user_not_in_htpasswd(tmp_path, monkey
         publish_users = ["alice", "eve"]
         """,
     )
-    with pytest.raises(ServerConfigError, match=r"publish_users contains name.*'eve'"):
-        load_local_config(tmp_path)
+    # Must NOT raise — the cross-check is server-start scope, not load.
+    # 'eve' isn't in htpasswd, but that's caught later, not here.
+    cfg = load_local_config(tmp_path)
+    assert cfg.publish_users == ("alice", "eve")
 
 
-def test_load_local_config_publish_users_membership_skipped_when_htpasswd_missing(
-    tmp_path, monkeypatch
-):
-    """If htpasswd file doesn't exist, the membership check skips silently —
-    the strategy will surface a clearer 'cannot read htpasswd' error at
-    server-start time."""
+def test_load_local_config_publish_users_no_htpasswd_read_when_file_missing(tmp_path, monkeypatch):
+    """Even with a missing htpasswd path, load_local_config doesn't try to read it."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     htp = tmp_path / "missing.htpasswd"  # never created
     _write_pyproject(

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -557,7 +557,10 @@ def test_load_local_config_loads_publish_users(tmp_path, monkeypatch):
     # Real bcrypt entries — the validator parses the file.
     import bcrypt
 
-    h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+    h = bcrypt.hashpw(  # NOSONAR python:S5344 - test fixture; production cost ≥ 12
+        b"pw",  # noqa: S106  # NOSONAR python:S6437,python:S2068 - test fixture
+        bcrypt.gensalt(rounds=4),  # NOSONAR python:S5344
+    )
     htp.write_bytes(b"alice:" + h + b"\nbob:" + h + b"\n")
     _write_pyproject(
         tmp_path,
@@ -637,7 +640,10 @@ def test_load_local_config_does_not_read_htpasswd(tmp_path, monkeypatch):
     htp = tmp_path / "htpasswd"
     import bcrypt
 
-    h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+    h = bcrypt.hashpw(  # NOSONAR python:S5344 - test fixture; production cost ≥ 12
+        b"pw",  # noqa: S106  # NOSONAR python:S6437,python:S2068 - test fixture
+        bcrypt.gensalt(rounds=4),  # NOSONAR python:S5344
+    )
     htp.write_bytes(b"alice:" + h + b"\n")
     _write_pyproject(
         tmp_path,
@@ -712,7 +718,10 @@ def test_load_local_config_publish_users_empty_list_is_read_only(tmp_path, monke
     htp = tmp_path / "htpasswd"
     import bcrypt
 
-    h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+    h = bcrypt.hashpw(  # NOSONAR python:S5344 - test fixture; production cost ≥ 12
+        b"pw",  # noqa: S106  # NOSONAR python:S6437,python:S2068 - test fixture
+        bcrypt.gensalt(rounds=4),  # NOSONAR python:S5344
+    )
     htp.write_bytes(b"alice:" + h + b"\n")
     _write_pyproject(
         tmp_path,

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -545,3 +545,175 @@ def test_localconfig_publish_users_is_tuple_for_freezable():
 def test_localconfig_max_upload_bytes_overridable():
     cfg = LocalConfig(max_upload_bytes=2 * 1024 * 1024 * 1024)
     assert cfg.max_upload_bytes == 2 * 1024 * 1024 * 1024
+
+
+# --------- v0.8.0 publish_users / max_upload_bytes validators ---------
+
+
+def test_load_local_config_loads_publish_users(tmp_path, monkeypatch):
+    """Reading publish_users requires htpasswd; supply one."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    htp = tmp_path / "htpasswd"
+    # Real bcrypt entries — the validator parses the file.
+    import bcrypt
+    h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+    htp.write_bytes(b"alice:" + h + b"\nbob:" + h + b"\n")
+    _write_pyproject(
+        tmp_path,
+        f"""
+        [tool.auntiepypi.local]
+        htpasswd = "{htp}"
+        publish_users = ["alice", "bob"]
+        max_upload_bytes = 209715200
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.publish_users == ("alice", "bob")
+    assert cfg.max_upload_bytes == 209715200
+    assert cfg.publish_enabled is True
+
+
+def test_load_local_config_rejects_publish_users_not_a_list(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        publish_users = "alice"
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"publish_users.*list of strings"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_publish_users_with_empty_string(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        publish_users = ["alice", ""]
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"publish_users\[1\].*non-empty"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_publish_users_with_non_string(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        publish_users = ["alice", 42]
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"publish_users\[1\].*non-empty"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_publish_users_without_htpasswd(tmp_path):
+    """Authorization without authentication is a hard error."""
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        publish_users = ["alice"]
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"publish_users.*requires.*htpasswd"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_publish_user_not_in_htpasswd(tmp_path, monkeypatch):
+    """Cross-validator catches a publish_users name that isn't an htpasswd entry."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    htp = tmp_path / "htpasswd"
+    import bcrypt
+    h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+    # Only alice in htpasswd, but publish_users names eve.
+    htp.write_bytes(b"alice:" + h + b"\n")
+    _write_pyproject(
+        tmp_path,
+        f"""
+        [tool.auntiepypi.local]
+        htpasswd = "{htp}"
+        publish_users = ["alice", "eve"]
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"publish_users contains name.*'eve'"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_publish_users_membership_skipped_when_htpasswd_missing(
+    tmp_path, monkeypatch
+):
+    """If htpasswd file doesn't exist, the membership check skips silently —
+    the strategy will surface a clearer 'cannot read htpasswd' error at
+    server-start time."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    htp = tmp_path / "missing.htpasswd"   # never created
+    _write_pyproject(
+        tmp_path,
+        f"""
+        [tool.auntiepypi.local]
+        htpasswd = "{htp}"
+        publish_users = ["alice"]
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.publish_users == ("alice",)
+
+
+def test_load_local_config_rejects_max_upload_bytes_not_int(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        max_upload_bytes = "104857600"
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"max_upload_bytes.*integer"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_max_upload_bytes_too_small(tmp_path):
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        max_upload_bytes = 100
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"max_upload_bytes.*>= 1024"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_rejects_max_upload_bytes_bool(tmp_path):
+    """`true` must not pass the int check (Python bool is an int subclass)."""
+    _write_pyproject(
+        tmp_path,
+        """
+        [tool.auntiepypi.local]
+        max_upload_bytes = true
+        """,
+    )
+    with pytest.raises(ServerConfigError, match=r"max_upload_bytes.*integer"):
+        load_local_config(tmp_path)
+
+
+def test_load_local_config_publish_users_empty_list_is_read_only(tmp_path, monkeypatch):
+    """An explicit empty publish_users list is the same as unset: read-only."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    htp = tmp_path / "htpasswd"
+    import bcrypt
+    h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+    htp.write_bytes(b"alice:" + h + b"\n")
+    _write_pyproject(
+        tmp_path,
+        f"""
+        [tool.auntiepypi.local]
+        htpasswd = "{htp}"
+        publish_users = []
+        """,
+    )
+    cfg = load_local_config(tmp_path)
+    assert cfg.publish_users == ()
+    assert cfg.publish_enabled is False

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -510,3 +510,38 @@ def test_load_local_config_localhost_with_cert_only_rejected(tmp_path):
     )
     with pytest.raises(ServerConfigError, match=r"TLS pair incomplete"):
         load_local_config(tmp_path)
+
+
+# --------- v0.8.0: publish_users + max_upload_bytes ---------
+
+
+def test_localconfig_publish_defaults_off():
+    """Defaults: empty publish_users, 100 MiB cap, publish_enabled False."""
+    cfg = LocalConfig()
+    assert cfg.publish_users == ()
+    assert cfg.max_upload_bytes == 100 * 1024 * 1024
+    assert cfg.publish_enabled is False
+
+
+def test_localconfig_publish_enabled_requires_both_allowlist_and_auth(tmp_path):
+    """publish_enabled is True only when publish_users non-empty AND auth_enabled."""
+    htp = tmp_path / "htpasswd"
+    # allowlist alone, no auth — False
+    assert LocalConfig(publish_users=("alice",)).publish_enabled is False
+    # auth alone, no allowlist — False
+    assert LocalConfig(htpasswd=htp).publish_enabled is False
+    # both — True
+    cfg = LocalConfig(htpasswd=htp, publish_users=("alice",))
+    assert cfg.publish_enabled is True
+
+
+def test_localconfig_publish_users_is_tuple_for_freezable():
+    """publish_users stored as tuple so the frozen dataclass stays hashable."""
+    cfg = LocalConfig(publish_users=("alice", "bob"))
+    assert isinstance(cfg.publish_users, tuple)
+    assert cfg.publish_users == ("alice", "bob")
+
+
+def test_localconfig_max_upload_bytes_overridable():
+    cfg = LocalConfig(max_upload_bytes=2 * 1024 * 1024 * 1024)
+    assert cfg.max_upload_bytes == 2 * 1024 * 1024 * 1024

--- a/tests/test_config_local.py
+++ b/tests/test_config_local.py
@@ -556,6 +556,7 @@ def test_load_local_config_loads_publish_users(tmp_path, monkeypatch):
     htp = tmp_path / "htpasswd"
     # Real bcrypt entries — the validator parses the file.
     import bcrypt
+
     h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
     htp.write_bytes(b"alice:" + h + b"\nbob:" + h + b"\n")
     _write_pyproject(
@@ -627,6 +628,7 @@ def test_load_local_config_rejects_publish_user_not_in_htpasswd(tmp_path, monkey
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     htp = tmp_path / "htpasswd"
     import bcrypt
+
     h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
     # Only alice in htpasswd, but publish_users names eve.
     htp.write_bytes(b"alice:" + h + b"\n")
@@ -649,7 +651,7 @@ def test_load_local_config_publish_users_membership_skipped_when_htpasswd_missin
     the strategy will surface a clearer 'cannot read htpasswd' error at
     server-start time."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-    htp = tmp_path / "missing.htpasswd"   # never created
+    htp = tmp_path / "missing.htpasswd"  # never created
     _write_pyproject(
         tmp_path,
         f"""
@@ -704,6 +706,7 @@ def test_load_local_config_publish_users_empty_list_is_read_only(tmp_path, monke
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     htp = tmp_path / "htpasswd"
     import bcrypt
+
     h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
     htp.write_bytes(b"alice:" + h + b"\n")
     _write_pyproject(

--- a/tests/test_server_app_auth.py
+++ b/tests/test_server_app_auth.py
@@ -164,22 +164,25 @@ def test_auth_does_not_bypass_path_traversal(served_with_auth):
     assert status == 404
 
 
-def test_post_still_405_with_auth(served_with_auth):
-    """POST is still rejected even with valid creds (read-only server)."""
+def test_post_rejected_when_publish_not_configured(served_with_auth):
+    """v0.7.0 fixture has auth but no publish_users — POST is auth-OK
+    but authz-rejected (403 'publish disabled'). Regression: POST
+    behaviour stays sealed when the operator hasn't opted into v0.8.0
+    publish authz.
+    """
     port, _, _ = served_with_auth
     conn = HTTPConnection("127.0.0.1", port, timeout=5)
     try:
         conn.request(
             "POST",
-            "/simple/",
+            "/",
             body=b"",
             headers={"Authorization": _basic_header("alice", "secret")},
         )
         resp = conn.getresponse()
-        assert resp.status in (401, 405, 501)
-        # Note: the auth check runs only in do_GET; POST takes a different
-        # code path in BaseHTTPRequestHandler (no do_POST defined → 501).
-        # Either outcome (401 from gate or 501 from no-handler) is fine.
+        # v0.7.0 fixture sets htpasswd_map but leaves publish_users
+        # at its default (empty tuple) → 403 publish disabled.
+        assert resp.status == 403
         resp.read()
     finally:
         conn.close()

--- a/tests/test_server_auth_user.py
+++ b/tests/test_server_auth_user.py
@@ -11,9 +11,15 @@ from __future__ import annotations
 import base64
 
 import bcrypt
+import pytest
 
 from auntiepypi._server import _auth
-from auntiepypi._server._auth import authenticate_user, verify_basic
+from auntiepypi._server._auth import (
+    PublishAuthzError,
+    assert_publish_users_in_htpasswd,
+    authenticate_user,
+    verify_basic,
+)
 
 
 def _bcrypt_hash(password: str) -> bytes:
@@ -150,3 +156,51 @@ def test_verify_basic_consistent_with_authenticate_user(monkeypatch):
 
 def test_authenticate_user_in_module_all():
     assert "authenticate_user" in _auth.__all__
+
+
+# --------- v0.8.0 publish-users / htpasswd cross-check ---------
+
+
+def _write_htpasswd(path, users):
+    """Write a tiny bcrypt-hashed htpasswd with the given user list."""
+    lines = []
+    for user in users:
+        h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+        lines.append(user.encode() + b":" + h)
+    path.write_bytes(b"\n".join(lines) + b"\n")
+
+
+def test_assert_publish_users_in_htpasswd_passes_for_complete_set(tmp_path):
+    htp = tmp_path / "htp"
+    _write_htpasswd(htp, ["alice", "bob"])
+    # No raise.
+    assert_publish_users_in_htpasswd(htp, ("alice", "bob"))
+
+
+def test_assert_publish_users_in_htpasswd_raises_on_missing_user(tmp_path):
+    htp = tmp_path / "htp"
+    _write_htpasswd(htp, ["alice"])
+    with pytest.raises(PublishAuthzError, match=r"'eve'"):
+        assert_publish_users_in_htpasswd(htp, ("alice", "eve"))
+
+
+def test_assert_publish_users_in_htpasswd_noop_when_publish_users_empty(tmp_path):
+    htp = tmp_path / "htp"
+    _write_htpasswd(htp, ["alice"])
+    # Empty → no read, no raise.
+    assert_publish_users_in_htpasswd(htp, ())
+
+
+def test_assert_publish_users_in_htpasswd_noop_when_htpasswd_none(tmp_path):
+    """Caller's existence check (``_verify_tls_auth_paths``) handles
+    the htpasswd-unset case before we get here."""
+    assert_publish_users_in_htpasswd(None, ("alice",))
+
+
+def test_assert_publish_users_in_htpasswd_silent_when_htpasswd_unreadable(tmp_path):
+    """A missing file produces a clearer error from the readability
+    pre-check; this helper falls through silently rather than
+    double-reporting."""
+    missing = tmp_path / "no-such.htpasswd"
+    # No raise.
+    assert_publish_users_in_htpasswd(missing, ("alice",))

--- a/tests/test_server_auth_user.py
+++ b/tests/test_server_auth_user.py
@@ -1,0 +1,152 @@
+"""Tests for `auntiepypi._server._auth.authenticate_user` (v0.8.0).
+
+The v0.8.0 primitive returns the username (or ``None``) instead of a
+bool. Every behavioural case from ``verify_basic`` has a counterpart
+here — wrong creds → None; valid → "alice"; cache hit returns the
+right user; rotation invalidates.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import bcrypt
+
+from auntiepypi._server import _auth
+from auntiepypi._server._auth import authenticate_user, verify_basic
+
+
+def _bcrypt_hash(password: str) -> bytes:
+    return bcrypt.hashpw(  # NOSONAR python:S5344 - test fixture; production cost ≥ 12
+        password.encode("utf-8"),
+        bcrypt.gensalt(rounds=4),  # NOSONAR python:S5344
+    )
+
+
+def _basic_header(user: str, password: str) -> str:
+    creds = f"{user}:{password}".encode("utf-8")
+    return "Basic " + base64.b64encode(creds).decode("ascii")
+
+
+# --------- happy paths ---------
+
+
+def test_authenticate_user_returns_username_on_valid_creds():
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    user = authenticate_user(_basic_header("alice", "secret"), htp)
+    assert user == "alice"
+
+
+def test_authenticate_user_picks_correct_user_among_multiple():
+    htp = {
+        "alice": _bcrypt_hash("alice-pw"),
+        "bob": _bcrypt_hash("bob-pw"),
+    }
+    assert authenticate_user(_basic_header("alice", "alice-pw"), htp) == "alice"
+    assert authenticate_user(_basic_header("bob", "bob-pw"), htp) == "bob"
+
+
+# --------- failure modes — every one returns None, never raises ---------
+
+
+def test_authenticate_user_missing_header_returns_none():
+    assert authenticate_user("", {"alice": _bcrypt_hash("pw")}) is None
+
+
+def test_authenticate_user_non_basic_scheme_returns_none():
+    assert authenticate_user("Bearer foo", {"alice": _bcrypt_hash("pw")}) is None
+
+
+def test_authenticate_user_malformed_b64_returns_none():
+    assert authenticate_user("Basic not_b64!!", {"alice": _bcrypt_hash("pw")}) is None
+
+
+def test_authenticate_user_wrong_password_returns_none():
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    assert authenticate_user(_basic_header("alice", "wrong"), htp) is None
+
+
+def test_authenticate_user_unknown_user_returns_none():
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    assert authenticate_user(_basic_header("eve", "secret"), htp) is None
+
+
+def test_authenticate_user_empty_table_returns_none():
+    assert authenticate_user(_basic_header("alice", "x"), {}) is None
+
+
+def test_authenticate_user_decoded_payload_without_colon_returns_none():
+    # Authorization: Basic <b64("nocolon")>
+    payload = base64.b64encode(b"nocolon").decode("ascii")
+    assert authenticate_user(f"Basic {payload}", {"alice": _bcrypt_hash("x")}) is None
+
+
+# --------- cache contract ---------
+
+
+def test_authenticate_user_cache_hit_returns_same_user():
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    header = _basic_header("alice", "secret")
+    # Prime the cache.
+    assert authenticate_user(header, htp) == "alice"
+    # Second call should reuse the cache (still alice).
+    assert authenticate_user(header, htp) == "alice"
+
+
+def test_authenticate_user_cache_invalidated_when_password_rotates():
+    """If the operator rotates alice's password and reloads the map,
+    the next authenticate_user call must re-verify, not return the
+    stale cached username with the old hash.
+    """
+    old_hash = _bcrypt_hash("old-pw")
+    new_hash = _bcrypt_hash("new-pw")
+    header = _basic_header("alice", "old-pw")
+    # Authenticate under old creds — populates the cache.
+    assert authenticate_user(header, {"alice": old_hash}) == "alice"
+    # Rotate the map; the cached entry's expected_hash no longer matches.
+    # Old creds must now fail to authenticate (re-verify against new hash).
+    assert authenticate_user(header, {"alice": new_hash}) is None
+    # Fresh creds against the new hash succeed.
+    new_header = _basic_header("alice", "new-pw")
+    assert authenticate_user(new_header, {"alice": new_hash}) == "alice"
+
+
+def test_authenticate_user_cache_invalidated_when_user_removed():
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    header = _basic_header("alice", "secret")
+    assert authenticate_user(header, htp) == "alice"
+    # Remove alice (operator ran `htpasswd -D`).
+    assert authenticate_user(header, {}) is None
+
+
+# --------- verify_basic delegates to authenticate_user ---------
+
+
+def test_verify_basic_is_thin_bool_adapter():
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    valid = _basic_header("alice", "secret")
+    invalid = _basic_header("alice", "wrong")
+    assert verify_basic(valid, htp) is True
+    assert verify_basic(invalid, htp) is False
+
+
+def test_verify_basic_consistent_with_authenticate_user(monkeypatch):
+    """For any inputs, ``verify_basic == (authenticate_user is not None)``."""
+    htp = {"alice": _bcrypt_hash("secret")}  # noqa: S106
+    cases = [
+        "",
+        "Bearer foo",
+        "Basic not_b64!!",
+        _basic_header("alice", "secret"),
+        _basic_header("alice", "wrong"),
+        _basic_header("eve", "secret"),
+    ]
+    for header in cases:
+        assert verify_basic(header, htp) == (authenticate_user(header, htp) is not None)
+
+
+# --------- module surface ---------
+
+
+def test_authenticate_user_in_module_all():
+    assert "authenticate_user" in _auth.__all__

--- a/tests/test_server_auth_user.py
+++ b/tests/test_server_auth_user.py
@@ -165,7 +165,10 @@ def _write_htpasswd(path, users):
     """Write a tiny bcrypt-hashed htpasswd with the given user list."""
     lines = []
     for user in users:
-        h = bcrypt.hashpw(b"pw", bcrypt.gensalt(rounds=4))  # noqa: S106
+        h = bcrypt.hashpw(  # NOSONAR python:S5344 - test fixture; production cost ≥ 12
+            b"pw",  # noqa: S106  # NOSONAR python:S6437,python:S2068 - test fixture
+            bcrypt.gensalt(rounds=4),  # NOSONAR python:S5344
+        )
         lines.append(user.encode() + b":" + h)
     path.write_bytes(b"\n".join(lines) + b"\n")
 

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -151,7 +151,7 @@ def test_parser_publish_user_repeatable():
     args = server_main._parser().parse_args(
         [
             "--root",
-            "/tmp/wh",  # noqa: S108
+            "/tmp/wh",  # noqa: S108  # NOSONAR python:S5443
             "--publish-user",
             "alice",
             "--publish-user",
@@ -162,18 +162,23 @@ def test_parser_publish_user_repeatable():
 
 
 def test_parser_publish_user_default_is_empty_list():
-    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108
+    args = server_main._parser().parse_args(
+        ["--root", "/tmp/wh"]  # noqa: S108  # NOSONAR python:S5443
+    )
     assert args.publish_user == []
 
 
 def test_parser_max_upload_bytes_default():
-    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108
+    args = server_main._parser().parse_args(
+        ["--root", "/tmp/wh"]  # noqa: S108  # NOSONAR python:S5443
+    )
     assert args.max_upload_bytes == 100 * 1024 * 1024
 
 
 def test_parser_max_upload_bytes_override():
+    fixture_root = "/tmp/wh"  # noqa: S108  # NOSONAR python:S5443
     args = server_main._parser().parse_args(
-        ["--root", "/tmp/wh", "--max-upload-bytes", "536870912"]  # noqa: S108
+        ["--root", fixture_root, "--max-upload-bytes", "536870912"]
     )
     assert args.max_upload_bytes == 536870912
 

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -71,23 +71,8 @@ def test_parser_tls_auth_flags_pass_through(tmp_path: Path):
 def test_main_calls_serve(monkeypatch, tmp_path):
     captured: dict[str, object] = {}
 
-    def fake_serve(
-        host: str,
-        port: int,
-        root: Path,
-        *,
-        ssl_context=None,
-        htpasswd_map=None,
-    ) -> None:
-        captured.update(
-            {
-                "host": host,
-                "port": port,
-                "root": root,
-                "ssl_context": ssl_context,
-                "htpasswd_map": htpasswd_map,
-            }
-        )
+    def fake_serve(host: str, port: int, root: Path, **kw) -> None:  # noqa: ANN003
+        captured.update({"host": host, "port": port, "root": root, **kw})
 
     monkeypatch.setattr(server_main, "serve", fake_serve)
     server_main.main(["--host", "127.0.0.1", "--port", "9999", "--root", str(tmp_path)])
@@ -96,6 +81,9 @@ def test_main_calls_serve(monkeypatch, tmp_path):
     assert captured["root"] == tmp_path
     assert captured["ssl_context"] is None
     assert captured["htpasswd_map"] is None
+    # v0.8.0 defaults: empty allowlist + 100 MiB cap
+    assert captured["publish_users"] == ()
+    assert captured["max_upload_bytes"] == 100 * 1024 * 1024
 
 
 def test_main_rejects_cert_without_key(tmp_path: Path):
@@ -114,8 +102,8 @@ def test_main_builds_ssl_context_when_pair_set(monkeypatch, tmp_path, tls_cert_p
     cert, key = tls_cert_pair
     captured: dict[str, object] = {}
 
-    def fake_serve(host, port, root, *, ssl_context=None, htpasswd_map=None):  # noqa: ANN001
-        captured["ssl_context"] = ssl_context
+    def fake_serve(host, port, root, **kw):  # noqa: ANN001
+        captured["ssl_context"] = kw.get("ssl_context")
 
     monkeypatch.setattr(server_main, "serve", fake_serve)
     server_main.main(
@@ -147,13 +135,70 @@ def test_main_parses_htpasswd_when_set(monkeypatch, tmp_path):
 
     captured: dict[str, object] = {}
 
-    def fake_serve(host, port, root, *, ssl_context=None, htpasswd_map=None):  # noqa: ANN001
-        captured["htpasswd_map"] = htpasswd_map
+    def fake_serve(host, port, root, **kw):  # noqa: ANN001
+        captured["htpasswd_map"] = kw.get("htpasswd_map")
 
     monkeypatch.setattr(server_main, "serve", fake_serve)
     server_main.main(["--root", str(tmp_path), "--htpasswd", str(htp)])
     assert isinstance(captured["htpasswd_map"], dict)
     assert "alice" in captured["htpasswd_map"]
+
+
+# --------- v0.8.0 publish flags ---------
+
+
+def test_parser_publish_user_repeatable():
+    args = server_main._parser().parse_args(
+        [
+            "--root",
+            "/tmp/wh",  # noqa: S108
+            "--publish-user",
+            "alice",
+            "--publish-user",
+            "bob",
+        ]
+    )
+    assert args.publish_user == ["alice", "bob"]
+
+
+def test_parser_publish_user_default_is_empty_list():
+    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108
+    assert args.publish_user == []
+
+
+def test_parser_max_upload_bytes_default():
+    args = server_main._parser().parse_args(["--root", "/tmp/wh"])  # noqa: S108
+    assert args.max_upload_bytes == 100 * 1024 * 1024
+
+
+def test_parser_max_upload_bytes_override():
+    args = server_main._parser().parse_args(
+        ["--root", "/tmp/wh", "--max-upload-bytes", "536870912"]  # noqa: S108
+    )
+    assert args.max_upload_bytes == 536870912
+
+
+def test_main_passes_publish_users_and_max_upload_bytes(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    def fake_serve(host, port, root, **kw):  # noqa: ANN001, ANN003
+        captured.update(kw)
+
+    monkeypatch.setattr(server_main, "serve", fake_serve)
+    server_main.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--publish-user",
+            "alice",
+            "--publish-user",
+            "bob",
+            "--max-upload-bytes",
+            "12345",
+        ]
+    )
+    assert captured["publish_users"] == ("alice", "bob")
+    assert captured["max_upload_bytes"] == 12345
 
 
 # --------- serve() integration ---------

--- a/tests/test_server_multipart.py
+++ b/tests/test_server_multipart.py
@@ -35,9 +35,7 @@ def _twine_body(content: bytes = b"WHEELBYTES", filename: str = "mypkg-1.0.whl")
             ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
             (
                 {
-                    "Content-Disposition": (
-                        f'form-data; name="content"; filename="{filename}"'
-                    ),
+                    "Content-Disposition": (f'form-data; name="content"; filename="{filename}"'),
                     "Content-Type": "application/octet-stream",
                 },
                 content,
@@ -85,9 +83,7 @@ def test_parse_ignores_extra_pypi_metadata_fields():
             ({"Content-Disposition": 'form-data; name="sha256_digest"'}, b"deadbeef"),
             (
                 {
-                    "Content-Disposition": (
-                        'form-data; name="content"; filename="mypkg-1.0.whl"'
-                    ),
+                    "Content-Disposition": ('form-data; name="content"; filename="mypkg-1.0.whl"'),
                 },
                 b"WHEELBYTES",
             ),
@@ -108,9 +104,7 @@ def test_parse_ignores_gpg_signature_part():
             ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
             (
                 {
-                    "Content-Disposition": (
-                        'form-data; name="content"; filename="mypkg-1.0.whl"'
-                    ),
+                    "Content-Disposition": ('form-data; name="content"; filename="mypkg-1.0.whl"'),
                 },
                 b"WHEELBYTES",
             ),
@@ -130,20 +124,24 @@ def test_parse_ignores_gpg_signature_part():
 
 def test_parse_handles_alternative_boundary_string():
     boundary = "Hi-there-this-is-a-different-boundary"
-    body = _twine_body() if False else _make_body(
-        [
-            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
-            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
-            (
-                {
-                    "Content-Disposition": (
-                        'form-data; name="content"; filename="mypkg-1.0.whl"'
-                    ),
-                },
-                b"WHEELBYTES",
-            ),
-        ],
-        boundary=boundary,
+    body = (
+        _twine_body()
+        if False
+        else _make_body(
+            [
+                ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+                ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+                (
+                    {
+                        "Content-Disposition": (
+                            'form-data; name="content"; filename="mypkg-1.0.whl"'
+                        ),
+                    },
+                    b"WHEELBYTES",
+                ),
+            ],
+            boundary=boundary,
+        )
     )
     fields = parse_multipart_upload(_ctype(boundary), body, _DEFAULT_MAX)
     assert fields.name == "mypkg"

--- a/tests/test_server_multipart.py
+++ b/tests/test_server_multipart.py
@@ -123,25 +123,20 @@ def test_parse_ignores_gpg_signature_part():
 
 
 def test_parse_handles_alternative_boundary_string():
+    """Custom boundary string still parses cleanly."""
     boundary = "Hi-there-this-is-a-different-boundary"
-    body = (
-        _twine_body()
-        if False
-        else _make_body(
-            [
-                ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
-                ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
-                (
-                    {
-                        "Content-Disposition": (
-                            'form-data; name="content"; filename="mypkg-1.0.whl"'
-                        ),
-                    },
-                    b"WHEELBYTES",
-                ),
-            ],
-            boundary=boundary,
-        )
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            (
+                {
+                    "Content-Disposition": ('form-data; name="content"; filename="mypkg-1.0.whl"'),
+                },
+                b"WHEELBYTES",
+            ),
+        ],
+        boundary=boundary,
     )
     fields = parse_multipart_upload(_ctype(boundary), body, _DEFAULT_MAX)
     assert fields.name == "mypkg"

--- a/tests/test_server_multipart.py
+++ b/tests/test_server_multipart.py
@@ -1,0 +1,233 @@
+"""Tests for `auntiepypi._server._multipart` — twine-shape upload parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from auntiepypi._server._multipart import (
+    MultipartError,
+    UploadFields,
+    parse_multipart_upload,
+)
+
+_BOUNDARY = "----auntie-pytest-boundary"
+_DEFAULT_MAX = 10 * 1024 * 1024
+
+
+def _make_body(parts: list[tuple[dict[str, str], bytes]], boundary: str = _BOUNDARY) -> bytes:
+    """Assemble a multipart body from (headers, payload) tuples."""
+    chunks: list[bytes] = []
+    for headers, payload in parts:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        for key, value in headers.items():
+            chunks.append(f"{key}: {value}\r\n".encode("utf-8"))
+        chunks.append(b"\r\n")
+        chunks.append(payload)
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks)
+
+
+def _twine_body(content: bytes = b"WHEELBYTES", filename: str = "mypkg-1.0.whl") -> bytes:
+    return _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            (
+                {
+                    "Content-Disposition": (
+                        f'form-data; name="content"; filename="{filename}"'
+                    ),
+                    "Content-Type": "application/octet-stream",
+                },
+                content,
+            ),
+        ]
+    )
+
+
+def _ctype(boundary: str = _BOUNDARY) -> str:
+    return f"multipart/form-data; boundary={boundary}"
+
+
+# --------- happy path ---------
+
+
+def test_parse_valid_twine_shape_returns_fields():
+    fields = parse_multipart_upload(_ctype(), _twine_body(), _DEFAULT_MAX)
+    assert isinstance(fields, UploadFields)
+    assert fields.action == "file_upload"
+    assert fields.name == "mypkg"
+    assert fields.filename == "mypkg-1.0.whl"
+    assert fields.content == b"WHEELBYTES"
+
+
+def test_parse_handles_content_with_binary_bytes():
+    """Wheel files contain arbitrary bytes including \\x00, \\xff."""
+    binary = bytes(range(256))
+    fields = parse_multipart_upload(_ctype(), _twine_body(content=binary), _DEFAULT_MAX)
+    assert fields.content == binary
+
+
+def test_parse_ignores_extra_pypi_metadata_fields():
+    """PyPI clients send ~20 fields. We consume :action/name/content
+    and silently ignore the rest. Extra fields must not break parsing.
+    """
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            ({"Content-Disposition": 'form-data; name="version"'}, b"1.0"),
+            ({"Content-Disposition": 'form-data; name="pyversion"'}, b"py3"),
+            ({"Content-Disposition": 'form-data; name="metadata_version"'}, b"2.1"),
+            ({"Content-Disposition": 'form-data; name="summary"'}, b"my pkg"),
+            ({"Content-Disposition": 'form-data; name="filetype"'}, b"bdist_wheel"),
+            ({"Content-Disposition": 'form-data; name="sha256_digest"'}, b"deadbeef"),
+            (
+                {
+                    "Content-Disposition": (
+                        'form-data; name="content"; filename="mypkg-1.0.whl"'
+                    ),
+                },
+                b"WHEELBYTES",
+            ),
+        ]
+    )
+    fields = parse_multipart_upload(_ctype(), body, _DEFAULT_MAX)
+    assert fields.name == "mypkg"
+    assert fields.filename == "mypkg-1.0.whl"
+    assert fields.content == b"WHEELBYTES"
+
+
+def test_parse_ignores_gpg_signature_part():
+    """Twine optionally uploads a detached .asc; PyPI deprecated this;
+    we silently discard it (server doesn't store signatures)."""
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            (
+                {
+                    "Content-Disposition": (
+                        'form-data; name="content"; filename="mypkg-1.0.whl"'
+                    ),
+                },
+                b"WHEELBYTES",
+            ),
+            (
+                {
+                    "Content-Disposition": (
+                        'form-data; name="gpg_signature"; filename="mypkg-1.0.whl.asc"'
+                    ),
+                },
+                b"-----BEGIN PGP SIGNATURE-----\n...sig...",
+            ),
+        ]
+    )
+    fields = parse_multipart_upload(_ctype(), body, _DEFAULT_MAX)
+    assert fields.name == "mypkg"
+
+
+def test_parse_handles_alternative_boundary_string():
+    boundary = "Hi-there-this-is-a-different-boundary"
+    body = _twine_body() if False else _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            (
+                {
+                    "Content-Disposition": (
+                        'form-data; name="content"; filename="mypkg-1.0.whl"'
+                    ),
+                },
+                b"WHEELBYTES",
+            ),
+        ],
+        boundary=boundary,
+    )
+    fields = parse_multipart_upload(_ctype(boundary), body, _DEFAULT_MAX)
+    assert fields.name == "mypkg"
+
+
+# --------- malformed Content-Type ---------
+
+
+def test_parse_rejects_non_multipart_content_type():
+    with pytest.raises(MultipartError, match=r"expected multipart"):
+        parse_multipart_upload("application/json", b"{}", _DEFAULT_MAX)
+
+
+def test_parse_rejects_empty_content_type():
+    with pytest.raises(MultipartError, match=r"expected multipart"):
+        parse_multipart_upload("", b"", _DEFAULT_MAX)
+
+
+def test_parse_rejects_multipart_without_boundary():
+    with pytest.raises(MultipartError, match=r"missing boundary"):
+        parse_multipart_upload("multipart/form-data", b"--xxx--", _DEFAULT_MAX)
+
+
+# --------- missing required parts ---------
+
+
+def test_parse_rejects_missing_action():
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            (
+                {"Content-Disposition": 'form-data; name="content"; filename="m.whl"'},
+                b"X",
+            ),
+        ]
+    )
+    with pytest.raises(MultipartError, match=r"':action'"):
+        parse_multipart_upload(_ctype(), body, _DEFAULT_MAX)
+
+
+def test_parse_rejects_missing_name():
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            (
+                {"Content-Disposition": 'form-data; name="content"; filename="m.whl"'},
+                b"X",
+            ),
+        ]
+    )
+    with pytest.raises(MultipartError, match=r"'name'"):
+        parse_multipart_upload(_ctype(), body, _DEFAULT_MAX)
+
+
+def test_parse_rejects_missing_content():
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+        ]
+    )
+    with pytest.raises(MultipartError, match=r"'content'"):
+        parse_multipart_upload(_ctype(), body, _DEFAULT_MAX)
+
+
+def test_parse_rejects_content_without_filename():
+    """Content part must carry filename= in its Content-Disposition.
+    Without it there's no on-disk name to use.
+    """
+    body = _make_body(
+        [
+            ({"Content-Disposition": 'form-data; name=":action"'}, b"file_upload"),
+            ({"Content-Disposition": 'form-data; name="name"'}, b"mypkg"),
+            ({"Content-Disposition": 'form-data; name="content"'}, b"WHEELBYTES"),
+        ]
+    )
+    with pytest.raises(MultipartError, match=r"missing filename="):
+        parse_multipart_upload(_ctype(), body, _DEFAULT_MAX)
+
+
+# --------- size cap ---------
+
+
+def test_parse_rejects_oversized_body():
+    body = _twine_body(content=b"X" * 1024)
+    with pytest.raises(MultipartError, match=r"body too large"):
+        parse_multipart_upload(_ctype(), body, max_bytes=100)

--- a/tests/test_server_publish.py
+++ b/tests/test_server_publish.py
@@ -66,19 +66,27 @@ def test_write_upload_handles_binary_content(tmp_path: Path):
 
 
 def test_write_upload_returns_500_on_oserror_with_cleanup(tmp_path: Path, monkeypatch):
-    """Simulate ENOSPC during rename — must return 500 and unlink temp."""
-    real_rename = os.rename
+    """Simulate ENOSPC during commit — must return 500 and unlink temp."""
+    real_link = os.link
 
-    def fake_rename(src, dst):
+    def fake_link(src, dst):
         raise OSError(28, "No space left on device")
 
-    monkeypatch.setattr(os, "rename", fake_rename)
+    monkeypatch.setattr(os, "link", fake_link)
     result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"contents")
     assert result.status == 500
     assert "No space left" in result.detail
-    monkeypatch.setattr(os, "rename", real_rename)
+    monkeypatch.setattr(os, "link", real_link)
     assert list(tmp_path.glob(".upload-*")) == []
     assert not (tmp_path / "demo-1.0-py3-none-any.whl").exists()
+
+
+def test_write_upload_returns_500_on_bad_root(tmp_path: Path):
+    """A non-existent root → temp create fails → 500, not unhandled traceback."""
+    bad_root = tmp_path / "does-not-exist"
+    result = write_upload(bad_root, "demo-1.0-py3-none-any.whl", b"contents")
+    assert result.status == 500
+    assert result.detail  # populated with the OSError detail
 
 
 def test_write_upload_concurrent_writers_first_wins(tmp_path: Path):
@@ -95,15 +103,36 @@ def test_write_upload_temp_file_uses_hidden_prefix(tmp_path: Path):
     """Temp file is hidden (.upload-…) so PEP 503 listing scanner skips it."""
     captured: dict[str, str] = {}
 
-    def fake_rename(src, dst):
+    def fake_link(src, dst):
         captured["src"] = str(src)
-        raise OSError("simulated rename failure")
+        raise OSError("simulated link failure")
 
-    with mock.patch("os.rename", fake_rename):
+    with mock.patch("os.link", fake_link):
         write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"x")
 
     assert "/.upload-" in captured["src"]
     assert captured["src"].endswith(".part")
+
+
+def test_write_upload_concurrent_collision_raises_filename_exists(tmp_path: Path):
+    """Even if a competing writer materialises the target *between* the
+    temp-write and the link commit, os.link's atomic no-clobber
+    behaviour means we get 409 — never an overwrite. Simulated by
+    pre-creating the target right before the commit step."""
+    target = tmp_path / "demo-1.0-py3-none-any.whl"
+    real_link = os.link
+
+    def racing_link(src, dst):
+        # Simulate a competitor winning the race: target appears
+        # between our temp-write and our link.
+        Path(dst).write_bytes(b"competitor")
+        return real_link(src, dst)
+
+    with mock.patch("os.link", racing_link):
+        result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"ours")
+    assert result.status == 409
+    # The competitor's bytes win; ours never get written.
+    assert target.read_bytes() == b"competitor"
 
 
 # --------- end-to-end POST handler ---------
@@ -397,3 +426,121 @@ def test_uploaded_file_downloadable_after_publish(served_publish_ready):
     finally:
         conn.close()
     assert downloaded == payload
+
+
+# --------- v0.8.0 round-1 hardening: Content-Length + Connection: close ---------
+
+
+def test_post_requires_content_length_returns_411(tmp_path: Path):
+    """Without a Content-Length header on POST, return 411 — never block
+    in read-until-EOF on a keep-alive client.
+    """
+    htpasswd_map = {"alice": _bcrypt_hash("secret")}
+    handler_cls = make_handler(
+        tmp_path,
+        htpasswd_map=htpasswd_map,
+        publish_users=("alice",),
+    )
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        # Hand-rolled HTTP/1.0 POST with no Content-Length. http.client
+        # would auto-add one; we send raw bytes to bypass.
+        import socket as _socket
+
+        s = _socket.create_connection(("127.0.0.1", port), timeout=5)
+        try:
+            req = (
+                b"POST / HTTP/1.0\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Authorization: " + _basic_header("alice", "secret").encode() + b"\r\n"
+                b"Content-Type: multipart/form-data; boundary=x\r\n"
+                b"\r\n"
+            )
+            s.sendall(req)
+            resp = s.recv(8192)
+        finally:
+            s.close()
+        # First line: HTTP/1.0 411 Length Required
+        assert b"411" in resp.split(b"\r\n", 1)[0]
+        assert b"Length" in resp
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def test_post_error_response_includes_connection_close(served_publish_ready):
+    """Every non-2xx POST response sends Connection: close so leftover
+    body bytes can't desync subsequent requests on a kept-alive socket.
+    """
+    port, _ = served_publish_ready
+    body, ctype = _twine_body(project="otherpkg")  # mismatch → 400
+    auth = _basic_header("alice", "secret")
+    status, _, headers = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 400
+    assert headers.get("Connection", "").lower() == "close"
+
+
+def test_post_success_response_includes_connection_close(served_publish_ready):
+    """Even on 201 we close — the upload is complete and the client
+    typically isn't reusing the socket. Eliminates a class of subtle
+    desync bugs at minimal cost."""
+    port, _ = served_publish_ready
+    body, ctype = _twine_body()
+    auth = _basic_header("alice", "secret")
+    status, _, headers = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 201
+    assert headers.get("Connection", "").lower() == "close"
+
+
+def test_post_truncated_body_returns_400(tmp_path: Path):
+    """Client claims Content-Length=999 but only sends 100 bytes →
+    counted-read loop catches the truncation and returns 400, not
+    block forever.
+    """
+    htpasswd_map = {"alice": _bcrypt_hash("secret")}
+    handler_cls = make_handler(
+        tmp_path,
+        htpasswd_map=htpasswd_map,
+        publish_users=("alice",),
+    )
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        import socket as _socket
+
+        s = _socket.create_connection(("127.0.0.1", port), timeout=5)
+        try:
+            short_body = b"X" * 50
+            req = (
+                b"POST / HTTP/1.0\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Authorization: " + _basic_header("alice", "secret").encode() + b"\r\n"
+                b"Content-Type: multipart/form-data; boundary=x\r\n"
+                b"Content-Length: 9999\r\n"
+                b"\r\n"
+            ) + short_body
+            s.sendall(req)
+            # Half-close the write side so server's read loop sees EOF
+            # rather than blocking.
+            s.shutdown(_socket.SHUT_WR)
+            resp = b""
+            while True:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                resp += chunk
+        finally:
+            s.close()
+        # Status line begins HTTP/1.0 400 …
+        assert b"400" in resp.split(b"\r\n", 1)[0]
+        assert b"incomplete body" in resp
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)

--- a/tests/test_server_publish.py
+++ b/tests/test_server_publish.py
@@ -1,0 +1,105 @@
+"""Tests for `auntiepypi._server._publish.write_upload` (writer-only).
+
+End-to-end do_POST tests live in tests/test_server_app_publish.py
+(task 7); this file covers the atomic-write path in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+from auntiepypi._server._publish import WriteResult, write_upload
+
+
+def test_write_upload_creates_file(tmp_path: Path):
+    result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"PK\x03\x04demo")
+    assert isinstance(result, WriteResult)
+    assert result.status == 201
+    assert result.written == len(b"PK\x03\x04demo")
+    assert (tmp_path / "demo-1.0-py3-none-any.whl").read_bytes() == b"PK\x03\x04demo"
+
+
+def test_write_upload_returns_409_when_target_exists(tmp_path: Path):
+    target = tmp_path / "demo-1.0-py3-none-any.whl"
+    target.write_bytes(b"original-bytes")
+    result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"new-bytes")
+    assert result.status == 409
+    assert "exists" in result.detail
+    # Original must be untouched.
+    assert target.read_bytes() == b"original-bytes"
+
+
+def test_write_upload_no_partial_file_on_existing(tmp_path: Path):
+    """When 409 fires, no temp file (.upload-*.part) is left behind."""
+    (tmp_path / "demo-1.0-py3-none-any.whl").write_bytes(b"x")
+    write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"y")
+    leftovers = list(tmp_path.glob(".upload-*"))
+    assert leftovers == []
+
+
+def test_write_upload_no_partial_file_on_success(tmp_path: Path):
+    write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"contents")
+    leftovers = list(tmp_path.glob(".upload-*"))
+    assert leftovers == []
+
+
+def test_write_upload_handles_binary_content(tmp_path: Path):
+    binary = bytes(range(256))
+    result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", binary)
+    assert result.status == 201
+    assert (tmp_path / "demo-1.0-py3-none-any.whl").read_bytes() == binary
+
+
+def test_write_upload_returns_500_on_oserror_with_cleanup(tmp_path: Path, monkeypatch):
+    """Simulate ENOSPC during rename — must return 500 and unlink temp."""
+    real_rename = os.rename
+
+    def fake_rename(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(os, "rename", fake_rename)
+    result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"contents")
+    assert result.status == 500
+    assert "No space left" in result.detail
+    # Restore so the cleanup line in `finally` works for verification.
+    monkeypatch.setattr(os, "rename", real_rename)
+    # No temp files left.
+    assert list(tmp_path.glob(".upload-*")) == []
+    # And the target wasn't created.
+    assert not (tmp_path / "demo-1.0-py3-none-any.whl").exists()
+
+
+def test_write_upload_concurrent_writers_first_wins(tmp_path: Path, monkeypatch):
+    """Two writers race on the same filename; first wins (201), second
+    sees existing → 409. We can't easily exercise true concurrency in
+    a unit test, but we can simulate the second-after-first sequence.
+    """
+    filename = "demo-1.0-py3-none-any.whl"
+    first = write_upload(tmp_path, filename, b"first")
+    second = write_upload(tmp_path, filename, b"second")
+    assert first.status == 201
+    assert second.status == 409
+    # First wheel's bytes survive.
+    assert (tmp_path / filename).read_bytes() == b"first"
+
+
+def test_write_upload_temp_file_uses_hidden_prefix(tmp_path: Path):
+    """The temp file should be hidden (starts with '.') so the
+    PEP 503 listing scanner doesn't pick up partial uploads.
+    """
+    # Capture the temp by mocking the rename (so the temp survives).
+    captured: dict[str, str] = {}
+
+    def fake_rename(src, dst):
+        captured["src"] = str(src)
+        # Don't actually rename; the finally clause will clean up.
+        raise OSError("simulated rename failure")
+
+    with mock.patch("os.rename", fake_rename):
+        write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"x")
+
+    # The src path's basename should start with '.upload-' (hidden).
+    assert "/.upload-" in captured["src"]
+    assert captured["src"].endswith(".part")

--- a/tests/test_server_publish.py
+++ b/tests/test_server_publish.py
@@ -24,7 +24,6 @@ import pytest
 from auntiepypi._server._app import make_handler
 from auntiepypi._server._publish import WriteResult, write_upload
 
-
 # --------- write_upload (writer-only) ---------
 
 
@@ -118,9 +117,7 @@ def _bcrypt_hash(password: str) -> bytes:
 
 
 def _basic_header(user: str, password: str) -> str:
-    return "Basic " + base64.b64encode(
-        f"{user}:{password}".encode("utf-8")
-    ).decode("ascii")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode("utf-8")).decode("ascii")
 
 
 _BOUNDARY = "----auntie-pytest-publish-boundary"
@@ -249,9 +246,7 @@ def test_post_returns_400_for_non_multipart_body(served_publish_ready):
     port, _ = served_publish_ready
     body = b'{"foo": "bar"}'
     auth = _basic_header("alice", "secret")
-    status, body_resp, _ = _post(
-        port, "/", body, _content_headers(body, "application/json", auth)
-    )
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, "application/json", auth))
     assert status == 400
     assert b"multipart" in body_resp
 

--- a/tests/test_server_publish.py
+++ b/tests/test_server_publish.py
@@ -1,16 +1,31 @@
-"""Tests for `auntiepypi._server._publish.write_upload` (writer-only).
+"""Tests for `auntiepypi._server._publish.write_upload` plus end-to-end
+POST handler tests (v0.8.0 task 6 + 7).
 
-End-to-end do_POST tests live in tests/test_server_app_publish.py
-(task 7); this file covers the atomic-write path in isolation.
+The first half exercises the atomic-write writer in isolation; the
+second half spins up a real ThreadingHTTPServer with auth + publish
+authz configured and POSTs to it.
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import os
+import threading
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
 from pathlib import Path
+from typing import Iterator
 from unittest import mock
 
+import bcrypt
+import pytest
+
+from auntiepypi._server._app import make_handler
 from auntiepypi._server._publish import WriteResult, write_upload
+
+
+# --------- write_upload (writer-only) ---------
 
 
 def test_write_upload_creates_file(tmp_path: Path):
@@ -27,7 +42,6 @@ def test_write_upload_returns_409_when_target_exists(tmp_path: Path):
     result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"new-bytes")
     assert result.status == 409
     assert "exists" in result.detail
-    # Original must be untouched.
     assert target.read_bytes() == b"original-bytes"
 
 
@@ -63,43 +77,328 @@ def test_write_upload_returns_500_on_oserror_with_cleanup(tmp_path: Path, monkey
     result = write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"contents")
     assert result.status == 500
     assert "No space left" in result.detail
-    # Restore so the cleanup line in `finally` works for verification.
     monkeypatch.setattr(os, "rename", real_rename)
-    # No temp files left.
     assert list(tmp_path.glob(".upload-*")) == []
-    # And the target wasn't created.
     assert not (tmp_path / "demo-1.0-py3-none-any.whl").exists()
 
 
-def test_write_upload_concurrent_writers_first_wins(tmp_path: Path, monkeypatch):
-    """Two writers race on the same filename; first wins (201), second
-    sees existing → 409. We can't easily exercise true concurrency in
-    a unit test, but we can simulate the second-after-first sequence.
-    """
+def test_write_upload_concurrent_writers_first_wins(tmp_path: Path):
+    """Sequential simulation of concurrent writers: first 201, second 409."""
     filename = "demo-1.0-py3-none-any.whl"
     first = write_upload(tmp_path, filename, b"first")
     second = write_upload(tmp_path, filename, b"second")
     assert first.status == 201
     assert second.status == 409
-    # First wheel's bytes survive.
     assert (tmp_path / filename).read_bytes() == b"first"
 
 
 def test_write_upload_temp_file_uses_hidden_prefix(tmp_path: Path):
-    """The temp file should be hidden (starts with '.') so the
-    PEP 503 listing scanner doesn't pick up partial uploads.
-    """
-    # Capture the temp by mocking the rename (so the temp survives).
+    """Temp file is hidden (.upload-…) so PEP 503 listing scanner skips it."""
     captured: dict[str, str] = {}
 
     def fake_rename(src, dst):
         captured["src"] = str(src)
-        # Don't actually rename; the finally clause will clean up.
         raise OSError("simulated rename failure")
 
     with mock.patch("os.rename", fake_rename):
         write_upload(tmp_path, "demo-1.0-py3-none-any.whl", b"x")
 
-    # The src path's basename should start with '.upload-' (hidden).
     assert "/.upload-" in captured["src"]
     assert captured["src"].endswith(".part")
+
+
+# --------- end-to-end POST handler ---------
+
+
+def _bcrypt_hash(password: str) -> bytes:
+    return bcrypt.hashpw(  # NOSONAR python:S5344 - test fixture; production cost ≥ 12
+        password.encode("utf-8"),
+        bcrypt.gensalt(rounds=4),  # NOSONAR python:S5344
+    )
+
+
+def _basic_header(user: str, password: str) -> str:
+    return "Basic " + base64.b64encode(
+        f"{user}:{password}".encode("utf-8")
+    ).decode("ascii")
+
+
+_BOUNDARY = "----auntie-pytest-publish-boundary"
+
+
+def _twine_body(
+    project: str = "mypkg",
+    filename: str = "mypkg-1.0-py3-none-any.whl",
+    content: bytes = b"WHEELBYTES",
+    boundary: str = _BOUNDARY,
+) -> tuple[bytes, str]:
+    parts: list[bytes] = []
+    parts.append(f"--{boundary}\r\n".encode("utf-8"))
+    parts.append(b'Content-Disposition: form-data; name=":action"\r\n\r\n')
+    parts.append(b"file_upload\r\n")
+    parts.append(f"--{boundary}\r\n".encode("utf-8"))
+    parts.append(b'Content-Disposition: form-data; name="name"\r\n\r\n')
+    parts.append(project.encode("utf-8") + b"\r\n")
+    parts.append(f"--{boundary}\r\n".encode("utf-8"))
+    parts.append(
+        f'Content-Disposition: form-data; name="content"; filename="{filename}"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n".encode("utf-8")
+    )
+    parts.append(content + b"\r\n")
+    parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+@pytest.fixture
+def served_publish_ready(tmp_path: Path) -> Iterator[tuple[int, Path]]:
+    """Server with auth + publish_users=(alice,). Yields (port, root)."""
+    htpasswd_map = {
+        "alice": _bcrypt_hash("secret"),
+        "bob": _bcrypt_hash("hunter2"),  # authenticates but NOT in publish_users
+    }
+    handler_cls = make_handler(
+        tmp_path,
+        htpasswd_map=htpasswd_map,
+        publish_users=("alice",),
+    )
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, tmp_path
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def _post(
+    port: int,
+    path: str,
+    body: bytes,
+    headers: dict[str, str],
+) -> tuple[int, bytes, dict[str, str]]:
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("POST", path, body=body, headers=headers)
+        resp = conn.getresponse()
+        return resp.status, resp.read(), dict(resp.getheaders())
+    finally:
+        conn.close()
+
+
+def _content_headers(body: bytes, ctype: str, auth_header: str | None = None) -> dict[str, str]:
+    h = {"Content-Type": ctype, "Content-Length": str(len(body))}
+    if auth_header is not None:
+        h["Authorization"] = auth_header
+    return h
+
+
+# --------- auth-not-configured ---------
+
+
+def test_post_returns_405_without_htpasswd(tmp_path: Path):
+    handler_cls = make_handler(tmp_path)  # no auth
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body, ctype = _twine_body()
+        status, _, _ = _post(port, "/", body, _content_headers(body, ctype))
+        assert status == 405
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+# --------- 401 / 403 / 404 / 400 / 413 / 409 / 201 ---------
+
+
+def test_post_returns_401_without_auth(served_publish_ready):
+    port, _ = served_publish_ready
+    body, ctype = _twine_body()
+    status, _, headers = _post(port, "/", body, _content_headers(body, ctype))
+    assert status == 401
+    assert "Basic" in headers["WWW-Authenticate"]
+
+
+def test_post_returns_403_for_authenticated_non_publisher(served_publish_ready):
+    """bob authenticates fine but is not in publish_users."""
+    port, _ = served_publish_ready
+    body, ctype = _twine_body()
+    auth = _basic_header("bob", "hunter2")
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 403
+    assert b"'bob' cannot publish" in body_resp
+
+
+def test_post_returns_404_for_wrong_path(served_publish_ready):
+    """Only `/` is the upload URL. /simple/ etc must 404 (not 405) so we
+    don't leak alternate routes."""
+    port, _ = served_publish_ready
+    body, ctype = _twine_body()
+    auth = _basic_header("alice", "secret")
+    status, _, _ = _post(port, "/simple/", body, _content_headers(body, ctype, auth))
+    assert status == 404
+
+
+def test_post_returns_400_for_non_multipart_body(served_publish_ready):
+    port, _ = served_publish_ready
+    body = b'{"foo": "bar"}'
+    auth = _basic_header("alice", "secret")
+    status, body_resp, _ = _post(
+        port, "/", body, _content_headers(body, "application/json", auth)
+    )
+    assert status == 400
+    assert b"multipart" in body_resp
+
+
+def test_post_returns_400_for_missing_action(served_publish_ready):
+    port, _ = served_publish_ready
+    boundary = "x"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="name"\r\n\r\nmypkg\r\n'
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="content"; filename="mypkg-1.0.whl"\r\n'
+        "\r\nX\r\n"
+        f"--{boundary}--\r\n"
+    ).encode("utf-8")
+    ctype = f"multipart/form-data; boundary={boundary}"
+    auth = _basic_header("alice", "secret")
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 400
+    assert b":action" in body_resp
+
+
+def test_post_returns_400_when_name_field_disagrees_with_filename(served_publish_ready):
+    port, _ = served_publish_ready
+    body, ctype = _twine_body(project="otherpkg")  # mismatch with mypkg-... filename
+    auth = _basic_header("alice", "secret")
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 400
+    assert b"does not match filename" in body_resp
+
+
+def test_post_returns_400_for_bad_filename(served_publish_ready):
+    """Filename containing path separators or non-dist extensions must 400."""
+    port, _ = served_publish_ready
+    body, ctype = _twine_body(filename="../etc/passwd")
+    auth = _basic_header("alice", "secret")
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 400
+    assert b"invalid filename" in body_resp or b"unrecognized" in body_resp
+
+
+def test_post_returns_413_when_body_too_large(tmp_path: Path):
+    """Server with low max_upload_bytes — POSTing more than that → 413."""
+    htpasswd_map = {"alice": _bcrypt_hash("secret")}
+    handler_cls = make_handler(
+        tmp_path,
+        htpasswd_map=htpasswd_map,
+        publish_users=("alice",),
+        max_upload_bytes=512,
+    )
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body, ctype = _twine_body(content=b"X" * 4096)
+        auth = _basic_header("alice", "secret")
+        status, _, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+        assert status == 413
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def test_post_creates_file_on_201(served_publish_ready):
+    port, root = served_publish_ready
+    body, ctype = _twine_body(content=b"PK\x03\x04WHEEL")
+    auth = _basic_header("alice", "secret")
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 201
+    assert (root / "mypkg-1.0-py3-none-any.whl").read_bytes() == b"PK\x03\x04WHEEL"
+    payload = json.loads(body_resp)
+    assert payload["ok"] is True
+    assert payload["filename"] == "mypkg-1.0-py3-none-any.whl"
+    assert payload["url"] == "/files/mypkg-1.0-py3-none-any.whl"
+
+
+def test_post_returns_409_when_file_exists(served_publish_ready):
+    port, root = served_publish_ready
+    (root / "mypkg-1.0-py3-none-any.whl").write_bytes(b"existing")
+    body, ctype = _twine_body(content=b"new bytes")
+    auth = _basic_header("alice", "secret")
+    status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+    assert status == 409
+    assert b"exists" in body_resp
+    assert (root / "mypkg-1.0-py3-none-any.whl").read_bytes() == b"existing"
+
+
+def test_post_403_when_publish_users_empty_but_authenticated(tmp_path: Path):
+    """publish_users=() with auth on → 403 'publish disabled'."""
+    htpasswd_map = {"alice": _bcrypt_hash("secret")}
+    handler_cls = make_handler(
+        tmp_path,
+        htpasswd_map=htpasswd_map,
+        publish_users=(),
+    )
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body, ctype = _twine_body()
+        auth = _basic_header("alice", "secret")
+        status, body_resp, _ = _post(port, "/", body, _content_headers(body, ctype, auth))
+        assert status == 403
+        assert b"disabled" in body_resp
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def test_uploaded_file_appears_in_simple_index(served_publish_ready):
+    """Regression: GET /simple/ after POST shows the new wheel."""
+    port, _ = served_publish_ready
+    body, ctype = _twine_body()
+    auth = _basic_header("alice", "secret")
+    _post(port, "/", body, _content_headers(body, ctype, auth))
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", "/simple/", headers={"Authorization": auth})
+        resp = conn.getresponse()
+        body_html = resp.read().decode()
+        resp.close()
+    finally:
+        conn.close()
+    assert "mypkg" in body_html
+
+
+def test_uploaded_file_downloadable_after_publish(served_publish_ready):
+    """Regression: GET /files/<name> after POST returns the bytes."""
+    port, _ = served_publish_ready
+    payload = b"PK\x03\x04demo-bytes"
+    body, ctype = _twine_body(content=payload)
+    auth = _basic_header("alice", "secret")
+    _post(port, "/", body, _content_headers(body, ctype, auth))
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request(
+            "GET",
+            "/files/mypkg-1.0-py3-none-any.whl",
+            headers={"Authorization": auth},
+        )
+        resp = conn.getresponse()
+        downloaded = resp.read()
+        resp.close()
+    finally:
+        conn.close()
+    assert downloaded == payload

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "auntiepypi"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## Summary

- New CLI verb `auntie publish <path>` that uploads wheels/sdists to the configured first-party local index. Reads creds from `$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` or interactive prompt; refuses to block in non-TTY.
- Twine-compatible POST upload at `/` (legacy PyPI protocol — `multipart/form-data` with `:action=file_upload`). Authorization is a strict superset of v0.7.0 auth: every publisher must be both authenticated AND in the new `publish_users` allowlist.
- New config keys `[tool.auntiepypi.local].publish_users` (allowlist; empty preserves read-only mode) and `.max_upload_bytes` (per-request cap, default 100 MiB). `publish_users` requires `htpasswd` and is cross-checked against actual entries at config-load.

## Slice scope (locked decisions)

D1: twine-compat POST · D2: `publish_users` allowlist · D3: `verify_basic` widens to `authenticate_user → str | None` · D4: existing-file → 409 Conflict (no overwrite) · D5: `max_upload_bytes` (100 MiB default; pre-read + counted reader) · D6: atomic write via `tempfile` + `os.rename` · D7: `auntie publish` CLI verb.

Out of scope (deferred): yank/delete (delete from `cfg.root` directly), per-package ownership (v1.0.0), keyring/netrc (v0.8.1), streaming multipart (v0.9.0), rate limiting, `gpg_signature` storage.

Spec: `docs/superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md`

## Test plan

- [x] `pytest -n auto --cov`: **636 pass**, coverage **94.15%** (over the 94% floor)
- [x] `black --check` + `isort --check`: clean
- [x] `flake8` + `pylint --errors-only`: clean
- [x] `bandit -c pyproject.toml -r auntiepypi`: 0 issues
- [x] `markdownlint-cli2 "**/*.md"`: clean
- [x] `portability-lint`: clean
- [x] Live smoke (loopback server with auth + `publish_users=["alice"]`):
  - `auntie up` → started · `auntie publish mypkg-1.0-py3-none-any.whl` → published · second publish → HTTP 409 file already exists · `curl -u alice:secret /simple/mypkg/` → listing OK · `curl -u alice:secret /files/...` → bytes OK · `auntie down` → stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude