### PR TITLE
v0.8.2: CI uploads coverage to SonarCloud

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Promote SONAR_TOKEN to job env so the SonarCloud step can gate on
+    # `env.SONAR_TOKEN != ''` — `secrets.*` isn't allowed in `if:`. This
+    # makes the step a no-op on fork PRs (where the secret isn't injected)
+    # and on any repo that hasn't configured the token yet, instead of
+    # failing the whole job.
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Sonar needs full git history for accurate "new code" blame attribution.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
       - run: uv python install 3.12
       - run: uv sync
       - run: uv run pytest -n auto --cov=auntiepypi --cov-report=xml:coverage.xml --cov-report=term -v
+
+      - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+        env:
+          SONAR_HOST_URL: https://sonarcloud.io
 
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-05-09
+
+### Added
+
+- CI: upload pytest coverage to SonarCloud (`agentculture_auntiepypi`) via `SonarSource/sonarqube-scan-action@v6`. Mirrors steward's `tests.yml` pattern: `SONAR_TOKEN` promoted to job env, checkout fetches full history for blame attribution, scan step gated on `env.SONAR_TOKEN != ''` so fork PRs no-op cleanly. The existing `coverage.xml` artifact and `sonar-project.properties` are unchanged.
+
 ## [0.8.1] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-05-09
+
+### Fixed
+
+- Wire `coverage.xml` into SonarCloud by adding `sonar.python.coverage.reportPaths=coverage.xml` (and `sonar.python.version=3.12`) to `sonar-project.properties`. v0.8.2 set up the scan step but the property file was missing the report path, so the dashboard reported 0% coverage on new code despite the scan succeeding. Caught by Qodo on PR #18.
+
 ## [0.8.2] - 2026-05-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auntiepypi"
-version = "0.8.1"
+version = "0.8.2"
 description = "auntiepypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auntiepypi"
-version = "0.8.2"
+version = "0.8.3"
 description = "auntiepypi — both ends of the Python distribution pipe for the AgentCulture mesh."
 readme = "README.md"
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,6 +16,11 @@ sonar.organization=agentculture
 sonar.sources=auntiepypi
 sonar.tests=tests
 
+# Coverage report produced in CI by `uv run pytest --cov-report=xml:coverage.xml`
+# (see .github/workflows/tests.yml). Path is relative to the repo root.
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.12
+
 # Hotspots: scan only production code.
 sonar.security.hotspots.exclusions=tests/**
 


### PR DESCRIPTION
## Summary

- Wires the existing `coverage.xml` artifact into the existing SonarCloud project (`agentculture_auntiepypi`) by porting steward's `tests.yml` pattern: `SONAR_TOKEN` promoted to job env, checkout fetches full history (`fetch-depth: 0`) for blame attribution, and a `SonarSource/sonarqube-scan-action@v6` step gated on `env.SONAR_TOKEN != ''`.
- No source / test / config changes — `pytest-cov`, `[tool.coverage.*]`, and `sonar-project.properties` were already in place. The `test` job was generating `coverage.xml` and discarding it; this PR uploads it.
- Patch bump (0.8.1 → 0.8.2): CI-only change, no behavior change.

## Test plan

- [ ] `Tests / test` job: pytest still emits `coverage.xml`, then `SonarCloud Scan` step runs (not skipped) and finishes green.
- [ ] `Tests / version-check` job passes (proves the patch bump landed).
- [ ] SonarCloud dashboard at `https://sonarcloud.io/project/overview?id=agentculture_auntiepypi` shows a fresh analysis with non-zero "Coverage on New Code" after merge.
- [ ] Fork-PR no-op behavior is inherited from the steward template (the `env.SONAR_TOKEN != ''` gate is the same).

- auntiepypi (Claude)