### PR TITLE
v0.8.1: public-facing docs (architecture, security, comparison) — #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-02
+
+### Added
+
+- docs/architecture.md, docs/security.md, docs/comparison.md — public-facing pages addressing issue #14: module map + state surfaces, security defaults + truth tables, side-by-side comparison with pypiserver / devpi / twine.
+- README.md — "What auntie is" lede, status table by version (mutation surface + shipped/planned), top-level docs nav block.
+
+### Changed
+
+- docs/about.md — refreshed "What it does today" through v0.8.0 (overview, doctor, lifecycle, first-party server, TLS+auth, publish) and rewrote "Where its headed" to track the v0.8.x / v0.9.0 / v1.0.0 roadmap.
+
 ## [0.8.0] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2026-05-02
+## [0.8.1] - 2026-05-03
 
 ### Added
 
@@ -14,7 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- docs/about.md — refreshed "What it does today" through v0.8.0 (overview, doctor, lifecycle, first-party server, TLS+auth, publish) and rewrote "Where its headed" to track the v0.8.x / v0.9.0 / v1.0.0 roadmap.
+- docs/about.md — refreshed "What it does today" through v0.8.0 (overview, doctor, lifecycle, first-party server, TLS+auth, publish) and rewrote "Where it's headed" to track the v0.8.x / v0.9.0 / v1.0.0 roadmap.
 
 ## [0.8.0] - 2026-05-03
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@
 
 A small CLI plus a stable plumbing layer that an agent inside the
 AgentCulture mesh can call. Read verbs (`overview`, `learn`,
-`explain`, `whoami`) never touch disk or bind ports. Mutation verbs
-(`doctor --apply`, `up`, `down`, `restart`, `publish`) do exactly one
-thing each, and every dangerous surface (public binding, POST upload,
-config edits) requires explicit operator opt-in. The first-party
+`explain`, `whoami`, `doctor` without `--apply`) read configuration
+and probe state but never write to disk or bind a port. Mutation
+verbs (`doctor --apply`, `up`, `down`, `restart`, `publish`) do
+exactly one thing each, and every dangerous surface (public binding,
+POST upload, config edits) requires explicit operator opt-in. The first-party
 server runs on loopback by default and stays read-only until
 `publish_users` is set. See [`docs/architecture.md`](docs/architecture.md)
 for the module map and [`docs/security.md`](docs/security.md) for the
@@ -29,7 +30,7 @@ threat model.
 | v0.3.0  | `auntie overview` server detection (`_detect/`)  | nothing           | shipped  |
 | v0.4.0  | `auntie doctor` lifecycle (`--apply`)            | `pyproject.toml`  | shipped  |
 | v0.5.0  | `auntie up` / `down` / `restart` (declared)      | process state     | shipped  |
-| v0.6.0  | First-party PEP 503 simple-index (read-only)     | wheelhouse (read) | shipped  |
+| v0.6.0  | First-party PEP 503 simple-index (read-only)     | nothing           | shipped  |
 | v0.7.0  | HTTPS + Basic auth on the first-party server     | nothing           | shipped  |
 | v0.8.0  | `auntie publish` — twine-compatible POST upload  | package index     | shipped  |
 | v0.8.x  | Keyring / netrc credential plumbing              | nothing           | planned  |

--- a/README.md
+++ b/README.md
@@ -3,27 +3,52 @@
 > auntie (Python distribution: `auntiepypi`) is both a CLI and an agent
 > that maintains, uses, and serves the CLI for managing PyPI packages.
 > It overviews packages on pypi.org, detects PyPI-flavored servers
-> running locally, and starts/stops/restarts declared servers —
-> informational first, actionable on demand.
+> running locally, starts/stops/restarts declared servers, and hosts a
+> first-party PEP 503 simple-index — informational first, actionable
+> on demand.
 
-**Status:** v0.8.0 — `auntie publish` (write side) landed. The
-first-party server now accepts twine-compatible POST uploads at `/`
-(legacy PyPI upload protocol — `multipart/form-data` with
-`:action=file_upload`). Authorization is gated by both v0.7.0 auth
-AND a new `publish_users` allowlist; empty allowlist preserves
-read-only mode. New CLI verb `auntie publish <path>` reads creds from
-`$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` or interactive
-prompt. Per-request body cap via `[tool.auntiepypi.local].max_upload_bytes`
-(default 100 MiB). No new runtime dep.
+## What auntie is
 
-Bare `auntie up` / `auntie down` / `auntie restart` (introduced in
-v0.6.0) continue to start, stop, and restart auntie's own simple-index
-server. Wheels in `$XDG_DATA_HOME/auntiepypi/wheels/` are served from
-`http://127.0.0.1:3141/simple/` (or `https://...` when TLS is
-configured) and installable via `pip install --index-url`. Lifecycle
-verbs continue to work against declared servers (`managed_by ∈
-{systemd-user, command}`); `--all` aggregates the first-party server
-with every supervised declaration.
+A small CLI plus a stable plumbing layer that an agent inside the
+AgentCulture mesh can call. Read verbs (`overview`, `learn`,
+`explain`, `whoami`) never touch disk or bind ports. Mutation verbs
+(`doctor --apply`, `up`, `down`, `restart`, `publish`) do exactly one
+thing each, and every dangerous surface (public binding, POST upload,
+config edits) requires explicit operator opt-in. The first-party
+server runs on loopback by default and stays read-only until
+`publish_users` is set. See [`docs/architecture.md`](docs/architecture.md)
+for the module map and [`docs/security.md`](docs/security.md) for the
+threat model.
+
+## Status
+
+| Version | Capability                                       | Mutates           | Status   |
+|---------|--------------------------------------------------|-------------------|----------|
+| v0.0.1  | Package skeleton (`learn`, `explain`, `whoami`)  | nothing           | shipped  |
+| v0.1.0  | `auntie overview` packages dashboard             | nothing           | shipped  |
+| v0.3.0  | `auntie overview` server detection (`_detect/`)  | nothing           | shipped  |
+| v0.4.0  | `auntie doctor` lifecycle (`--apply`)            | `pyproject.toml`  | shipped  |
+| v0.5.0  | `auntie up` / `down` / `restart` (declared)      | process state     | shipped  |
+| v0.6.0  | First-party PEP 503 simple-index (read-only)     | wheelhouse (read) | shipped  |
+| v0.7.0  | HTTPS + Basic auth on the first-party server     | nothing           | shipped  |
+| v0.8.0  | `auntie publish` — twine-compatible POST upload  | package index     | shipped  |
+| v0.8.x  | Keyring / netrc credential plumbing              | nothing           | planned  |
+| v0.9.0  | Streaming multipart (multi-GiB ML wheels)        | package index     | planned  |
+| v1.0.0  | Mesh-aware: Culture-mesh service-registry discovery | nothing        | planned  |
+
+Roadmap is descriptive of intent, not a commitment.
+
+## Docs
+
+- [`docs/about.md`](docs/about.md) — non-technical explainer.
+- [`docs/architecture.md`](docs/architecture.md) — module map, state
+  surfaces, read-only vs write-capable verbs.
+- [`docs/security.md`](docs/security.md) — defaults, public-binding
+  rules, publish authorization, body cap, file permissions.
+- [`docs/comparison.md`](docs/comparison.md) — when to pick auntie vs
+  pypiserver / devpi / twine.
+- [`docs/superpowers/specs/`](docs/superpowers/specs/) — per-milestone
+  design docs (decisions and rationale).
 
 ## Quick start
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -12,9 +12,9 @@ inside the AgentCulture mesh can call. The tool reads. It reports. It
 does not block builds, fail CI on package-quality grounds, or insist on
 its own opinions of "good enough".
 
-## What it does today (v0.4.0)
+## What it does today (v0.8.0)
 
-Three things:
+Five things:
 
 1. **Dashboard.** Run `auntie overview` and you get a
    one-row-per-package summary of every package listed in your repo's
@@ -38,6 +38,21 @@ Three things:
    config fields. We never invent config values; ambiguous cases (e.g.
    duplicate names) are deferred to a `--decide` re-run.
 
+4. **Lifecycle.** `auntie up` / `auntie down` / `auntie restart`
+   start, stop, and restart servers. Bare invocation targets auntie's
+   own first-party PEP 503 simple-index server (loopback only by
+   default; HTTPS + Basic auth required for public binding). A named
+   target acts on one declared `[[tool.auntiepypi.servers]]` entry;
+   `--all` aggregates the first-party server with every supervised
+   declaration.
+
+5. **Publish.** `auntie publish <path>` uploads a wheel or sdist to
+   the configured first-party index using the legacy PyPI POST upload
+   protocol (twine-compatible). Authorization is a strict superset of
+   authentication: every publisher must be both authenticated AND in
+   the `publish_users` allowlist. Empty / unset allowlist preserves
+   read-only mode (POST → 403 "publish disabled").
+
 The same machinery feeds the top-level `auntie overview`, which
 composes the packages dashboard with a `servers` section that surfaces
 declared servers, default-port finds, and (with `--proc`) /proc-walked
@@ -56,38 +71,45 @@ This is a deliberate choice. Tools that gate on opinion-shaped metrics
 get worked around. Tools that report on opinion-shaped metrics stay
 useful.
 
-## v0.3.0 — detect, don't supervise
+## How we got here
 
-`auntie overview` now sees more than just the canonical-port devpi /
-pypiserver instances: it reads `[[tool.auntiepypi.servers]]` from
-`pyproject.toml`, fingerprints anything running on port 3141 / 8080,
-and (with `--proc`) walks `/proc` for matching processes. The CLI
-binary is `auntie` (`auntiepypi` stays as an alias for muscle memory).
-
-It deliberately stopped at *seeing*. Lifecycle — start, stop — landed
-in v0.4.0.
-
-## v0.4.0 — doctor acts
-
-Doctor diagnoses what's wrong, explains how to fix it, and (with
-`--apply`) acts. The acts are narrow: spawn declared servers via their
-`managed_by` strategy (`systemd-user` or `command`), or delete
-half-supervised declarations that are missing required fields. We never
-invent config values; ambiguous cases are deferred to a `--decide`
-re-run. Before any `pyproject.toml` edit, a numbered `.bak` snapshot
-is written so you can roll back with a single `mv` command.
-
-The `--fix` flag from earlier versions is replaced by `--apply`. The
-`packages` noun (`auntie packages overview`) is removed — use
-`auntie overview <PKG>` instead.
+- **v0.3.0 — detect, don't supervise.** `auntie overview` learned to
+  read `[[tool.auntiepypi.servers]]`, fingerprint default-port devpi
+  / pypiserver, and (with `--proc`) walk `/proc`. The CLI binary
+  became `auntie`; `auntiepypi` stayed as an alias.
+- **v0.4.0 — doctor acts.** Diagnosis + `--apply` to dispatch
+  declared servers and delete half-supervised entries. Numbered
+  `.bak` snapshots before any `pyproject.toml` edit.
+- **v0.5.0 — lifecycle verbs.** `auntie up` / `auntie down` /
+  `auntie restart` against declared servers. PID-file + sidecar
+  tracking; argv-matched port-walk fallback when no PID file exists.
+- **v0.6.0 — first-party server.** Read-only PEP 503 simple-index
+  for mesh-private use; bare `auntie up` / `down` / `restart` start
+  and stop it. Loopback-only binding.
+- **v0.7.0 — HTTPS + Basic auth.** Operator-supplied PEM cert and
+  htpasswd (bcrypt-only). Public binding allowed only when both are
+  configured; either alone rejected at config-load time. `bcrypt`
+  becomes the first runtime dependency.
+- **v0.8.0 — `auntie publish` (write side).** Twine-compatible POST
+  upload at `/`, gated by v0.7.0 auth plus a `publish_users`
+  allowlist (cross-checked against htpasswd at config-load).
+  Per-request body cap via `max_upload_bytes` (default 100 MiB).
+  No new runtime dep — `email.parser.BytesParser` parses the
+  multipart body.
 
 ## Where it's headed
 
-- v0.5.0 — own server + lifecycle commands. `auntie up` / `auntie down`
-  / `auntie restart`; PID-file tracking; first-party PEP 503
-  simple-index for mesh-private use.
-- Later — release orchestration (trigger sibling `publish.yml`
-  workflows); additional detectors as needed; whatever the mesh needs next.
+- **v0.8.x — keyring / netrc.** Credential plumbing for
+  `auntie publish`: read username/password from system keyring or a
+  netrc-format file. Reduces the `$AUNTIE_PUBLISH_*` env-var
+  ergonomics gap.
+- **v0.9.0 — streaming multipart.** Replace the v0.8.0 in-memory
+  parser with a streaming variant so multi-GiB ML wheels don't pay
+  the memory cost. Same on-the-wire protocol.
+- **v1.0.0 — mesh-aware.** Local index discoverable via Culture-mesh
+  service registry; trust boundary documented. Per-package ownership
+  maps likely land here too.
 
 Nothing here gets shipped without a brainstorm pass and a written spec
-under `docs/superpowers/specs/`. The roadmap is a sketch, not a plan.
+under `docs/superpowers/specs/`. The roadmap is descriptive of intent,
+not a commitment — reorder or replace as the design lands.

--- a/docs/about.md
+++ b/docs/about.md
@@ -50,8 +50,10 @@ Five things:
    the configured first-party index using the legacy PyPI POST upload
    protocol (twine-compatible). Authorization is a strict superset of
    authentication: every publisher must be both authenticated AND in
-   the `publish_users` allowlist. Empty / unset allowlist preserves
-   read-only mode (POST → 403 "publish disabled").
+   the `publish_users` allowlist. With no `htpasswd` configured, the
+   server is read-only (POST → 405). With auth configured but
+   `publish_users` empty, authenticated POSTs return 403
+   "publish disabled" — read-only mode is preserved either way.
 
 The same machinery feeds the top-level `auntie overview`, which
 composes the packages dashboard with a `servers` section that surfaces

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,10 +2,12 @@
 
 `auntiepypi` is a CLI plus a local HTTP server. The CLI inspects PyPI
 and your local machine; the server hosts a private PEP 503 simple
-index. State lives in two places — `pyproject.toml` (declared
-inventory + first-party server config) and the wheelhouse directory
-(`$XDG_DATA_HOME/auntiepypi/wheels/` by default). There is no hidden
-global state.
+index. The two declarative state surfaces are `pyproject.toml`
+(declared inventory + first-party server config) and the wheelhouse
+directory (`$XDG_DATA_HOME/auntiepypi/wheels/` by default). The
+runtime layer adds PID-file sidecars (`_actions/command.py`) and
+numbered `.bak` snapshots written before any `pyproject.toml` edit —
+both auditable and rollback-safe. There is no hidden global state.
 
 ## Bird's-eye view
 
@@ -65,8 +67,10 @@ distribution files. `_auth.py` parses htpasswd (bcrypt-only) and
 verifies HTTP Basic. `_tls.py` builds the `ssl.SSLContext`.
 `_multipart.py` parses twine-shape upload bodies via stdlib
 `email.parser.BytesParser`. `_publish.py` writes uploads atomically
-via `tempfile.NamedTemporaryFile + os.rename`. `_config.py` is the
-frozen `LocalConfig` dataclass.
+via `tempfile.NamedTemporaryFile` + `os.link` (no-clobber on POSIX;
+`FileExistsError` → 409 with no TOCTOU window — see
+[`security.md`](security.md) for the rationale). `_config.py` is
+the frozen `LocalConfig` dataclass.
 
 ## Where state lives
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,117 @@
+# Architecture and data flow
+
+`auntiepypi` is a CLI plus a local HTTP server. The CLI inspects PyPI
+and your local machine; the server hosts a private PEP 503 simple
+index. State lives in two places — `pyproject.toml` (declared
+inventory + first-party server config) and the wheelhouse directory
+(`$XDG_DATA_HOME/auntiepypi/wheels/` by default). There is no hidden
+global state.
+
+## Bird's-eye view
+
+```text
+                          ┌──────────────────────────┐
+   user / agent  ──────►  │  auntie <verb> [args]    │
+                          │  (auntiepypi.cli)        │
+                          └──────────────┬───────────┘
+                                         │
+              ┌──────────────────────────┼──────────────────────────┐
+              │                          │                          │
+              ▼                          ▼                          ▼
+      ┌──────────────┐          ┌────────────────┐         ┌────────────────┐
+      │  _detect/    │          │  _actions/     │         │  _server/      │
+      │  read-only   │          │  start/stop    │         │  HTTP listener │
+      │  inventory   │          │  process state │         │  PEP 503 +     │
+      │  + probes    │          │  + pyproject   │         │  POST upload   │
+      └──────┬───────┘          └────────┬───────┘         └────────┬───────┘
+             │                           │                          │
+             ▼                           ▼                          ▼
+     ┌──────────────┐           ┌────────────────┐          ┌────────────────┐
+     │ pyproject.toml│          │ pyproject.toml │          │ wheels/ dir    │
+     │ (read)       │           │ (.bak snapshots│          │ (read + write) │
+     │ pypi.org     │           │  before edit)  │          │ htpasswd, cert │
+     │ /proc, ports │           │ PID files      │          │ (read)         │
+     └──────────────┘           └────────────────┘          └────────────────┘
+```
+
+The CLI dispatcher is `auntiepypi.cli:main`. Each verb is a small
+module under `auntiepypi/cli/_commands/` that delegates the heavy
+lifting to one of the three packages above. `auntie learn` and
+`auntie explain` are pure reads of the in-process `explain/catalog.py`
+catalog — no network, no filesystem.
+
+## What each module owns
+
+**`auntiepypi/_detect/`** — read-only inventory. `_declared.py` parses
+`[[tool.auntiepypi.servers]]`. `_port.py` probes the canonical
+`devpi` (3141) and `pypiserver` (8080) ports. `_proc.py` walks
+`/proc` (Linux only, opt-in via `--proc`) for matching argvs.
+`_local.py` emits the auntie-flavored detection for the first-party
+server. Together they feed `auntie overview` and the diagnosis phase
+of `auntie doctor`.
+
+**`auntiepypi/_actions/`** — process and config mutators.
+`systemd_user.py` shells out to `systemctl --user`. `command.py`
+spawns a subprocess from a declared `command = [...]` argv and tracks
+the PID via a sidecar file. `auntie.py` wraps `command.py` with the
+derived `python -m auntiepypi._server` argv. Every config edit
+(`--apply` deletes a half-supervised entry; `--decide` resolves a
+duplicate) writes a numbered `pyproject.toml.<N>.bak` snapshot first;
+rollback is one `mv`.
+
+**`auntiepypi/_server/`** — the first-party HTTP listener.
+`_app.py` is the request handler factory. `_wheelhouse.py` enumerates
+distribution files. `_auth.py` parses htpasswd (bcrypt-only) and
+verifies HTTP Basic. `_tls.py` builds the `ssl.SSLContext`.
+`_multipart.py` parses twine-shape upload bodies via stdlib
+`email.parser.BytesParser`. `_publish.py` writes uploads atomically
+via `tempfile.NamedTemporaryFile + os.rename`. `_config.py` is the
+frozen `LocalConfig` dataclass.
+
+## Where state lives
+
+| Surface           | Owner                  | Read by                      | Mutated by                          |
+|-------------------|------------------------|------------------------------|-------------------------------------|
+| `pyproject.toml`  | the user / operator    | every verb                   | `auntie doctor --apply`, `--decide` |
+| `wheels/` dir     | the first-party server | `auntie up` (serve), `pip`   | `auntie publish`, `twine upload`    |
+| `htpasswd`, certs | the operator           | `auntie up` (load at start)  | never (out-of-band)                 |
+| PID files         | `_actions/command.py`  | `auntie down`, `restart`     | `auntie up`, `down`, `restart`      |
+| `.bak` snapshots  | `auntie doctor --apply`| rollback                     | `auntie doctor --apply` only        |
+
+## Read-only vs write-capable, by surface
+
+| Verb                              | Mutates                                  |
+|-----------------------------------|------------------------------------------|
+| `learn`, `explain`, `whoami`      | nothing (pure reads)                     |
+| `overview`                        | nothing (probes pypi.org + local ports)  |
+| `doctor` (no `--apply`)           | nothing (dry-run report)                 |
+| `doctor --apply`                  | process state + `pyproject.toml`         |
+| `up`, `down`, `restart`           | process state                            |
+| `publish`                         | the package index (wheels directory)     |
+
+`overview`, `learn`, `explain`, and `whoami` never write to disk and
+never bind a port. `doctor` is dry-run by default; the `--apply`
+opt-in is the only path that writes `pyproject.toml`. `up` / `down` /
+`restart` only touch process state and PID files. `publish` is the
+only verb that can change the contents of the package index — and
+only against a server whose operator has opted in via `publish_users`.
+
+## Network surface
+
+The first-party server (`auntie up`) binds to `127.0.0.1:3141` by
+default. PEP 503 routes (`GET /simple/`, `GET /simple/<pkg>/`,
+`GET /files/<filename>`) are open to any client that can reach the
+socket. The legacy upload route (`POST /`) is gated by HTTP Basic
+auth plus the `publish_users` allowlist. Public (non-loopback)
+binding is rejected at config-load time unless both TLS (cert+key)
+and auth (htpasswd) are configured — see [`security.md`](security.md)
+for the truth table and rationale.
+
+## See also
+
+- [`about.md`](about.md) — non-technical explainer.
+- [`security.md`](security.md) — security model and defaults.
+- [`comparison.md`](comparison.md) — when to pick auntie vs
+  pypiserver / devpi / twine.
+- [`superpowers/specs/`](superpowers/specs/) — design docs per
+  milestone (architecture decisions and rationale).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,75 @@
+# When to use auntie vs pypiserver / devpi / twine
+
+`auntiepypi` overlaps with several existing tools but targets a
+different shape: agent-friendly verbs, a single small mesh-private
+index, and lifecycle for whatever's already running. It is not a
+drop-in replacement for any of them.
+
+| Tool        | Role                          | auntie's relationship                                               |
+|-------------|-------------------------------|---------------------------------------------------------------------|
+| pypiserver  | Minimal index daemon          | auntie wraps it as one supported `flavor`; adds detection + lifecycle. |
+| devpi       | Multi-index server with mirroring + staging | Different scale tier — auntie is single-index only.              |
+| twine       | Upload client for any PyPI-shaped index | `auntie publish` speaks the same wire protocol; either works against an auntie server. |
+
+## vs pypiserver
+
+`pypiserver` is a small, focused PyPI-compatible index daemon. If you
+just need an index, `pypiserver` alone is fine — auntie itself
+declares it as one of the supported `flavor`s and is happy to detect
+and lifecycle-manage a `pypiserver` instance you already run.
+
+Pick auntie over a bare `pypiserver` when you want:
+
+- One config block (`[[tool.auntiepypi.servers]]`) describing every
+  index daemon on the host, regardless of flavor.
+- `auntie doctor` diagnosing what's down or half-supervised, with
+  `--apply` dispatching the right `systemctl --user` invocation.
+- `auntie up --all` starting the first-party server plus every
+  declared `pypiserver` / `devpi` in one shot.
+- The agent-readable verbs (`learn`, `explain`, `--json`) for
+  programmatic use.
+
+If none of those matter, run `pypiserver` directly.
+
+## vs devpi
+
+`devpi` is a much larger system: a multi-index server with mirroring,
+staging, per-user namespaces, and a release-promotion pipeline. It is
+the right answer for an organisation that needs proper package
+promotion (dev → staging → release) or transparent mirroring of
+upstream PyPI.
+
+auntie is intentionally smaller. The first-party server is a single
+read+write index, mesh-private by default, with no mirroring and no
+multi-index namespacing. Pick devpi for org-scale package pipelines;
+pick auntie for a loopback or small-mesh slice where the simpler
+mental model is the point. auntie can also detect and lifecycle a
+declared `devpi-server` instance — the two coexist fine.
+
+## vs twine
+
+`twine` and `auntie publish` solve the same problem on the wire: both
+POST a `multipart/form-data` body with `:action=file_upload` to a
+PyPI-shaped index. The auntie server accepts twine, flit, hatch, and
+`auntie publish` interchangeably — pick whichever fits the
+publisher's environment.
+
+Pick `auntie publish` over `twine` when:
+
+- The publisher is already inside the auntie CLI (one less tool in
+  the agent's path).
+- Credentials live in `$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD`
+  and you want consistent exit-code semantics with the rest of
+  `auntie *`.
+- You're targeting an auntie server and want the flag set to match
+  (`AUNTIE_INSECURE_SKIP_VERIFY=1` for self-signed, etc.).
+
+Pick `twine` when:
+
+- You're publishing to upstream PyPI / TestPyPI as well, and want one
+  client across all targets.
+- You want twine's release-engineering ergonomics (sign, check
+  metadata, etc.) — `auntie publish` is intentionally minimal.
+
+There is no lock-in either way: every artifact uploaded via one
+client is downloadable by anything that speaks PEP 503.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,124 @@
+# Security model
+
+`auntiepypi` ships with safe defaults: loopback bind, read-only mode,
+no auth required for loopback, empty `publish_users` so POST uploads
+are disabled even when auth is configured. Every dangerous surface
+requires explicit operator opt-in. This page summarises the
+guarantees the server enforces and where they live in code.
+
+For the detailed design rationale, see
+[`superpowers/specs/2026-05-02-auntiepypi-v0.7.0-tls-auth-design.md`](superpowers/specs/2026-05-02-auntiepypi-v0.7.0-tls-auth-design.md)
+and
+[`superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md`](superpowers/specs/2026-05-03-auntiepypi-v0.8.0-publish-design.md).
+
+## Defaults are safe
+
+- Default bind is `127.0.0.1:3141` (loopback). No remote host can
+  connect without explicit reconfiguration.
+- No auth required for loopback. Plausible single-user setup.
+- `publish_users` is empty by default. The POST upload endpoint
+  returns 403 "publish disabled" until an operator names at least one
+  publisher.
+- Existing files in the wheelhouse are never overwritten. A POST that
+  would clobber an existing distribution returns 409 Conflict; the
+  publisher must pick a new version.
+
+## Public binding requires both TLS and Basic auth
+
+When `[tool.auntiepypi.local].host` resolves to anything other than
+`127.0.0.1` / `::1` / `localhost`, the config loader requires **both**
+of:
+
+- `cert` and `key` — operator-supplied PEM paths. Loaded via
+  `ssl.SSLContext.load_cert_chain`; minimum version pinned to TLS 1.2.
+  auntie does not auto-generate certs.
+- `htpasswd` — Apache htpasswd file with bcrypt-only entries
+  (`$2y$` / `$2b$` / `$2a$`). Non-bcrypt lines are rejected at load
+  time with the offending line number; silent skip would be how an
+  auth bypass ships.
+
+Either alone fails fast with `ServerConfigError`. The truth-table
+check fires before the listener binds — see `_server/_config.py` and
+`_detect/_config.py`.
+
+## Publish authorization is a strict superset of authentication
+
+Every uploader must be both authenticated AND in `publish_users`.
+The cross-check fires at config-load time: every name in
+`publish_users` must reference an actual htpasswd entry, and a
+non-empty `publish_users` without `htpasswd` is rejected.
+
+| State                                              | POST `/` returns      |
+|----------------------------------------------------|-----------------------|
+| `htpasswd` not configured                          | 405 Method Not Allowed|
+| `htpasswd` configured, no/invalid creds            | 401 Unauthorized      |
+| valid creds, `publish_users` empty                 | 403 "publish disabled"|
+| valid creds, user not in `publish_users`           | 403 "user … cannot publish" |
+| valid creds, user in `publish_users`, valid upload | 201 Created           |
+
+## Body cap and atomic writes
+
+`max_upload_bytes` (default 100 MiB) caps every request body. The
+cap is enforced **twice**:
+
+- Pre-read via `Content-Length` — a 413 fires before any bytes are
+  consumed. `Content-Length` is required (411 Length Required when
+  absent); read-until-EOF would block on keep-alive.
+- During-read via a counted reader — a lying `Content-Length` cannot
+  push past the cap. Truncated bodies surface as 400.
+
+Writes are atomic. `_server/_publish.py` opens
+`tempfile.NamedTemporaryFile(dir=root, prefix=".upload-",
+suffix=".part")` so the rename stays on the same filesystem (atomic
+on POSIX), then `os.rename`s the temp into place. Errors during
+write unlink the temp; partial uploads never litter the wheelhouse.
+
+## Basic auth caveat (pip URL-embedded credentials)
+
+`pip install --index-url https://user:pass@host:port/simple/` works,
+but credentials in URLs leak into process listings, shell history,
+and pip's own debug output. Until keyring integration lands
+(planned post-v0.8.0), prefer a per-user `pip.conf` with restrictive
+permissions (`python -m pip config debug` shows the resolved path):
+
+```ini
+[global]
+index-url = https://alice:secret@auntie.example.lan:3141/simple/
+```
+
+The same caveat applies to `twine upload --repository-url` URLs.
+For `auntie publish`, credentials come from
+`$AUNTIE_PUBLISH_USER` / `$AUNTIE_PUBLISH_PASSWORD` (or interactive
+prompt) — they never appear in argv.
+
+## File permissions
+
+- htpasswd: readable by the user running `auntie up`, ideally not
+  world-readable. Populate via `htpasswd -B` (bcrypt). Any non-bcrypt
+  entry is rejected at load time, not silently skipped.
+- TLS key file: readable by the same user, never world-readable.
+  auntie does not auto-generate keys; use `mkcert`, `certbot`, or
+  your internal CA.
+- Wheelhouse directory: readable by anyone who needs to install from
+  the index; writable by the user running `auntie up` (so atomic
+  rename succeeds). Distribution files inherit umask.
+
+## Self-signed certificates
+
+The `auntie publish` client validates server certificates by default.
+For self-signed setups (typical on a single-host LAN), set
+`AUNTIE_INSECURE_SKIP_VERIFY=1`. The flag is loud — every invocation
+prints a stderr warning — and is intended for local-only use. There
+is no equivalent flag on the server itself; the server presents the
+operator-supplied cert verbatim.
+
+## Threat model summary
+
+| Surface | Posture                                                |
+|---------|--------------------------------------------------------|
+| Read    | "single-host LAN with auth + TLS." Plain HTTP is loopback-only; non-loopback requires auth + TLS at config-load time. |
+| Write   | "single-host LAN with auth + TLS + per-user authz." Every publisher authenticated AND in `publish_users`. |
+| Local   | No process isolation between the CLI and the server when both run as the same user — auntie does not implement privilege separation. |
+
+A multi-tenant deployment is out of scope; the v1.0.0 mesh-aware
+milestone will revisit the trust boundary.

--- a/docs/security.md
+++ b/docs/security.md
@@ -16,8 +16,11 @@ and
 - Default bind is `127.0.0.1:3141` (loopback). No remote host can
   connect without explicit reconfiguration.
 - No auth required for loopback. Plausible single-user setup.
-- `publish_users` is empty by default. The POST upload endpoint
-  returns 403 "publish disabled" until an operator names at least one
+- `publish_users` is empty by default. With no `htpasswd`
+  configured, POST is disabled at the protocol level (405 Method Not
+  Allowed). With `htpasswd` configured but `publish_users` empty,
+  authenticated POSTs return 403 "publish disabled" — read-only mode
+  is preserved either way until an operator names at least one
   publisher.
 - Existing files in the wheelhouse are never overwritten. A POST that
   would clobber an existing distribution returns 409 Conflict; the
@@ -67,10 +70,14 @@ cap is enforced **twice**:
 - During-read via a counted reader — a lying `Content-Length` cannot
   push past the cap. Truncated bodies surface as 400.
 
-Writes are atomic. `_server/_publish.py` opens
+Writes are atomic and no-clobber. `_server/_publish.py` opens
 `tempfile.NamedTemporaryFile(dir=root, prefix=".upload-",
-suffix=".part")` so the rename stays on the same filesystem (atomic
-on POSIX), then `os.rename`s the temp into place. Errors during
+suffix=".part")` (same filesystem so the link is atomic), fsyncs,
+then commits via `os.link(tmp, target)` — which fails with
+`FileExistsError` if the target already exists. `os.link` is the
+no-clobber primitive on POSIX; using `os.rename` would have left a
+TOCTOU window in which a competing writer could materialise the
+target between an existence check and the rename. Errors during
 write unlink the temp; partial uploads never litter the wheelhouse.
 
 ## Basic auth caveat (pip URL-embedded credentials)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auntiepypi"
-version = "0.8.0"
+version = "0.8.1"
 description = "auntiepypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "auntiepypi"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## Summary

Closes #14. Adds the four deliverables called for in the org-wide
public-facing docs audit, refreshes the existing about.md, and
restructures the README around a status table.

- `README.md` — "What auntie is" lede; status table (version /
  capability / mutation surface / shipped vs planned); top-level docs
  nav block. Quick start, doctor walkthrough, and develop sections
  unchanged.
- `docs/architecture.md` — bird's-eye ASCII diagram, module
  ownership (`_detect` / `_actions` / `_server`), state-surface
  table, read-only vs write-capable verb matrix, network surface.
- `docs/security.md` — safe defaults, public-binding truth table,
  publish-authorization superset rule (with full status-code matrix),
  body cap + atomic-write guarantees, Basic-auth caveat, file
  permissions, self-signed cert flag, threat-model summary.
- `docs/comparison.md` — short table + paragraph each for
  pypiserver / devpi / twine.
- `docs/about.md` — refreshed "What it does today" through v0.8.0
  (overview, doctor, lifecycle, first-party server, TLS+auth,
  publish); rewrote "Where it's headed" to track the v0.8.x /
  v0.9.0 / v1.0.0 roadmap from `CLAUDE.md`.

Patch bump (`0.8.0 → 0.8.1`) for `version-check`. Note: the
`v0.8.x` row in the status table reflects that the keyring/netrc
milestone may now land at `v0.8.2` rather than `v0.8.1` — the
roadmap text already calls itself "descriptive of intent, not a
commitment."

## Test plan

- [x] `uv run pytest -n auto -q` — 647 passed.
- [x] `markdownlint-cli2 docs/*.md README.md CHANGELOG.md` — clean.
- [x] `bash .claude/skills/pr-review/scripts/portability-lint.sh` —
  clean (no `/home/<user>` paths, no `~/.<dotfile>` refs in new
  pages).
- [ ] CI: tests + lint + version-check + live.
- [ ] Manual: visitor-in-60-seconds read-through of README + new
  docs.

- Claude